### PR TITLE
Activate core product specs

### DIFF
--- a/docs/product-specs/daily-mode-user-flow.md
+++ b/docs/product-specs/daily-mode-user-flow.md
@@ -1,6 +1,6 @@
 # Daily Mode User Flow
 
-Status: Draft
+Status: Active
 
 ## Purpose
 

--- a/docs/product-specs/discord-command-behavior.md
+++ b/docs/product-specs/discord-command-behavior.md
@@ -1,6 +1,6 @@
 # Discord Command Behavior
 
-Status: Draft
+Status: Active
 
 ## Purpose
 

--- a/docs/product-specs/index.md
+++ b/docs/product-specs/index.md
@@ -38,5 +38,5 @@ The following specs are expected to be useful as the product surface expands:
 
 ## Status Notes
 
-Unless otherwise stated, product specs in this directory should be treated as draft working documents for v1.
-They describe intended behavior and should be updated as product decisions become more concrete.
+The documents in this directory define the current v1 product expectations for 39claw.
+Update them when product behavior changes so implementation and documentation remain aligned.

--- a/docs/product-specs/task-mode-user-flow.md
+++ b/docs/product-specs/task-mode-user-flow.md
@@ -1,6 +1,6 @@
 # Task Mode User Flow
 
-Status: Draft
+Status: Active
 
 ## Purpose
 


### PR DESCRIPTION
## Summary

- Mark the daily, task, and Discord command product specs as active
- Update the product specs index to reflect these documents as current v1 expectations

## Background

These product specs have been discussed enough to stop treating them as draft-only working documents.

## Related issue(s)

- None

## Implementation details

- Change `Status: Draft` to `Status: Active` in the three approved product spec documents
- Rewrite the status note in `docs/product-specs/index.md` so it describes the directory as the current v1 product contract

## Test coverage

- `make lint`
- `make test`

## Breaking changes

- None

## Notes

- Documentation-only change
- Created by Codex
