### PR TITLE
docs: add implementation spec for v1 defaults

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,6 +79,8 @@ The repository includes a `Makefile` for common development checks.
   - Project principles and architectural beliefs
 - `docs/design-docs/architecture-overview.md`
   - Short onboarding summary of the system shape and request flow
+- `docs/design-docs/implementation-spec.md`
+  - Short implementation-facing defaults that close the remaining v1 gaps between architecture and product specs
 - `docs/design-docs/thread-modes.md`
   - `daily` and `task` mode definitions, expected behavior, and tradeoffs
 - `docs/design-docs/state-and-storage.md`

--- a/docs/design-docs/implementation-spec.md
+++ b/docs/design-docs/implementation-spec.md
@@ -1,0 +1,139 @@
+# Implementation Spec
+
+This document captures the concrete v1 implementation defaults for 39claw.
+`ARCHITECTURE.md` remains the authoritative architecture reference, and the documents under `docs/product-specs` remain the source of truth for user-facing behavior.
+This file exists to fix implementation choices that are still ambiguous in those higher-level documents so contributors can begin building without reopening the same decisions.
+
+This document is intentionally short.
+If implementation direction changes, update this file together with `ARCHITECTURE.md` and any affected product specs.
+Large feature work may still use an ExecPlan after these defaults are set.
+
+## Fixed v1 Implementation Defaults
+
+39claw should be implemented as a thin runtime pipeline:
+
+```text
+Discord runtime -> application service -> thread policy -> SQLite store -> Codex gateway -> Discord presenter
+```
+
+The bot runs with one global configuration per instance:
+
+- one thread mode
+- one working directory
+- one timezone
+
+v1 does not introduce a local agent loop or local tool orchestration.
+Codex remains responsible for remote thread execution and tool use.
+
+The expected package direction for v1 is:
+
+- `internal/config`
+- `internal/observe`
+- `internal/runtime/discord`
+- `internal/app`
+- `internal/thread`
+- `internal/store/sqlite`
+- `internal/codex`
+
+The recommended delivery order is:
+
+1. foundation and shared interfaces
+2. `daily` mode routing and persistence
+3. `task` mode state and command workflow
+4. Discord command and presentation refinement
+
+## Internal Interfaces to Freeze
+
+The following internal contracts should be treated as stable v1 design targets even if exact Go type names evolve during implementation.
+
+- `MessageRequest`
+  - carries Discord user ID, channel ID, message ID, message content, mention or command metadata, and received time
+- `MessageResponse`
+  - carries rendered response text and presentation hints needed for Discord reply, chunking, and ephemeral command responses
+- `ThreadPolicy`
+  - resolves a logical thread key from the configured mode and the current message or task context
+- `ThreadStore`
+  - loads and upserts thread bindings and manages task records plus active task state
+- `CodexGateway`
+  - creates or resumes Codex threads, runs a turn, and returns a normalized final response
+- `TaskCommandService`
+  - implements `/task`, `/task list`, `/task new <name>`, `/task switch <id>`, and `/task close <id>`
+
+The application layer should depend on these responsibilities rather than on Discord SDK details or raw SQL.
+
+## Persistence Defaults
+
+SQLite is the required v1 storage backend.
+
+The storage model uses three tables:
+
+- `thread_bindings`
+  - stores `mode`, `logical_thread_key`, `codex_thread_id`, nullable `task_id`, `created_at`, and `updated_at`
+  - enforces one binding per `(mode, logical_thread_key)`
+- `tasks`
+  - stores `task_id`, `discord_user_id`, `task_name`, `status`, `created_at`, `updated_at`, and nullable `closed_at`
+  - uses ULID strings for `task_id`
+  - allows duplicate task names for the same user
+- `active_tasks`
+  - stores `discord_user_id`, `task_id`, and `updated_at`
+  - enforces one active task per Discord user within a bot instance
+
+Task status is `open` or `closed`.
+Closing a task marks it `closed` and removes its `active_tasks` mapping when that task is currently active.
+`/task list` should show open tasks and clearly mark the active task for the requesting user.
+
+The logical thread key defaults are:
+
+- `daily`: configured local date formatted as `YYYY-MM-DD`
+- `task`: `discord_user_id + task_id`
+
+## Discord Behavior Defaults
+
+Normal conversation is mention-only in v1.
+When a qualifying normal message is handled, the bot replies in the same channel and targets the triggering message as the reply root.
+
+`/help` and `/task ...` are slash-command surfaces.
+Task-control command responses are ephemeral by default.
+When a bot instance runs in `daily` mode, `/task ...` must return a clear not-available response instead of pretending the command worked.
+
+When a bot instance runs in `task` mode, normal messages without an active task must not be routed to Codex.
+They should return actionable guidance that points the user to `/task new <name>`, `/task list`, or `/task switch <id>`.
+
+Unsupported non-mention chatter is ignored.
+Long responses are chunked into Discord-safe messages while preserving code fences when practical.
+Only one Codex turn may run at a time for a given logical thread key.
+If another message arrives for the same logical thread while a turn is running, the bot should return a busy or retry response rather than queueing implicitly.
+
+## Configuration Defaults
+
+v1 configuration should be provided through environment variables.
+The expected variables are:
+
+- `CLAW_MODE`
+- `CLAW_TIMEZONE`
+- `CLAW_DISCORD_TOKEN`
+- `CLAW_CODEX_WORKDIR`
+- `CLAW_SQLITE_PATH`
+- `CLAW_CODEX_EXECUTABLE`
+- `CLAW_CODEX_BASE_URL`
+- `CLAW_CODEX_API_KEY`
+- `CLAW_LOG_LEVEL`
+
+`CLAW_MODE`, `CLAW_TIMEZONE`, `CLAW_DISCORD_TOKEN`, `CLAW_CODEX_WORKDIR`, `CLAW_SQLITE_PATH`, and `CLAW_CODEX_EXECUTABLE` are required.
+`CLAW_CODEX_BASE_URL`, `CLAW_CODEX_API_KEY`, and `CLAW_LOG_LEVEL` are optional.
+`CLAW_MODE` accepts `daily` or `task`.
+`CLAW_TIMEZONE` must be set explicitly for each deployment.
+`CLAW_LOG_LEVEL` defaults to `info` when omitted.
+
+## Validation Targets
+
+The initial implementation should demonstrate the following observable behavior:
+
+- In `daily` mode, the first qualifying mention creates a thread binding, a second same-day mention reuses it, and the first mention on the next local date creates a new binding.
+- In `task` mode, a normal mention without an active task returns guidance instead of routing to Codex.
+- `/task new <name>` creates a task and sets it active for the requesting user.
+- `/task switch <id>` changes the routing target for subsequent normal messages.
+- `/task close <id>` closes the task and clears active state when the closed task was active.
+- Existing `daily` and `task` bindings survive process restart through SQLite-backed state.
+- Non-mention chatter is ignored, supported slash commands respond correctly, and long replies are chunked cleanly.
+- Simultaneous requests for the same logical thread do not execute overlapping Codex turns.

--- a/docs/design-docs/index.md
+++ b/docs/design-docs/index.md
@@ -16,6 +16,7 @@ The project direction is intentionally small and opinionated:
 
 - [Core Beliefs](./core-beliefs.md) - explains the project principles behind the design
 - [Architecture Overview](./architecture-overview.md) - provides a short onboarding-oriented map of the system shape
+- [Implementation Spec](./implementation-spec.md) - fixes the concrete v1 implementation defaults that sit between the architecture and product specs
 - [Thread Modes](./thread-modes.md) - explains the mode model, behavior, and tradeoffs
 - [State and Storage](./state-and-storage.md) - explains persistence requirements and storage boundaries
 


### PR DESCRIPTION
## Summary

- add a short implementation spec that fixes concrete v1 defaults between the architecture and product docs
- document implementation-facing decisions for interfaces, persistence, Discord behavior, configuration, and validation targets
- link the new design doc from the design-doc index and contributor guide

## Background

The repository documentation was strong at the architecture and product levels, but there was still a gap between those layers and the first implementation slice. This change adds a compact decision memo so future implementation work can begin without reopening the same v1 defaults.

## Related issue(s)

- None

## Implementation details

- add `docs/design-docs/implementation-spec.md` as a one-page implementation decision memo
- freeze the intended v1 runtime pipeline, package direction, internal interface boundaries, SQLite schema defaults, Discord behavior defaults, and environment variables
- update the design-doc index and `AGENTS.md` reference list to include the new document

## Test coverage

- `make test`
- `make lint`

## Breaking changes

- None

## Notes

Created by Codex
