### PR TITLE
Clarify architecture document roles

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,7 +78,7 @@ The repository includes a `Makefile` for common development checks.
 - `docs/design-docs/core-beliefs.md`
   - Project principles and architectural beliefs
 - `docs/design-docs/architecture-overview.md`
-  - High-level component model and request flow
+  - Short onboarding summary of the system shape and request flow
 - `docs/design-docs/thread-modes.md`
   - `daily` and `task` mode definitions, expected behavior, and tradeoffs
 - `docs/design-docs/state-and-storage.md`
@@ -110,6 +110,7 @@ The repository includes a `Makefile` for common development checks.
 
 `AGENTS.md` is intentionally short.
 For thread modes, package boundaries, persistence direction, v1 scope, and non-goals, refer to `ARCHITECTURE.md`.
+Use `docs/design-docs/architecture-overview.md` when a quick orientation is enough, but use `ARCHITECTURE.md` for implementation decisions.
 
 ## Maintenance Rule
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -5,6 +5,16 @@ It should be treated as the implementation guide for future development.
 
 If code and this document diverge, either the code should be corrected or this document should be updated deliberately.
 
+## How to Use This Document
+
+`ARCHITECTURE.md` is the authoritative architecture document for this repository.
+It defines the intended system role, core boundaries, thread-mode model, persistence direction, and v1 scope.
+
+If another design note summarizes the architecture differently, this document takes precedence.
+
+The companion document at `docs/design-docs/architecture-overview.md` is intentionally shorter.
+It exists as an onboarding-oriented map for quickly understanding the system shape before reading this reference in full.
+
 ## 1. Project Identity
 
 - Project: `39bot`
@@ -27,6 +37,29 @@ Instead:
 - 39bot owns local persistence for Codex thread bindings
 
 The application should stay intentionally thin.
+
+### 2.1 Codex Working Model
+
+39bot adopts Codex's repository-scoped operating model and exposes it through Discord.
+
+Codex works against a specific working directory, typically a Git repository, where it can:
+
+- read files
+- edit files
+- execute shell commands
+- follow repository-level instructions
+
+39bot does not redefine that model locally.
+Instead, it routes Discord interactions into Codex threads that operate against the repository configured for the current bot instance.
+
+The distinction between `daily` mode and `task` mode is therefore not a different execution engine.
+It is a difference in the role of the repository that Codex is operating against.
+
+- In `task` mode, the repository is an execution-oriented work repository where Codex can help perform operational tasks such as code changes, pull request handling, and release workflows.
+- In `daily` mode, the repository is a knowledge-oriented repository that primarily contains instructions and documentation, allowing Codex to answer questions by following local guidance and searching the knowledge base.
+
+Both modes share the same Codex-native foundation.
+They differ in repository purpose, continuity policy, and resulting user experience.
 
 ## 3. Design Principles
 
@@ -162,6 +195,7 @@ Responsibilities:
 Purpose:
 
 - support lightweight daily continuity without explicit task management
+- support knowledge-oriented conversation against a repository that primarily contains instructions and documentation
 
 Logical key concept:
 
@@ -175,6 +209,7 @@ Behavior:
 - if a thread exists for that key, resume it
 - otherwise create a new Codex thread
 - when the date changes, the logical bucket changes automatically
+- Codex answers by following repository guidance and consulting the documentation in that repository
 
 Properties:
 
@@ -192,6 +227,7 @@ Tradeoffs:
 Purpose:
 
 - support longer-running work streams with explicit task identity
+- support execution-oriented repository work through Discord
 
 Logical key concept:
 
@@ -204,6 +240,7 @@ Behavior:
 - normal messages require an active task context
 - messages route to the thread bound to the active task
 - changing the active task changes the target thread
+- each task maps to a distinct Codex conversation thread, so switching tasks also switches execution context
 
 Minimum v1 UX requirements:
 
@@ -216,6 +253,7 @@ Properties:
 
 - better for project-oriented or issue-oriented work
 - keeps context stable across days
+- makes parallel long-running work practical without mixing task context
 
 Tradeoffs:
 

--- a/docs/design-docs/architecture-overview.md
+++ b/docs/design-docs/architecture-overview.md
@@ -1,6 +1,11 @@
 # Architecture Overview
 
-This document describes the concept-level application architecture for 39bot.
+This document is a short onboarding-oriented summary of the 39bot architecture.
+
+It is not the authoritative implementation reference.
+For architectural decisions, scope boundaries, and source-of-truth behavior, see the root `ARCHITECTURE.md`.
+
+Use this document when you want a quick mental model of the system before reading the full reference.
 
 ## System Role
 
@@ -8,6 +13,20 @@ This document describes the concept-level application architecture for 39bot.
 
 It does not act as a full local coding agent runtime.
 Instead, it delegates agent execution to Codex and manages the local application-side policy.
+
+## Codex Working Model
+
+39bot adopts Codex's repository-scoped operating model.
+Each bot instance is configured against a repository-shaped working directory, and Discord interactions are routed into Codex threads that operate against that repository.
+
+This leads to two distinct mode families on the same foundation:
+
+- `daily`
+  - knowledge-oriented interaction against repository instructions and documentation
+- `task`
+  - execution-oriented interaction against a work repository where Codex can help perform operational tasks
+
+The detailed rationale for these modes lives in `ARCHITECTURE.md` and `thread-modes.md`.
 
 ## High-Level Components
 
@@ -24,66 +43,27 @@ Discord Runtime
 
 ### Discord Runtime
 
-The Discord runtime is responsible for:
-
-- receiving messages and interaction commands
-- deciding whether the bot should respond
-- passing normalized requests into the application service
-- sending formatted responses back to Discord
+Receives Discord inputs and delivers formatted responses.
 
 ### Message Application Service
 
-This is the main orchestration layer.
-Its responsibility is to process one incoming user turn from start to finish.
-
-At a concept level, it should:
-
-1. receive a normalized user message
-2. ask the thread policy for the logical thread key
-3. load any existing Codex thread binding from storage
-4. create a new Codex thread if needed
-5. send the user turn to Codex
-6. present the result back to Discord
+Processes one user turn end to end by resolving the thread target, delegating to Codex, and returning the normalized result.
 
 ### Thread Policy
 
-The thread policy converts a Discord message context into a logical thread key.
-
-The policy depends on the global thread mode.
-Two v1 modes are planned:
-
-- `daily`
-- `task`
+Converts Discord context into a logical thread key according to the globally configured mode.
 
 ### Thread Store
 
-The thread store persists the relationship between:
-
-- a logical thread key
-- a Codex thread ID
-
-This is the local continuity layer that allows the bot to resume the correct remote conversation.
+Persists the local continuity data that lets 39bot resume the correct Codex thread.
 
 ### Codex Gateway
 
-The Codex gateway is the only component that talks to the Codex SDK or Codex API integration layer.
-
-Its responsibilities include:
-
-- creating threads
-- resuming existing threads by ID
-- sending a turn into a thread
-- returning the assistant result in a normalized application format
+Owns the direct integration with the Codex SDK or Codex API layer.
 
 ### Response Presenter
 
-The presenter adapts Codex responses for Discord output.
-
-It should handle:
-
-- message formatting
-- trimming or chunking if Discord limits are exceeded
-- error-friendly responses when backend requests fail
+Adapts normalized application output into Discord-safe responses.
 
 ## Request Flow
 
@@ -99,38 +79,11 @@ It should handle:
 9. Discord runtime posts the reply
 ```
 
-## What v1 Intentionally Does Not Include
+## Read Next
 
-The following concerns are intentionally outside the first concept:
-
-- local agent loop implementation
-- local tool orchestration
-- multi-provider LLM support
-- per-user or per-channel policy overrides
-- web or TUI runtime surfaces
-
-## Suggested Package Shape
-
-The exact package layout may change, but the current direction is roughly:
-
-```text
-cmd/39bot
-cmd/codexplay
-internal/app
-internal/runtime/discord
-internal/thread
-internal/store/sqlite
-internal/codex
-internal/config
-internal/observe
-```
-
-## Bootstrap Status
-
-The repository currently contains a minimal executable entrypoint at `cmd/39bot/main.go`.
-This file is only a bootstrap placeholder and does not yet implement Discord runtime wiring or Codex integration.
-
-The repository also includes an initial `internal/codex` package that experiments with direct Codex CLI integration in Go.
-Its current scope is intentionally narrow and focused on thread start or resume behavior, streamed event handling, and local image input support.
-
-An additional experimental CLI entrypoint at `cmd/codexplay` is available for manual integration checks against the real `codex` binary.
+- root `ARCHITECTURE.md`
+  - authoritative architecture reference
+- `thread-modes.md`
+  - mode definitions, behavior, and tradeoffs
+- `state-and-storage.md`
+  - persistence model and storage expectations

--- a/docs/design-docs/index.md
+++ b/docs/design-docs/index.md
@@ -2,6 +2,9 @@
 
 This directory captures the current concept-level design of 39bot.
 
+These documents are companions to the root `ARCHITECTURE.md`, not replacements for it.
+Use `ARCHITECTURE.md` as the authoritative architecture reference and use the files in this directory as focused supporting notes.
+
 The project direction is intentionally small and opinionated:
 
 - 39bot is a Codex-native Discord bot.
@@ -11,10 +14,10 @@ The project direction is intentionally small and opinionated:
 
 ## Documents
 
-- [Core Beliefs](./core-beliefs.md)
-- [Architecture Overview](./architecture-overview.md)
-- [Thread Modes](./thread-modes.md)
-- [State and Storage](./state-and-storage.md)
+- [Core Beliefs](./core-beliefs.md) - explains the project principles behind the design
+- [Architecture Overview](./architecture-overview.md) - provides a short onboarding-oriented map of the system shape
+- [Thread Modes](./thread-modes.md) - explains the mode model, behavior, and tradeoffs
+- [State and Storage](./state-and-storage.md) - explains persistence requirements and storage boundaries
 
 ## Current v1 Direction
 
@@ -28,4 +31,4 @@ The project direction is intentionally small and opinionated:
 
 ## Notes
 
-These documents describe the current design direction, not a final implementation contract.
+These documents describe the current design direction and should stay aligned with `ARCHITECTURE.md`.

--- a/docs/design-docs/thread-modes.md
+++ b/docs/design-docs/thread-modes.md
@@ -106,7 +106,15 @@ Costs:
 
 ## Why Both Modes Exist
 
-The modes support different user experiences:
+Both modes are built on the same Codex operating model.
+Codex works against a repository-scoped working directory and follows the instructions defined there.
+
+The difference is the role of the repository:
+
+- `daily` uses a knowledge-oriented repository that primarily contains instructions and documentation
+- `task` uses an execution-oriented repository where Codex can help perform real operational work
+
+As a result, the modes support different user experiences:
 
 - `daily` is conversation-oriented
 - `task` is work-oriented

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,10 +6,12 @@ It is organized into a small set of document layers so contributors can quickly 
 
 ## Document Map
 
+- [Root Architecture Reference](../ARCHITECTURE.md)
+  - The authoritative architecture document for the repository
 - [Product Specs](./product-specs/index.md)
   - Product-facing user journeys, interaction rules, and expected behavior
 - [Design Docs](./design-docs/index.md)
-  - Architecture direction, internal design boundaries, and system concepts
+  - Supporting design notes, focused concepts, and onboarding-oriented summaries
 - [References](./references/index.md)
   - External references and bundled source material
 
@@ -27,6 +29,12 @@ Use `docs/design-docs` when the question is about:
 - which responsibilities belong to which component
 - how thread routing, storage, and integration boundaries should work
 
+Use the root `ARCHITECTURE.md` when the question is about:
+
+- the authoritative architecture decision
+- the intended system boundaries or v1 scope
+- resolving ambiguity between design notes
+
 Use `docs/references` when the question is about:
 
 - external SDK behavior
@@ -42,6 +50,7 @@ Use `docs/references` when the question is about:
 ## Maintenance Notes
 
 - Keep product behavior in `docs/product-specs`.
-- Keep implementation design in `docs/design-docs`.
+- Keep the authoritative architecture model in `ARCHITECTURE.md`.
+- Keep supporting implementation design notes in `docs/design-docs`.
 - Keep external source material in `docs/references`.
 - Update this index when a new top-level documentation layer is introduced.

--- a/docs/product-specs/daily-mode-user-flow.md
+++ b/docs/product-specs/daily-mode-user-flow.md
@@ -11,6 +11,7 @@ The goal of `daily` mode is to make the bot feel natural and low-friction for on
 ## Product Goal
 
 A user should be able to send a normal message and continue the conversation naturally throughout the day without needing to manage thread state explicitly.
+At a product level, this mode should feel like talking to a living knowledge base backed by repository instructions and documentation.
 
 ## User Promise
 

--- a/docs/product-specs/task-mode-user-flow.md
+++ b/docs/product-specs/task-mode-user-flow.md
@@ -11,6 +11,7 @@ The goal of `task` mode is to support durable, explicit work streams that can co
 ## Product Goal
 
 A user should be able to attach conversation continuity to an explicit task identity and switch work contexts intentionally rather than implicitly.
+At a product level, this mode should feel like driving real repository work through Discord rather than using a general chat thread.
 
 ## User Promise
 


### PR DESCRIPTION
## Summary

- clarify the roles of `ARCHITECTURE.md` and `docs/design-docs/architecture-overview.md`
- make `ARCHITECTURE.md` the explicit source of truth for architecture decisions
- align supporting documentation with the updated document hierarchy

## Background

The architecture documentation had started to feel ambiguous because the root architecture reference and the design-doc overview both described similar concepts. This change makes the document hierarchy easier to understand and keeps the high-level overview focused on onboarding.

## Related issue(s)

- None

## Implementation details

- added explicit guidance to `ARCHITECTURE.md` describing its authoritative role
- expanded the Codex working model explanation in the root architecture reference
- reduced `docs/design-docs/architecture-overview.md` into a shorter onboarding-oriented summary
- updated documentation index files and contributor guidance to reflect the new division of responsibility
- added short mode-positioning sentences to the daily and task product specs

## Test coverage

- `make test`
- `make lint`

## Breaking changes

- None

## Notes

- This PR changes documentation structure and wording only

Created by Codex
