### PR TITLE
docs: add self-contained exec plans

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,6 +70,8 @@ The repository includes a `Makefile` for common development checks.
 
 - `docs/index.md`
   - Entry point for the repository documentation set
+- `docs/exec-plans/index.md`
+  - Entry point for living execution plans and deferred follow-up notes
 
 ### Design notes
 
@@ -117,6 +119,7 @@ Use `docs/design-docs/architecture-overview.md` when a quick orientation is enou
 ## ExecPlans
 
 When writing complex features or significant refactors, use an ExecPlan (as described in .agents/PLANS.md) from design to implementation.
+Store active plans under `docs/exec-plans/active` and move them to `docs/exec-plans/completed` when they are finished.
 
 ## Maintenance Rule
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ For the intended system shape, thread model, and user-facing behavior, start wit
   - user-facing journeys, command behavior, and workflow expectations
 - `docs/design-docs`
   - supporting architecture and design notes
+- `docs/exec-plans`
+  - living execution plans for active and completed implementation work
 - `docs/references`
   - external reference material
 

--- a/docs/exec-plans/active/01-foundation-and-contracts.md
+++ b/docs/exec-plans/active/01-foundation-and-contracts.md
@@ -1,0 +1,223 @@
+# Build the foundation, contracts, and bootstrap path
+
+This ExecPlan is a living document. The sections `Progress`, `Surprises & Discoveries`, `Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work proceeds.
+
+This document must be maintained in accordance with `.agents/PLANS.md`.
+
+## Purpose / Big Picture
+
+After this plan, the repository should have a real application skeleton instead of a dummy `hello world` executable. A maintainer should be able to start `39claw`, have it load configuration from environment variables, initialize logging, open SQLite, construct the Codex integration boundary, and start a runtime shell. This plan does not need to deliver complete `daily` or `task` behavior yet. Its job is to freeze the seams that the later plans will build on.
+
+## Progress
+
+- [x] (2026-04-04 15:27Z) Defined this plan from `ARCHITECTURE.md`, `docs/design-docs/implementation-spec.md`, and the current repository state.
+- [ ] Replace the placeholder `cmd/39claw` executable with real startup wiring.
+- [ ] Add `internal/config` with environment parsing and validation tests.
+- [ ] Add `internal/observe` with `slog` logger construction.
+- [ ] Add the app-layer request and response contracts in `internal/app`.
+- [ ] Add the initial thread-policy and execution-guard seams in `internal/thread`.
+- [ ] Add `internal/store/sqlite` with schema creation and repository-facing interfaces.
+- [ ] Add a higher-level Codex gateway wrapper around the existing `internal/codex` client.
+- [ ] Update startup-oriented docs once the new bootstrap path exists.
+
+## Surprises & Discoveries
+
+- Observation: The repository already has a tested low-level Codex adapter, so the missing foundation work is around orchestration rather than around raw Codex execution.
+  Evidence: `internal/codex/codex_test.go`
+
+- Observation: There is no current package layout for application orchestration, storage, or runtime concerns.
+  Evidence: `internal/` currently contains only `internal/codex`
+
+## Decision Log
+
+- Decision: Keep the first plan focused on frozen seams and startup wiring instead of partial end-user features.
+  Rationale: Later plans will move faster and break less often if they build on stable contracts.
+  Date/Author: 2026-04-04 / Codex
+
+- Decision: Prefer `database/sql` with a small SQLite driver hidden behind `internal/store/sqlite`.
+  Rationale: The app layer should not know which SQLite driver was chosen, and the standard library surface is enough for v1.
+  Date/Author: 2026-04-04 / Codex
+
+## Outcomes & Retrospective
+
+The outcome of this plan should be a repository that finally has a real startup spine. Even if the bot does not yet answer useful messages, the code should now express where configuration, runtime, storage, application orchestration, and Codex boundaries live.
+
+## Context and Orientation
+
+The current `cmd/39claw/main.go` returns a greeting string and prints it. That file must be replaced. The design target from `docs/design-docs/implementation-spec.md` requires these packages:
+
+- `internal/config`
+- `internal/observe`
+- `internal/runtime/discord`
+- `internal/app`
+- `internal/thread`
+- `internal/store/sqlite`
+- `internal/codex`
+
+This plan should create the first six boundaries and extend the seventh with a higher-level gateway wrapper. The application contracts that must exist by the end of this plan are:
+
+- `MessageRequest`
+- `MessageResponse`
+- `ThreadPolicy`
+- `ThreadStore`
+- `CodexGateway`
+- `TaskCommandService`
+
+In this repository, "frozen contracts" means the later plans can depend on these responsibilities without rewriting them every time. Exact Go type names may evolve, but the responsibilities must stay stable.
+
+## Starting State
+
+Begin this plan only after confirming the repository still matches this baseline:
+
+- `cmd/39claw/main.go` is still a placeholder executable
+- `internal/` contains only `internal/codex`
+- `make test` passes
+- `make lint` passes
+
+If the repository has already moved beyond that baseline, do not discard the newer code. Instead, compare the existing implementation against the acceptance section in this plan and treat any already-complete step as done. Update the `Progress` section before making new edits so the plan remains truthful.
+
+## Preconditions
+
+This plan has no earlier ExecPlan prerequisite. It is the first implementation plan in the sequence.
+
+The only required repository knowledge is embedded here:
+
+- `ARCHITECTURE.md` defines the system boundary: Discord integration, thread routing, SQLite persistence, and Codex integration
+- `docs/design-docs/implementation-spec.md` fixes the v1 package direction and storage defaults
+- `docs/product-specs/discord-command-behavior.md` explains that normal conversation is mention-only and slash commands are explicit control surfaces
+
+If those documents change while this plan is in flight, update this plan to capture the changed assumptions before continuing.
+
+## Plan of Work
+
+Replace `cmd/39claw/main.go` with a real bootstrap path. Add a small `run` function that reads environment variables through `internal/config`, builds a logger through `internal/observe`, opens the SQLite store, ensures the schema exists, constructs the Codex gateway, and initializes a Discord runtime shell. If the runtime shell is not fully implemented yet, it may return a clear not-implemented startup error, but the bootstrap path itself must be real and testable.
+
+Create `internal/config/config.go` and `internal/config/config_test.go`. Parse the environment variables from `docs/design-docs/implementation-spec.md`: `CLAW_MODE`, `CLAW_TIMEZONE`, `CLAW_DISCORD_TOKEN`, `CLAW_CODEX_WORKDIR`, `CLAW_SQLITE_PATH`, and `CLAW_CODEX_EXECUTABLE` as required values, with optional support for `CLAW_CODEX_BASE_URL`, `CLAW_CODEX_API_KEY`, and `CLAW_LOG_LEVEL`. Validate that mode is `daily` or `task`, timezone loads successfully, and required paths are not empty.
+
+Create `internal/observe/logger.go` with a function that returns `*slog.Logger` using the configured log level. Keep the logging package minimal and avoid introducing a broad observability framework.
+
+Create `internal/app/types.go` and define request and response structs that contain application-level information only. Create service-oriented files such as `internal/app/message_service.go` and `internal/app/task_service.go` for the interfaces that later plans will implement. Do not import `discordgo` into this package.
+
+Create `internal/thread/policy.go` and `internal/thread/guard.go`. The policy file should define the interface for resolving logical thread keys. The guard file should define an in-memory per-key execution guard that can later reject concurrent turns for the same logical key.
+
+Create `internal/store/sqlite/store.go` and `internal/store/sqlite/store_test.go`. Use SQLite as required, create the schema idempotently, and define repository-facing methods for thread bindings, tasks, and active tasks even if some task methods are not fully exercised until the next plan.
+
+Create `internal/codex/gateway.go` with a higher-level wrapper that uses the existing `Client` and `Thread` types. The gateway should normalize the result of a Codex turn into application-friendly fields such as final response text and thread ID.
+
+Do not implement full Discord behavior in this plan. The runtime shell only needs enough structure to prove startup wiring, dependency injection, and graceful shutdown. A small interface plus a no-op or minimal runtime implementation is acceptable if it allows the process to start cleanly and keeps the later Discord-specific work isolated.
+
+## Concrete Steps
+
+Run all commands from `/home/filepang/playground/39claw`.
+
+1. Confirm the baseline before starting.
+
+    make test
+    make lint
+
+2. Implement the new foundation packages and bootstrap wiring.
+
+3. Run focused tests while iterating.
+
+    go test ./cmd/39claw ./internal/config ./internal/observe ./internal/app ./internal/thread ./internal/store/sqlite ./internal/codex
+
+4. Run the full repository checks after the plan lands.
+
+    make test
+    make lint
+
+5. Perform one startup validation with missing environment variables and expect a clear error instead of a panic.
+
+6. Record what exists at the end of the plan so later contributors can quickly verify the expected starting state for the next plan:
+
+    find internal -maxdepth 2 -type f | sort
+
+## Validation and Acceptance
+
+This plan is complete when:
+
+- `cmd/39claw` no longer prints a placeholder greeting
+- `internal/config` validates required environment variables and timezone loading with tests
+- `internal/observe` builds a `slog` logger from the configured level
+- `internal/app` exposes stable request, response, and service contracts without Discord SDK types
+- `internal/store/sqlite` creates the required tables idempotently
+- `internal/codex/gateway.go` exists and wraps the low-level Codex adapter in application-friendly behavior
+- `make test` passes
+- `make lint` passes
+
+The next plan should be able to assume these repository facts without inventing them:
+
+- `cmd/39claw` has a real `run` path
+- configuration parsing and logger construction exist
+- SQLite schema initialization exists
+- app-layer request and response contracts exist
+- a Codex gateway interface and implementation exist
+
+## Idempotence and Recovery
+
+Schema creation must use `CREATE TABLE IF NOT EXISTS` statements so the initialization path can be rerun safely. If startup wiring fails midway, recovery should only require fixing the code and rerunning `make test`; no manual state cleanup should be required for a fresh SQLite file used during development.
+
+If you open this plan and the repository is missing one of the acceptance items, implement the missing piece here rather than jumping ahead to a later plan. This plan is the recovery point for all missing foundation work.
+
+## Artifacts and Notes
+
+Keep this schema excerpt aligned with the implementation:
+
+    CREATE TABLE IF NOT EXISTS thread_bindings (
+        mode TEXT NOT NULL,
+        logical_thread_key TEXT NOT NULL,
+        codex_thread_id TEXT NOT NULL,
+        task_id TEXT NULL,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL,
+        PRIMARY KEY (mode, logical_thread_key)
+    );
+
+    CREATE TABLE IF NOT EXISTS tasks (
+        task_id TEXT PRIMARY KEY,
+        discord_user_id TEXT NOT NULL,
+        task_name TEXT NOT NULL,
+        status TEXT NOT NULL,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL,
+        closed_at TEXT NULL
+    );
+
+    CREATE TABLE IF NOT EXISTS active_tasks (
+        discord_user_id TEXT PRIMARY KEY,
+        task_id TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+    );
+
+## Interfaces and Dependencies
+
+At the end of this plan, the repository should contain interfaces shaped like these examples:
+
+    type MessageRequest struct {
+        UserID      string
+        ChannelID   string
+        MessageID   string
+        Content     string
+        Mentioned   bool
+        CommandName string
+        CommandArgs []string
+        ReceivedAt  time.Time
+    }
+
+    type MessageResponse struct {
+        Text      string
+        ReplyToID string
+        Ephemeral bool
+        Ignore    bool
+    }
+
+    type ThreadPolicy interface {
+        ResolveMessageKey(ctx context.Context, request MessageRequest) (string, error)
+    }
+
+    type CodexGateway interface {
+        RunTurn(ctx context.Context, threadID string, prompt string) (RunTurnResult, error)
+    }
+
+Revision Note: 2026-04-04 / Codex - Created this smaller child ExecPlan during the split of the original all-in-one runtime plan.
+Revision Note: 2026-04-04 / Codex - Removed the master-plan dependency and expanded this document with explicit starting-state and recovery guidance so it can stand alone.

--- a/docs/exec-plans/active/02-daily-mode-routing.md
+++ b/docs/exec-plans/active/02-daily-mode-routing.md
@@ -1,0 +1,160 @@
+# Implement `daily` mode routing and persistence
+
+This ExecPlan is a living document. The sections `Progress`, `Surprises & Discoveries`, `Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work proceeds.
+
+This document must be maintained in accordance with `.agents/PLANS.md`.
+
+## Purpose / Big Picture
+
+After this plan, a user should be able to mention the bot in `daily` mode and get same-day continuity automatically. The first qualifying mention of the local day should create a new Codex thread binding, later mentions on the same configured local date should reuse it, and the first qualifying mention on the next local date should create a fresh binding. This should be provable through store-backed tests and application-level orchestration tests without requiring a live Discord server.
+
+## Progress
+
+- [x] (2026-04-04 15:27Z) Defined the `daily` mode plan and its acceptance targets.
+- [ ] Confirm that the repository provides the foundation capabilities listed in `Starting State`.
+- [ ] Implement the `daily` logical thread key policy based on the configured timezone.
+- [ ] Implement thread-binding load and upsert behavior for `daily` mode.
+- [ ] Implement the message orchestration path that creates or resumes Codex threads in `daily` mode.
+- [ ] Add the per-logical-thread busy guard so overlapping turns are rejected instead of queued.
+- [ ] Add tests for same-day reuse, next-day rollover, and busy-thread rejection.
+
+## Surprises & Discoveries
+
+- Observation: `daily` mode is the smallest complete user-facing slice because it does not require task commands or explicit task selection.
+  Evidence: `docs/design-docs/implementation-spec.md`
+
+## Decision Log
+
+- Decision: Deliver `daily` mode before `task` mode.
+  Rationale: It is the first end-to-end behavior in the implementation-spec delivery order and exercises the storage and gateway seams with less state complexity.
+  Date/Author: 2026-04-04 / Codex
+
+- Decision: Treat the configured timezone as the only source of truth for daily bucket calculation.
+  Rationale: The product specs describe date boundaries in terms of the bot instance's configured local timezone.
+  Date/Author: 2026-04-04 / Codex
+
+## Outcomes & Retrospective
+
+This plan should produce the first real user-facing feature in the repository. Success means the app can route one kind of normal conversation correctly and persist its continuity over restart.
+
+## Context and Orientation
+
+The relevant user-facing behavior comes from `docs/product-specs/daily-mode-user-flow.md` and `docs/product-specs/discord-command-behavior.md`.
+
+In `daily` mode, the logical thread key is the configured local date formatted as `YYYY-MM-DD`. That key is not exposed to end users, but it is the stable internal identity for the current day's shared conversation. A "qualifying normal message" means a mention-triggered message that the bot is expected to handle. Unsupported non-mention chatter must still be ignored.
+
+The repository must persist the mapping between the `daily` logical key and the Codex thread ID in SQLite. If the process restarts, the app must be able to load the same binding and continue the same remote thread on the same day.
+
+## Starting State
+
+Start this plan only after confirming the repository provides all of the following capabilities:
+
+- `cmd/39claw` has a real startup path instead of a greeting stub
+- `internal/config` can load mode and timezone configuration
+- `internal/app` exposes message request and response contracts
+- `internal/thread` exposes a thread-policy seam and an execution guard seam
+- `internal/store/sqlite` can create the schema and upsert thread bindings
+- `internal/codex` exposes an application-friendly gateway wrapper
+
+Verify that state with:
+
+    make test
+    make lint
+
+If one or more of those capabilities is missing, stop and implement the missing foundation work first inside the same branch. Do not work around a missing seam by introducing a second temporary abstraction in this plan.
+
+## Preconditions
+
+This plan assumes only the repository state listed above. It does not require the reader to open another ExecPlan. The important repository facts are repeated here:
+
+- normal conversation is mention-only in v1
+- the `daily` logical key is the configured local date formatted as `YYYY-MM-DD`
+- SQLite stores the mapping from logical thread key to Codex thread ID
+- overlapping turns for the same logical key must be rejected instead of queued
+
+## Plan of Work
+
+Implement the `daily` key resolver in `internal/thread/policy.go` or a mode-specific helper file such as `internal/thread/daily_policy.go`. The resolver should accept a timestamp and a loaded timezone and return the local date in `YYYY-MM-DD` format.
+
+Implement the application-layer normal-message service for `daily` mode in `internal/app/message_service.go`. It should reject unsupported non-mention chatter by returning a response that signals "ignore". For a qualifying mention, it should resolve the logical key, consult the thread store, create a new Codex thread when no binding exists, or resume an existing thread when a binding is present. It should then call the Codex gateway, persist the returned thread ID, and return a normalized response for later presentation.
+
+Wire the per-logical-thread guard into the message service. If a second request arrives while the same logical key is already in flight, the service should return a busy or retry response instead of waiting in an internal queue. Keep this behavior in the application layer so the later Discord runtime only needs to present the returned message.
+
+Add tests in `internal/thread`, `internal/app`, and `internal/store/sqlite`. Use a fake Codex gateway in app tests so they can assert thread creation versus thread reuse without talking to the real Codex CLI. Include restart-oriented tests that reopen the SQLite store and confirm that the previously written thread binding is still available.
+
+If the repository does not yet have a concrete message-service implementation, create it here. Do not postpone that work on the assumption that another document covers it. This plan is responsible for the first complete end-to-end behavior for normal messages.
+
+## Concrete Steps
+
+Run all commands from `/home/filepang/playground/39claw`.
+
+1. Confirm the repository matches the required starting state.
+
+    make test
+    make lint
+
+2. Implement the `daily` key policy and message orchestration.
+
+3. Run focused tests while iterating.
+
+    go test ./internal/thread ./internal/app ./internal/store/sqlite -run 'TestDaily|TestThreadBinding|TestBusy'
+
+4. Run the full repository checks after the plan lands.
+
+    make test
+    make lint
+
+5. Record a short proof artifact for the next contributor:
+
+    go test ./internal/thread ./internal/app ./internal/store/sqlite -run 'TestDaily|TestThreadBinding|TestBusy' -v
+
+## Validation and Acceptance
+
+This plan is complete when:
+
+- in `daily` mode, the first qualifying mention creates a new thread binding
+- a second same-day qualifying mention reuses the existing thread binding
+- the first qualifying mention on the next configured local date creates a new logical binding
+- a restarted process can still load the same-day binding from SQLite
+- unsupported non-mention chatter is ignored
+- overlapping turns for the same logical thread key are rejected with a busy or retry response
+- `make test` passes
+- `make lint` passes
+
+The next plan should be able to assume these repository facts:
+
+- a concrete message-service path exists for normal mentions
+- `daily` routing behavior is tested without a live Discord server
+- thread-binding persistence survives store reopen
+
+## Idempotence and Recovery
+
+The store may be reopened many times during testing. Keep test fixtures isolated so reopening the same SQLite file is safe. If a daily-policy bug is discovered after persistence tests are written, fix the policy and rerun the app-level tests rather than deleting the store code and rewriting it.
+
+If you open this plan and discover that the repository does not satisfy the starting-state checklist, repair the missing foundation item first and update `Progress` to reflect that detour. The plan remains valid as long as the document tells the truth about the current state.
+
+## Artifacts and Notes
+
+Useful test scenarios to keep visible in this plan:
+
+    first mention at 2026-04-05T09:00:00+09:00 -> key 2026-04-05
+    second mention at 2026-04-05T16:00:00+09:00 -> key 2026-04-05
+    first mention at 2026-04-06T00:01:00+09:00 -> key 2026-04-06
+
+## Interfaces and Dependencies
+
+This plan should build on seams shaped like these examples:
+
+    type ThreadStore interface {
+        FindThreadBinding(ctx context.Context, mode string, logicalKey string) (ThreadBinding, bool, error)
+        UpsertThreadBinding(ctx context.Context, binding ThreadBinding) error
+    }
+
+    type CodexGateway interface {
+        StartOrResumeTurn(ctx context.Context, threadID string, prompt string) (RunTurnResult, error)
+    }
+
+Keep the Discord runtime out of scope here. The app tests should speak in request and response structs, not in Discord SDK payloads.
+
+Revision Note: 2026-04-04 / Codex - Created this smaller child ExecPlan during the split of the original all-in-one runtime plan.
+Revision Note: 2026-04-04 / Codex - Removed the parent-plan dependency and added explicit starting-state and recovery guidance so the document can stand alone.

--- a/docs/exec-plans/active/03-task-mode-workflow.md
+++ b/docs/exec-plans/active/03-task-mode-workflow.md
@@ -1,0 +1,171 @@
+# Implement `task` mode task workflow and command orchestration
+
+This ExecPlan is a living document. The sections `Progress`, `Surprises & Discoveries`, `Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work proceeds.
+
+This document must be maintained in accordance with `.agents/PLANS.md`.
+
+## Purpose / Big Picture
+
+After this plan, `task` mode should support explicit, durable work streams. A user should be able to create a task, switch tasks, list open tasks, close a task, and continue a task across days without losing context. Normal messages in `task` mode must not reach Codex unless the user has an active task, and the missing-context response must point the user toward the `/task ...` workflow.
+
+## Progress
+
+- [x] (2026-04-04 15:27Z) Defined the `task` mode plan and its acceptance targets.
+- [ ] Confirm that the repository provides the capabilities listed in `Starting State`.
+- [ ] Implement persistent task records and active-task state in SQLite.
+- [ ] Implement `/task`, `/task list`, `/task new <name>`, `/task switch <id>`, and `/task close <id>` in the app layer.
+- [ ] Implement missing-active-task guidance for normal mentions in `task` mode.
+- [ ] Ensure task-based logical thread keys are stable across days and process restart.
+- [ ] Add tests for task lifecycle transitions, user-scoped active task behavior, and missing-context guidance.
+
+## Surprises & Discoveries
+
+- Observation: `task` mode shares the same Codex gateway and thread-binding machinery as `daily` mode, but it introduces extra user-scoped state that must remain correct under closure and switching.
+  Evidence: `docs/design-docs/implementation-spec.md`
+
+## Decision Log
+
+- Decision: Keep active-task state scoped to one Discord user within one bot instance.
+  Rationale: This is the fixed v1 behavior in the implementation spec and product specs.
+  Date/Author: 2026-04-04 / Codex
+
+- Decision: Use ULID strings for `task_id`.
+  Rationale: The implementation spec fixes ULID as the v1 identifier format and it keeps task IDs sortable and copyable.
+  Date/Author: 2026-04-04 / Codex
+
+## Outcomes & Retrospective
+
+The outcome of this plan should be a repository that can support durable work context intentionally instead of guessing. Success means the user can see and control which work stream the bot is continuing.
+
+## Context and Orientation
+
+The relevant behavior definitions live in `docs/product-specs/task-mode-user-flow.md` and `docs/product-specs/discord-command-behavior.md`.
+
+In `task` mode, the logical thread key is `discord_user_id + task_id`. The user-facing task identity is the ULID `task_id` plus the human-friendly `task_name`. The active task must persist in SQLite so a later normal message can continue the same work stream without the user reselecting it after every restart.
+
+Task command responses should be written in application terms here. Whether those responses are presented as Discord ephemeral messages belongs to the later runtime plan.
+
+## Starting State
+
+Start this plan only after confirming the repository provides all of the following capabilities:
+
+- a real startup path in `cmd/39claw`
+- stable app-layer request and response contracts
+- SQLite schema creation and thread-binding persistence
+- a Codex gateway wrapper that can create or resume turns
+- `daily` mode normal-message orchestration and tests
+
+Verify that state with:
+
+    make test
+    make lint
+
+If the repository is missing the foundation items, implement them first. If the repository is missing only the `daily` mode behavior, complete that behavior before adding `task` mode. This plan assumes those pieces exist so it can focus on explicit task context instead of rebuilding the first normal-message slice.
+
+## Preconditions
+
+This document is self-contained. The facts you need are repeated here:
+
+- task identity is user-scoped within one bot instance
+- task IDs are ULID strings
+- open and closed are the only v1 task statuses
+- closing an active task must remove the active-task mapping
+- normal messages in `task` mode must not route unless an active task exists
+
+## Plan of Work
+
+Extend `internal/store/sqlite/store.go` with the concrete task operations required here. Add methods for creating a task, listing open tasks for a user, reading the current active task, setting the active task, and closing a task. Closing a task should mark its status as `closed`, set `closed_at`, and remove the `active_tasks` mapping if that task was active.
+
+Implement `TaskCommandService` in `internal/app/task_service.go`. The service should provide separate methods for showing the current task, listing open tasks, creating a task, switching tasks, and closing a task. The response text should clearly describe what changed and what the active task is now when relevant.
+
+Update the normal-message service so that in `task` mode it checks for an active task before routing to Codex. When no active task exists, it must return actionable guidance that points the user toward `/task new <name>`, `/task list`, or `/task switch <id>`. It must not create tasks implicitly and must not route the message anyway.
+
+Reuse the same thread-binding table for task threads. The binding should include the logical key built from user ID and task ID. Add tests that show the same task routes to the same Codex thread across multiple days because task mode is not date-bound.
+
+If you discover that the current normal-message service is too narrow to support both `daily` and `task` behavior cleanly, refactor it here as part of the plan. Do not create a separate parallel orchestration path just for tasks.
+
+## Concrete Steps
+
+Run all commands from `/home/filepang/playground/39claw`.
+
+1. Confirm the repository matches the required starting state.
+
+    make test
+    make lint
+
+2. Implement task storage operations and command orchestration.
+
+3. Run focused tests while iterating.
+
+    go test ./internal/app ./internal/store/sqlite -run 'TestTask|TestActiveTask|TestCloseTask|TestMissingActiveTask'
+
+4. Run the full repository checks after the plan lands.
+
+    make test
+    make lint
+
+5. Record a short proof artifact for the next contributor:
+
+    go test ./internal/app ./internal/store/sqlite -run 'TestTask|TestActiveTask|TestCloseTask|TestMissingActiveTask' -v
+
+## Validation and Acceptance
+
+This plan is complete when:
+
+- `/task new <name>` creates a task and makes it active for the requesting user
+- `/task` shows the current active task name and ID when one exists
+- `/task list` shows open tasks and clearly marks the active task
+- `/task switch <id>` changes the active task for the requesting user only
+- `/task close <id>` marks the task closed and clears active state if that task was active
+- in `task` mode, a normal mention without an active task returns actionable guidance instead of reaching Codex
+- task-based thread bindings survive process restart and are not reset by a date boundary
+- `make test` passes
+- `make lint` passes
+
+The next plan should be able to assume these repository facts:
+
+- task records and active-task state are persisted in SQLite
+- the app layer can answer `/task` command requests without Discord SDK types
+- normal mentions in `task` mode produce guidance when no active task exists
+
+## Idempotence and Recovery
+
+Task creation tests should use isolated SQLite files or temporary databases so reruns remain safe. If the output wording of task guidance changes, update the tests intentionally rather than weakening them to vague string matches that stop proving useful behavior.
+
+If you open this plan and the repository is missing a required starting-state capability, add the smallest necessary missing piece and record that decision in `Decision Log`. The recovery rule is to preserve one orchestration path, not to fork a second one.
+
+## Artifacts and Notes
+
+Keep this user-flow reminder visible:
+
+    no active task -> normal mention -> guidance only
+    /task new release -> task created and active
+    next normal mention -> routes to release task thread
+    /task close <id> -> task closed, active mapping cleared if applicable
+
+## Interfaces and Dependencies
+
+This plan should rely on store methods shaped like these examples:
+
+    type Task struct {
+        TaskID        string
+        DiscordUserID string
+        TaskName      string
+        Status        string
+        CreatedAt     time.Time
+        UpdatedAt     time.Time
+        ClosedAt      *time.Time
+    }
+
+    type ThreadStore interface {
+        CreateTask(ctx context.Context, params CreateTaskParams) (Task, error)
+        ListOpenTasks(ctx context.Context, userID string) ([]Task, error)
+        GetActiveTask(ctx context.Context, userID string) (Task, bool, error)
+        SetActiveTask(ctx context.Context, userID string, taskID string) error
+        CloseTask(ctx context.Context, userID string, taskID string, closedAt time.Time) error
+    }
+
+Any later Discord runtime work should call into this service rather than rebuilding task logic itself.
+
+Revision Note: 2026-04-04 / Codex - Created this smaller child ExecPlan during the split of the original all-in-one runtime plan.
+Revision Note: 2026-04-04 / Codex - Removed the parent-plan dependency and added explicit starting-state and recovery guidance so the document can stand alone.

--- a/docs/exec-plans/active/04-discord-runtime-and-presentation.md
+++ b/docs/exec-plans/active/04-discord-runtime-and-presentation.md
@@ -1,0 +1,174 @@
+# Implement the Discord runtime, commands, and response presentation
+
+This ExecPlan is a living document. The sections `Progress`, `Surprises & Discoveries`, `Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work proceeds.
+
+This document must be maintained in accordance with `.agents/PLANS.md`.
+
+## Purpose / Big Picture
+
+After this plan, `39claw` should expose the implemented application behavior through a real Discord runtime. A user in a Discord server should be able to mention the bot for normal conversation, invoke `/help` and `/task ...` slash commands, receive replies in the same channel, and get long responses chunked into readable Discord-safe messages. This is the plan that turns the internal application pipeline into an actual bot experience.
+
+## Progress
+
+- [x] (2026-04-04 15:27Z) Defined the Discord runtime plan and its acceptance targets.
+- [ ] Confirm that the repository provides the capabilities listed in `Starting State`.
+- [ ] Add the real Discord session runtime using a thin adapter.
+- [ ] Add mention filtering for normal-message handling.
+- [ ] Add `/help` and `/task ...` slash-command registration and routing.
+- [ ] Add reply targeting for normal messages and ephemeral responses for task-control commands.
+- [ ] Add Discord-safe response chunking that preserves fenced code blocks when practical.
+- [ ] Add runtime-level tests and a short manual smoke-test checklist.
+
+## Surprises & Discoveries
+
+- Observation: Discord-specific behavior should stay in a thin adapter because the core design explicitly keeps application logic independent from the Discord SDK.
+  Evidence: `ARCHITECTURE.md`
+
+## Decision Log
+
+- Decision: Use `github.com/bwmarrin/discordgo` for the first runtime implementation unless implementation evidence forces a change.
+  Rationale: It directly supports message handling, slash commands, replies, and interaction responses in Go while keeping the runtime surface thin.
+  Date/Author: 2026-04-04 / Codex
+
+- Decision: Keep chunking and presentation in the runtime adapter rather than the core app service.
+  Rationale: Discord message-length limits are transport concerns, not core orchestration concerns.
+  Date/Author: 2026-04-04 / Codex
+
+## Outcomes & Retrospective
+
+The outcome of this plan should be a bot that is observable from Discord, not just from unit tests. Success means the end-user workflow now matches the product docs closely enough for a real smoke test.
+
+## Context and Orientation
+
+The app layer should already know how to handle `daily` and `task` semantics; the runtime's responsibility is to translate Discord inputs into app requests and to translate app responses back into Discord messages.
+
+In v1, normal conversation is mention-only. Unsupported non-mention chatter should be ignored. `/help` should explain the commands that are actually available for the configured mode. `/task ...` should return a not-available response when the bot instance is running in `daily` mode. Task-control responses should be ephemeral by default.
+
+Long responses must be chunked into Discord-safe messages. When the content contains fenced code blocks, the chunker should preserve readable formatting when practical instead of splitting raw text arbitrarily.
+
+## Starting State
+
+Start this plan only after confirming the repository provides all of the following capabilities:
+
+- a real startup path in `cmd/39claw`
+- configuration loading and logger setup
+- app-layer message handling for `daily` mode
+- app-layer task command handling for `task` mode
+- SQLite-backed thread and task persistence
+
+Verify that state with:
+
+    make test
+    make lint
+
+If one of those capabilities is missing, implement the missing application behavior before building the Discord adapter. This plan should not become the place where core routing logic is invented for the first time.
+
+## Preconditions
+
+This document is self-contained. The facts you need are repeated here:
+
+- normal conversation is mention-only in v1
+- `/help` is always an explicit slash command
+- `/task ...` is the explicit task-control surface
+- task-control responses are ephemeral by default
+- transport-specific behavior such as chunking and Discord reply metadata belongs in the runtime adapter, not in the core app service
+
+## Plan of Work
+
+Create the real runtime under `internal/runtime/discord`. Add a small `Runtime` type that owns a `discordgo.Session`, registers handlers, and exposes `Start` and `Close` methods. Keep Discord-specific payload parsing in mapper files such as `message_mapper.go` and `interaction_mapper.go`.
+
+Implement mention filtering for message-create events. The mapper should produce `internal/app.MessageRequest` values only for qualifying mention-triggered messages. Unsupported chatter should be ignored without noise.
+
+Implement slash-command registration and routing for `/help` and `/task`. Map the command payloads into calls to the application services. When the configured mode is `daily`, `/task ...` should return a clear not-available response. When the configured mode is `task`, `/help` should describe the task workflow and task command success responses should be ephemeral.
+
+Implement the presenter in files such as `presenter.go` and `chunker.go`. Normal conversation responses should reply to the triggering message in the same channel. Command responses should use interaction responses and set ephemeral flags where appropriate. Long content should be chunked under Discord limits while trying to preserve code fences and a readable message sequence.
+
+Add runtime-oriented tests using fake session collaborators or a narrow wrapper around the Discord session. The tests should prove mention filtering, command mapping, ephemeral task-control behavior, and chunking logic. Finish with a manual smoke test described in `README.md`.
+
+## Concrete Steps
+
+Run all commands from `/home/filepang/playground/39claw`.
+
+1. Confirm the repository matches the required starting state.
+
+    make test
+    make lint
+
+2. Add the Discord runtime adapter and presenter.
+
+3. Run focused tests while iterating.
+
+    go test ./internal/runtime/discord -run 'TestMessage|TestCommand|TestChunk'
+
+4. Run the full repository checks after the plan lands.
+
+    make test
+    make lint
+
+5. Perform a manual smoke test with a disposable Discord server.
+
+    CLAW_MODE=daily \
+    CLAW_TIMEZONE=Asia/Tokyo \
+    CLAW_DISCORD_TOKEN=... \
+    CLAW_CODEX_WORKDIR=/absolute/path/to/repo \
+    CLAW_SQLITE_PATH=/tmp/39claw-dev.sqlite \
+    CLAW_CODEX_EXECUTABLE=/absolute/path/to/codex \
+    go run ./cmd/39claw
+
+6. Record a short proof artifact for later contributors:
+
+    go test ./internal/runtime/discord -run 'TestMessage|TestCommand|TestChunk' -v
+
+## Validation and Acceptance
+
+This plan is complete when:
+
+- normal message handling is mention-only
+- unsupported non-mention chatter is ignored
+- normal conversation replies in the same channel and targets the triggering message as the reply root
+- `/help` responds with commands appropriate to the configured mode
+- `/task ...` is available in `task` mode and clearly not available in `daily` mode
+- task-control command responses are ephemeral by default
+- long replies are chunked into Discord-safe messages while preserving code fences when practical
+- `make test` passes
+- `make lint` passes
+- a manual smoke test in a real Discord server succeeds
+
+At the end of this plan, the repository should no longer need a fake runtime shell. `cmd/39claw` should boot the real Discord adapter.
+
+## Idempotence and Recovery
+
+Command registration should be safe to repeat during development. If the runtime uses guild-scoped commands for smoke testing, document how to clean them up in `README.md` so retries do not leave stale command definitions behind.
+
+If you open this plan and discover that the app layer is still missing one of the required behaviors, pause the runtime work and add the missing behavior first. The recovery rule is to keep Discord-specific code thin. Do not duplicate core business logic inside the runtime package.
+
+## Artifacts and Notes
+
+Useful smoke-test checklist:
+
+    mention bot in daily mode -> receives same-channel reply
+    send unrelated chatter without mention -> bot stays silent
+    run /help in daily mode -> no task workflow advertised
+    run /task list in daily mode -> clear not-available message
+    switch to task mode and run /task new demo -> ephemeral success response
+
+## Interfaces and Dependencies
+
+The runtime should depend on app-layer surfaces shaped like these examples:
+
+    type MessageService interface {
+        HandleMessage(ctx context.Context, request MessageRequest) (MessageResponse, error)
+    }
+
+    type TaskCommandService interface {
+        ShowCurrent(ctx context.Context, userID string) (MessageResponse, error)
+        List(ctx context.Context, userID string) (MessageResponse, error)
+        New(ctx context.Context, userID string, name string) (MessageResponse, error)
+        Switch(ctx context.Context, userID string, taskID string) (MessageResponse, error)
+        Close(ctx context.Context, userID string, taskID string) (MessageResponse, error)
+    }
+
+Keep `discordgo` imports inside `internal/runtime/discord` and `cmd/39claw` only.
+
+Revision Note: 2026-04-04 / Codex - Created this smaller child ExecPlan during the split of the original all-in-one runtime plan.
+Revision Note: 2026-04-04 / Codex - Removed the parent-plan dependency and added explicit starting-state and recovery guidance so the document can stand alone.

--- a/docs/exec-plans/completed/README.md
+++ b/docs/exec-plans/completed/README.md
@@ -1,0 +1,5 @@
+# Completed ExecPlans
+
+Move finished execution plans into this directory once their validation and acceptance sections have been satisfied.
+
+Keep completed plans unchanged except for the final updates required by their living-document sections.

--- a/docs/exec-plans/index.md
+++ b/docs/exec-plans/index.md
@@ -1,0 +1,31 @@
+# 39claw ExecPlans
+
+This directory stores living execution plans for concrete implementation work.
+
+An ExecPlan is the repository's step-by-step delivery document for a feature, refactor, or milestone-sized change.
+Plans in this directory should be written and maintained in line with `.agents/PLANS.md`.
+
+## Structure
+
+- `active/`
+  - contains plans that are still being implemented or are ready to be picked up next
+- `completed/`
+  - contains plans that have been finished and are kept for historical reference
+- `tech-debt-tracker.md`
+  - tracks follow-up work that was intentionally deferred during implementation
+
+## Working Rules
+
+- Create a new plan in `active/` before starting large feature work or a significant refactor.
+- Keep each plan self-contained so a new contributor can continue from only the plan and the current working tree.
+- Move a plan from `active/` to `completed/` only after its acceptance criteria and validation steps are satisfied.
+- Record intentionally deferred work in `tech-debt-tracker.md` instead of leaving it implicit.
+
+## Current Active Plans
+
+These plans are intended to be executed in numeric order. Each plan is self-contained, but later plans name the repository state they expect to find and explain how to recover if that state is missing.
+
+- [Build the foundation, contracts, and bootstrap path](./active/01-foundation-and-contracts.md)
+- [Implement `daily` mode routing and persistence](./active/02-daily-mode-routing.md)
+- [Implement `task` mode task workflow and command orchestration](./active/03-task-mode-workflow.md)
+- [Implement the Discord runtime, commands, and response presentation](./active/04-discord-runtime-and-presentation.md)

--- a/docs/exec-plans/tech-debt-tracker.md
+++ b/docs/exec-plans/tech-debt-tracker.md
@@ -1,0 +1,34 @@
+# Tech Debt Tracker
+
+This file records follow-up work that is intentionally deferred while delivering an active ExecPlan.
+
+## How to Use This File
+
+- Add one entry when implementation deliberately leaves a non-blocking gap behind.
+- Link the relevant ExecPlan and explain why the work was deferred.
+- Remove or mark an entry resolved when the follow-up lands.
+
+## Entry Template
+
+### Title
+
+- Status: `open` or `resolved`
+- Date:
+- Related plan:
+- Owner:
+
+### Context
+
+Explain the current behavior and why the gap exists.
+
+### Risk
+
+Explain the user-facing or contributor-facing downside if the debt remains.
+
+### Next step
+
+Describe the smallest safe follow-up that should address the debt.
+
+## Current Entries
+
+No tracked follow-up items yet.

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,6 +12,8 @@ It is organized into a small set of document layers so contributors can quickly 
   - Product-facing user journeys, interaction rules, and expected behavior
 - [Design Docs](./design-docs/index.md)
   - Supporting design notes, focused concepts, and onboarding-oriented summaries
+- [ExecPlans](./exec-plans/index.md)
+  - Living execution plans, active implementation tracks, and deferred follow-up notes
 - [References](./references/index.md)
   - External references and bundled source material
 
@@ -28,6 +30,12 @@ Use `docs/design-docs` when the question is about:
 - how the system is structured
 - which responsibilities belong to which component
 - how thread routing, storage, and integration boundaries should work
+
+Use `docs/exec-plans` when the question is about:
+
+- the step-by-step delivery plan for a concrete feature
+- which implementation milestone is currently active
+- which follow-up items were intentionally deferred during delivery
 
 Use the root `ARCHITECTURE.md` when the question is about:
 
@@ -52,5 +60,6 @@ Use `docs/references` when the question is about:
 - Keep product behavior in `docs/product-specs`.
 - Keep the authoritative architecture model in `ARCHITECTURE.md`.
 - Keep supporting implementation design notes in `docs/design-docs`.
+- Keep living execution plans and deferred follow-up notes in `docs/exec-plans`.
 - Keep external source material in `docs/references`.
 - Update this index when a new top-level documentation layer is introduced.


### PR DESCRIPTION
## Summary

- add a dedicated `docs/exec-plans` documentation layer
- add four self-contained ExecPlans for the implementation-spec delivery sequence
- link the new execution-plan layer from contributor and repository docs

## Background

The repository had an implementation spec but no stable place to track execution plans for larger feature delivery. The first attempt used a large umbrella plan, but the ExecPlan guidance in `.agents/PLANS.md` is better served by smaller, self-contained plans that can be executed and resumed independently.

## Related issue(s)

- None

## Implementation details

- added `docs/exec-plans/index.md` and `docs/exec-plans/tech-debt-tracker.md`
- added four active ExecPlans for foundation, `daily`, `task`, and Discord runtime work
- added `docs/exec-plans/completed/README.md` for completed-plan handling
- updated `docs/index.md`, `README.md`, and `AGENTS.md` to reference the new ExecPlan layer
- removed the temporary master-plan approach in favor of self-contained plans

## Test coverage

- ran `make test`
- ran `make lint`
- no dedicated integration or e2e test targets exist yet in this repository

## Breaking changes

- None

## Notes

- The active ExecPlans are intended to be executed in numeric order.
- Each plan includes explicit starting-state and recovery guidance so it can stand alone.

Created by Codex
