### PR TITLE
chore: bootstrap go module and ci checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  checks:
+    name: Test and Lint
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v5
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: false
+
+      - name: Run unit tests
+        run: make test
+
+      - name: Run lint
+        run: make lint

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .envrc
+.tools

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,62 @@
+version: "2"
+run:
+  tests: false
+linters:
+  enable:
+    - bodyclose
+    - containedctx
+    - contextcheck
+    - dupl
+    - exhaustive
+    - goconst
+    - gocritic
+    - gocyclo
+    - gosec
+    - maintidx
+    - misspell
+    - mnd
+    - nestif
+    - noctx
+    - revive
+    - rowserrcheck
+    - sqlclosecheck
+    - unconvert
+    - staticcheck
+    - errcheck
+    - govet
+    - ineffassign
+    - unused
+  settings:
+    errcheck:
+      check-blank: true
+    gocyclo:
+      min-complexity: 30
+    mnd:
+      checks:
+        - argument
+        - case
+        - condition
+        - return
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - mocks
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - mocks
+      - third_party$
+      - builtin$
+      - examples$

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,6 +50,13 @@ Document roles should remain clear:
 - `AGENTS.md` should focus on implementation guidance and document navigation for contributors and coding agents
 - `README.md` should focus on end-user-facing project information
 
+### 4. Use the Makefile for basic checks
+
+The repository includes a `Makefile` for common development checks.
+
+- run unit tests with `make test`
+- run lint checks with `make lint`
+
 ## Reference Documents
 
 ### Primary implementation reference

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+all: help
+
+.PHONY: help
+help: Makefile
+	@sed -n 's/^##//p' $< | awk 'BEGIN {FS = ":"}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+
+## test: Run unittest
+.PHONY: test
+test:
+	@go test -v $(TESTARGS) ./...
+
+## lint: Run lint
+.PHONY: lint
+lint:
+	@./scripts/lint -c .golangci.yml

--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# 39bot
+
+39bot is a Go-based, Codex-native Discord bot.
+
+## Current Status
+
+The repository currently includes a minimal bootstrap executable at `cmd/39bot/main.go`.
+It prints a dummy `hello world` message and exists only to validate the initial Go module, test, and lint workflow.
+
+## Development Checks
+
+Run local checks with the provided Make targets:
+
+- `make test`
+- `make lint`
+
+The same checks run in GitHub Actions for pushes to `master` and for pull requests.

--- a/cmd/39bot/main.go
+++ b/cmd/39bot/main.go
@@ -1,0 +1,11 @@
+package main
+
+import "fmt"
+
+func greeting() string {
+	return "hello world"
+}
+
+func main() {
+	fmt.Println(greeting())
+}

--- a/cmd/39bot/main_test.go
+++ b/cmd/39bot/main_test.go
@@ -1,0 +1,29 @@
+package main
+
+import "testing"
+
+func TestGreeting(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		want string
+	}{
+		{
+			name: "returns dummy hello world message",
+			want: "hello world",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := greeting(); got != tt.want {
+				t.Fatalf("greeting() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/docs/design-docs/architecture-overview.md
+++ b/docs/design-docs/architecture-overview.md
@@ -123,3 +123,8 @@ internal/codex
 internal/config
 internal/observe
 ```
+
+## Bootstrap Status
+
+The repository currently contains a minimal executable entrypoint at `cmd/39bot/main.go`.
+This file is only a bootstrap placeholder and does not yet implement Discord runtime wiring or Codex integration.

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/HatsuneMiku3939/39bot
+
+go 1.26

--- a/scripts/lint
+++ b/scripts/lint
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+TOOLS_DIR="$REPO_ROOT/.tools"
+mkdir -p "$TOOLS_DIR"
+export PATH="$TOOLS_DIR:$PATH"
+
+GOLANGCI_LINT_VERSION="v2.11.4"
+
+function ensure_golangci_lint() {
+	local need_install="true"
+	if command -v golangci-lint >/dev/null 2>&1; then
+		local current_version
+		current_version="$(golangci-lint version --short 2>/dev/null || true)"
+		if [ "v$current_version" = "$GOLANGCI_LINT_VERSION" ]; then
+			need_install="false"
+		fi
+	fi
+
+	if [ "$need_install" = "true" ]; then
+		echo "Installing golangci-lint $GOLANGCI_LINT_VERSION into $TOOLS_DIR ..."
+		curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b "$TOOLS_DIR" "$GOLANGCI_LINT_VERSION"
+	fi
+}
+
+ensure_golangci_lint
+GOLANGCI_LINT_OPTIONS="--timeout 10m"
+
+while getopts "c:" opt; do
+	case ${opt} in
+	c)
+		GOLANGCI_LINT_OPTIONS="$GOLANGCI_LINT_OPTIONS -c $OPTARG"
+		;;
+	esac
+done
+
+golangci-lint run $GOLANGCI_LINT_OPTIONS
+LINT_RESULT=$?
+
+if [ $LINT_RESULT -ne 0 ]; then
+	echo "Linting failed"
+	exit 1
+fi
+
+echo "Linting passed"


### PR DESCRIPTION
## Summary

- bootstrap the Go module for 39bot
- add a dummy `hello world` executable and unit test
- add Makefile-based lint and test checks plus GitHub Actions CI
- document the bootstrap status and development checks

## Background

The repository needed an initial runnable Go entrypoint and a repeatable validation flow for local development and pull requests.

## Related issue(s)

- None

## Implementation details

- added `go.mod` with the repository module path
- added `cmd/39bot/main.go` and a table-driven unit test
- added `.golangci.yml`, `Makefile`, and `scripts/lint`
- added a GitHub Actions workflow that runs on pushes to `master` and on pull requests
- updated contributor and user-facing documentation for bootstrap status and development checks

## Test coverage

- `make test`
- `make lint`

## Breaking changes

- None

## Notes

- Integration and end-to-end test suites are not defined yet, so the current CI scope covers the available unit test and lint checks.

Created by Codex
