### PR TITLE
docs: clarify shared daily mode thread mapping

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -195,12 +195,12 @@ Responsibilities:
 Purpose:
 
 - support lightweight daily continuity without explicit task management
-- support knowledge-oriented conversation against a repository that primarily contains instructions and documentation
+- support shared, knowledge-oriented conversation against a repository that primarily contains instructions and documentation
 
 Logical key concept:
 
 ```text
-thread_key = user + local_date
+thread_key = local_date
 ```
 
 Behavior:
@@ -215,11 +215,12 @@ Properties:
 
 - no explicit thread command is required for normal usage
 - simple and low-friction
-- best for conversation-oriented flows
+- best for shared, conversation-oriented assistant flows
 
 Tradeoffs:
 
 - long-running work may be split across date boundaries
+- unrelated same-day conversations may influence one another inside the shared daily context
 - timezone must be an explicit configuration concern
 
 ## 7.2 `task`

--- a/docs/design-docs/thread-modes.md
+++ b/docs/design-docs/thread-modes.md
@@ -15,13 +15,12 @@ The user should not need to manage thread state explicitly.
 
 The logical thread key is derived from:
 
-- user
 - current local date
 
 Conceptually:
 
 ```text
-thread_key = user + local_date
+thread_key = local_date
 ```
 
 ### Behavior
@@ -43,11 +42,13 @@ Benefits:
 
 - simple and predictable
 - low-friction user experience
+- supports a shared-assistant feel for a bounded team environment
 - very easy to explain
 
 Costs:
 
 - long-running work may be split across calendar boundaries
+- unrelated same-day conversations may share context
 - the definition of "day" depends on a configured timezone
 
 ## Mode B: `task`

--- a/docs/product-specs/daily-mode-user-flow.md
+++ b/docs/product-specs/daily-mode-user-flow.md
@@ -10,14 +10,14 @@ The goal of `daily` mode is to make the bot feel natural and low-friction for on
 
 ## Product Goal
 
-A user should be able to send a normal message and continue the conversation naturally throughout the day without needing to manage thread state explicitly.
+A user should be able to send a normal message and continue the shared conversation naturally throughout the day without needing to manage thread state explicitly.
 At a product level, this mode should feel like talking to a living knowledge base backed by repository instructions and documentation.
 
 ## User Promise
 
 In `daily` mode, the bot should feel like:
 
-- a conversation that continues during the current day
+- a shared conversation that continues during the current day
 - a fresh start on a new day
 - a tool that does not require explicit setup for normal use
 
@@ -29,7 +29,7 @@ The user should be able to send a message without first creating a task, selecti
 
 ### 2. Daily continuity should be automatic
 
-Messages from the same user on the same local date should feel like they continue the same line of work unless the product explicitly says otherwise.
+Messages handled on the same local date should feel like they continue the same line of work unless the product explicitly says otherwise.
 
 ### 3. Day boundaries should reset context cleanly
 
@@ -48,7 +48,7 @@ Expected flow:
 
 1. The user sends a normal message in a supported channel.
 2. 39claw determines that the message should be handled.
-3. 39claw resolves the current daily thread bucket for that user.
+3. 39claw resolves the current daily thread bucket.
 4. If no thread exists for that bucket, 39claw creates a new one automatically.
 5. The user receives a normal response.
 
@@ -67,7 +67,7 @@ Expected flow:
 
 Expected user perception:
 
-- “The bot remembers today’s context.”
+- “The bot remembers today’s shared context.”
 - “I do not need to restate everything.”
 
 ### Scenario: First message on a new day
@@ -94,7 +94,6 @@ The user should not have to manually select a thread for normal use in `daily` m
 
 Continuity should be preserved:
 
-- for the same user
 - on the same configured local date
 
 Continuity should not be assumed across different days unless the product later adds an explicit bridging workflow.
@@ -124,8 +123,13 @@ If the product exposes date-boundary behavior to users, it should do so in terms
 
 ### Channel changes
 
-If the same user speaks in a different channel within the same bot instance, the product should preserve daily continuity rather than silently resetting it.
+If conversation continues in a different channel within the same bot instance, the product should preserve daily continuity rather than silently resetting it.
 If that creates confusion for a specific deployment, the preferred solution is to separate bot instances by purpose rather than keying continuity by channel.
+
+### Concurrent unrelated topics
+
+If multiple unrelated discussions happen on the same day, `daily` mode may expose some shared context across those turns.
+That tradeoff is acceptable when the product is intentionally operating as a shared assistant for a bounded group.
 
 ## Non-Goals
 


### PR DESCRIPTION
## Summary

- redefine `daily` mode documentation around a shared date-scoped context
- simplify the documented daily thread key to `local_date`
- document the shared-context tradeoff for unrelated same-day conversations

## Background

The desired `daily` mode behavior is a shared assistant experience for a bounded internal team. The previous wording still reflected user-scoped continuity in several places, which conflicted with that direction.

## Related issue(s)

- None

## Implementation details

- updated `ARCHITECTURE.md` to describe shared daily continuity and the simplified key concept
- updated `docs/design-docs/thread-modes.md` to align the mode intent, key derivation, and tradeoffs
- updated `docs/product-specs/daily-mode-user-flow.md` to reflect shared daily continuity and clarify concurrent-topic tradeoffs

## Test coverage

- `make test`
- `make lint`

## Breaking changes

- None

## Notes

- This change is documentation-only and does not yet implement runtime thread-policy changes.

Created by Codex
