### PR TITLE
Implement daily mode message routing

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -141,8 +141,8 @@ Responsibilities:
 1. accept a normalized message request
 2. ask the thread policy for a logical thread key
 3. load any existing binding from the thread store
-4. create a Codex thread if no binding exists
-5. send the user turn through the Codex gateway
+4. call the Codex gateway with or without an existing thread ID
+5. persist the returned thread ID when a new binding is created or updated
 6. return a normalized response for presentation
 
 ### 6.3 Thread Policy
@@ -171,9 +171,9 @@ The Codex gateway wraps the Codex SDK or Codex integration layer.
 
 Responsibilities:
 
-- create remote threads
 - resume remote threads by ID
 - send a turn to Codex
+- return the resulting remote thread ID for persistence when the first turn creates it
 - normalize Codex output for the application layer
 
 All Codex-specific details should stay behind this boundary.
@@ -206,8 +206,8 @@ thread_key = local_date
 Behavior:
 
 - incoming messages automatically resolve to today's bucket
-- if a thread exists for that key, resume it
-- otherwise create a new Codex thread
+- if a thread exists for that key, resume it by passing the saved thread ID into the next turn
+- otherwise run the first turn without a saved thread ID and persist the returned thread ID
 - when the date changes, the logical bucket changes automatically
 - Codex answers by following repository guidance and consulting the documentation in that repository
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,14 @@ The repository now includes a real startup spine for `cmd/39claw`:
 - a minimal Discord runtime shell in `internal/runtime/discord`
 
 The Discord runtime is still intentionally thin in this stage.
-It proves wiring, dependency boundaries, and graceful shutdown, but it does not yet implement the full `daily` or `task` interaction behavior.
+It proves wiring, dependency boundaries, and graceful shutdown, but it does not yet implement the full Discord adapter.
+The core `daily` message-routing path now exists in the application layer with tests for:
+
+- mention-only handling versus ignored chatter
+- same-day thread reuse
+- next-day rollover
+- SQLite-backed thread-binding persistence across reopen
+- busy-thread rejection
 
 The current direction is documented in the root architecture and product documents rather than in the executable surface alone.
 For the intended system shape, thread model, and user-facing behavior, start with the documents linked below.

--- a/docs/design-docs/architecture-overview.md
+++ b/docs/design-docs/architecture-overview.md
@@ -72,9 +72,9 @@ Adapts normalized application output into Discord-safe responses.
 2. Runtime normalizes the request
 3. Application service asks the thread policy for a thread key
 4. Thread store checks whether a Codex thread already exists
-5. If not found, Codex gateway creates a new thread
-6. Application service persists the new binding
-7. Codex gateway sends the user turn
+5. Application service sends the turn through the Codex gateway with the saved thread ID when one exists
+6. If no saved thread exists yet, the first turn creates one and returns its thread ID
+7. Application service persists the returned binding
 8. Response presenter formats the result
 9. Discord runtime posts the reply
 ```

--- a/docs/design-docs/implementation-spec.md
+++ b/docs/design-docs/implementation-spec.md
@@ -55,11 +55,22 @@ The following internal contracts should be treated as stable v1 design targets e
 - `ThreadStore`
   - loads and upserts thread bindings and manages task records plus active task state
 - `CodexGateway`
-  - creates or resumes Codex threads, runs a turn, and returns a normalized final response
+  - runs a turn against an existing Codex thread when a thread ID is present
+  - creates the first remote thread implicitly when the first turn runs without a saved thread ID
+  - returns a normalized final response plus the thread ID that should be persisted
 - `TaskCommandService`
   - implements `/task`, `/task list`, `/task new <name>`, `/task switch <id>`, and `/task close <id>`
 
 The application layer should depend on these responsibilities rather than on Discord SDK details or raw SQL.
+
+The concrete v1 message path lives in the application layer rather than in the Discord runtime.
+The message service is responsible for:
+
+- ignoring unsupported non-mention chatter
+- resolving the logical thread key
+- rejecting overlapping turns for the same logical thread key
+- loading and upserting SQLite thread bindings
+- calling the Codex gateway and returning a normalized reply payload
 
 ## Persistence Defaults
 

--- a/docs/exec-plans/active/02-daily-mode-routing.md
+++ b/docs/exec-plans/active/02-daily-mode-routing.md
@@ -11,17 +11,23 @@ After this plan, a user should be able to mention the bot in `daily` mode and ge
 ## Progress
 
 - [x] (2026-04-04 15:27Z) Defined the `daily` mode plan and its acceptance targets.
-- [ ] Confirm that the repository provides the foundation capabilities listed in `Starting State`.
-- [ ] Implement the `daily` logical thread key policy based on the configured timezone.
-- [ ] Implement thread-binding load and upsert behavior for `daily` mode.
-- [ ] Implement the message orchestration path that creates or resumes Codex threads in `daily` mode.
-- [ ] Add the per-logical-thread busy guard so overlapping turns are rejected instead of queued.
-- [ ] Add tests for same-day reuse, next-day rollover, and busy-thread rejection.
+- [x] (2026-04-05 16:00Z) Confirmed the repository provides the foundation capabilities listed in `Starting State` by rerunning `make test` and `make lint`.
+- [x] (2026-04-05 16:17Z) Implemented the `daily` logical thread key policy based on the configured timezone, including a local-midnight rollover test.
+- [x] (2026-04-05 16:17Z) Implemented thread-binding load and upsert behavior for `daily` mode, including a SQLite reopen persistence test.
+- [x] (2026-04-05 16:17Z) Implemented the message orchestration path that creates or resumes Codex threads in `daily` mode.
+- [x] (2026-04-05 16:17Z) Added the per-logical-thread busy guard so overlapping turns are rejected instead of queued.
+- [x] (2026-04-05 16:17Z) Added tests for ignored chatter, same-day reuse, next-day rollover, busy-thread rejection, and missing-task guidance.
 
 ## Surprises & Discoveries
 
 - Observation: `daily` mode is the smallest complete user-facing slice because it does not require task commands or explicit task selection.
   Evidence: `docs/design-docs/implementation-spec.md`
+
+- Observation: The first persisted Codex thread ID is created by the first successful turn, not by a separate empty-thread API call.
+  Evidence: `internal/codex/gateway.go`, `internal/app/message_service_impl.go`
+
+- Observation: Keeping busy-thread rejection and missing-task guidance inside the application layer makes the daily workflow fully testable without a Discord runtime.
+  Evidence: `go test ./internal/thread ./internal/app ./internal/store/sqlite -run 'TestMessageService|TestPolicy|TestGuard|TestStoreThreadBinding' -v`
 
 ## Decision Log
 
@@ -33,9 +39,17 @@ After this plan, a user should be able to mention the bot in `daily` mode and ge
   Rationale: The product specs describe date boundaries in terms of the bot instance's configured local timezone.
   Date/Author: 2026-04-04 / Codex
 
+- Decision: Use application-layer sentinel errors for `no active task` and `execution already in progress`.
+  Rationale: The message service needs to translate these states into user-facing responses without importing the thread package and creating a package cycle.
+  Date/Author: 2026-04-05 / Codex
+
+- Decision: Persist the returned thread ID after every successful turn instead of only on first creation.
+  Rationale: The current gateway contract returns the authoritative thread ID for both new and resumed turns, so persisting the latest value keeps the binding path simple and idempotent.
+  Date/Author: 2026-04-05 / Codex
+
 ## Outcomes & Retrospective
 
-This plan should produce the first real user-facing feature in the repository. Success means the app can route one kind of normal conversation correctly and persist its continuity over restart.
+This plan now produces the first real user-facing feature in the repository at the application layer. The app can route mention-triggered `daily` conversation correctly, persist same-day continuity over restart, reject overlapping turns for the same logical key, and ignore unsupported chatter. The remaining work for later plans is to connect this behavior to the real Discord runtime and presenter.
 
 ## Context and Orientation
 
@@ -108,6 +122,10 @@ Run all commands from `/home/filepang/playground/39claw`.
 
     go test ./internal/thread ./internal/app ./internal/store/sqlite -run 'TestDaily|TestThreadBinding|TestBusy' -v
 
+Completed proof artifact:
+
+    go test ./internal/thread ./internal/app ./internal/store/sqlite -run 'TestMessageService|TestPolicy|TestGuard|TestStoreThreadBinding' -v
+
 ## Validation and Acceptance
 
 This plan is complete when:
@@ -158,3 +176,4 @@ Keep the Discord runtime out of scope here. The app tests should speak in reques
 
 Revision Note: 2026-04-04 / Codex - Created this smaller child ExecPlan during the split of the original all-in-one runtime plan.
 Revision Note: 2026-04-04 / Codex - Removed the parent-plan dependency and added explicit starting-state and recovery guidance so the document can stand alone.
+Revision Note: 2026-04-05 / Codex - Recorded the completed application-layer daily routing implementation, updated proof commands, and captured the thread-ID persistence nuance.

--- a/internal/app/errors.go
+++ b/internal/app/errors.go
@@ -1,0 +1,8 @@
+package app
+
+import "errors"
+
+var (
+	ErrNoActiveTask        = errors.New("no active task selected")
+	ErrExecutionInProgress = errors.New("execution already in progress for thread key")
+)

--- a/internal/app/message_service_impl.go
+++ b/internal/app/message_service_impl.go
@@ -1,0 +1,136 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/HatsuneMiku3939/39claw/internal/config"
+)
+
+const (
+	busyRetryMessage    = "A response is already running for this conversation. Please retry in a moment."
+	noActiveTaskMessage = "No active task is selected. Use `/task new <name>`, `/task list`, or `/task switch <id>` first."
+)
+
+type ExecutionGuard interface {
+	Acquire(key string) (ReleaseFunc, error)
+}
+
+type ReleaseFunc func()
+
+type MessageServiceDependencies struct {
+	Mode    config.Mode
+	Policy  ThreadPolicy
+	Store   ThreadStore
+	Gateway CodexGateway
+	Guard   ExecutionGuard
+}
+
+type DefaultMessageService struct {
+	mode    config.Mode
+	policy  ThreadPolicy
+	store   ThreadStore
+	gateway CodexGateway
+	guard   ExecutionGuard
+}
+
+func NewMessageService(deps MessageServiceDependencies) (*DefaultMessageService, error) {
+	if deps.Mode == "" {
+		return nil, errors.New("mode must not be empty")
+	}
+
+	if deps.Policy == nil {
+		return nil, errors.New("thread policy must not be nil")
+	}
+
+	if deps.Store == nil {
+		return nil, errors.New("thread store must not be nil")
+	}
+
+	if deps.Gateway == nil {
+		return nil, errors.New("codex gateway must not be nil")
+	}
+
+	if deps.Guard == nil {
+		return nil, errors.New("execution guard must not be nil")
+	}
+
+	return &DefaultMessageService{
+		mode:    deps.Mode,
+		policy:  deps.Policy,
+		store:   deps.Store,
+		gateway: deps.Gateway,
+		guard:   deps.Guard,
+	}, nil
+}
+
+func (s *DefaultMessageService) HandleMessage(ctx context.Context, request MessageRequest) (MessageResponse, error) {
+	if !request.Mentioned {
+		return MessageResponse{Ignore: true}, nil
+	}
+
+	logicalKey, err := s.policy.ResolveMessageKey(ctx, request)
+	if err != nil {
+		if errors.Is(err, ErrNoActiveTask) {
+			return MessageResponse{
+				Text:      noActiveTaskMessage,
+				ReplyToID: request.MessageID,
+			}, nil
+		}
+
+		return MessageResponse{}, fmt.Errorf("resolve logical thread key: %w", err)
+	}
+
+	release, err := s.guard.Acquire(buildExecutionKey(s.mode, logicalKey))
+	if err != nil {
+		if errors.Is(err, ErrExecutionInProgress) {
+			return MessageResponse{
+				Text:      busyRetryMessage,
+				ReplyToID: request.MessageID,
+			}, nil
+		}
+
+		return MessageResponse{}, fmt.Errorf("acquire execution guard: %w", err)
+	}
+	defer release()
+
+	binding, ok, err := s.store.GetThreadBinding(ctx, string(s.mode), logicalKey)
+	if err != nil {
+		return MessageResponse{}, fmt.Errorf("load thread binding: %w", err)
+	}
+
+	threadID := ""
+	if ok {
+		threadID = binding.CodexThreadID
+	} else {
+		binding = ThreadBinding{
+			Mode:             string(s.mode),
+			LogicalThreadKey: logicalKey,
+		}
+	}
+
+	result, err := s.gateway.RunTurn(ctx, threadID, strings.TrimSpace(request.Content))
+	if err != nil {
+		return MessageResponse{}, fmt.Errorf("run codex turn: %w", err)
+	}
+
+	if strings.TrimSpace(result.ThreadID) == "" {
+		return MessageResponse{}, errors.New("codex gateway returned an empty thread id")
+	}
+
+	binding.CodexThreadID = result.ThreadID
+	if err := s.store.UpsertThreadBinding(ctx, binding); err != nil {
+		return MessageResponse{}, fmt.Errorf("persist thread binding: %w", err)
+	}
+
+	return MessageResponse{
+		Text:      result.ResponseText,
+		ReplyToID: request.MessageID,
+	}, nil
+}
+
+func buildExecutionKey(mode config.Mode, logicalKey string) string {
+	return string(mode) + ":" + logicalKey
+}

--- a/internal/app/message_service_test.go
+++ b/internal/app/message_service_test.go
@@ -1,0 +1,352 @@
+package app_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/HatsuneMiku3939/39claw/internal/app"
+	"github.com/HatsuneMiku3939/39claw/internal/config"
+	"github.com/HatsuneMiku3939/39claw/internal/thread"
+)
+
+func TestMessageServiceHandleMessageIgnoresNonMentionChatter(t *testing.T) {
+	t.Parallel()
+
+	service := newDailyMessageService(t, &memoryThreadStore{}, &fakeCodexGateway{}, &stubExecutionGuard{})
+
+	response, err := service.HandleMessage(context.Background(), app.MessageRequest{
+		MessageID:  "message-1",
+		Content:    "just chatting",
+		Mentioned:  false,
+		ReceivedAt: time.Date(2026, time.April, 5, 9, 0, 0, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatalf("HandleMessage() error = %v", err)
+	}
+
+	if !response.Ignore {
+		t.Fatal("Ignore = false, want true")
+	}
+}
+
+func TestMessageServiceHandleMessageDailyReusesSameDayBinding(t *testing.T) {
+	t.Parallel()
+
+	store := &memoryThreadStore{}
+	gateway := &fakeCodexGateway{
+		results: []app.RunTurnResult{
+			{ThreadID: "thread-1", ResponseText: "First response"},
+			{ThreadID: "thread-1", ResponseText: "Second response"},
+		},
+	}
+	service := newDailyMessageService(t, store, gateway, &stubExecutionGuard{})
+
+	firstResponse, err := service.HandleMessage(context.Background(), app.MessageRequest{
+		MessageID:  "message-1",
+		Content:    "hello there",
+		Mentioned:  true,
+		ReceivedAt: time.Date(2026, time.April, 5, 0, 0, 0, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatalf("HandleMessage() first error = %v", err)
+	}
+
+	secondResponse, err := service.HandleMessage(context.Background(), app.MessageRequest{
+		MessageID:  "message-2",
+		Content:    "follow up",
+		Mentioned:  true,
+		ReceivedAt: time.Date(2026, time.April, 5, 7, 0, 0, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatalf("HandleMessage() second error = %v", err)
+	}
+
+	if firstResponse.Text != "First response" {
+		t.Fatalf("first response text = %q, want %q", firstResponse.Text, "First response")
+	}
+
+	if secondResponse.Text != "Second response" {
+		t.Fatalf("second response text = %q, want %q", secondResponse.Text, "Second response")
+	}
+
+	if secondResponse.ReplyToID != "message-2" {
+		t.Fatalf("second reply id = %q, want %q", secondResponse.ReplyToID, "message-2")
+	}
+
+	if len(gateway.calls) != 2 {
+		t.Fatalf("RunTurn() call count = %d, want %d", len(gateway.calls), 2)
+	}
+
+	if gateway.calls[0].threadID != "" {
+		t.Fatalf("first thread id = %q, want empty", gateway.calls[0].threadID)
+	}
+
+	if gateway.calls[1].threadID != "thread-1" {
+		t.Fatalf("second thread id = %q, want %q", gateway.calls[1].threadID, "thread-1")
+	}
+
+	binding, ok, err := store.GetThreadBinding(context.Background(), "daily", "2026-04-05")
+	if err != nil {
+		t.Fatalf("GetThreadBinding() error = %v", err)
+	}
+
+	if !ok {
+		t.Fatal("GetThreadBinding() ok = false, want true")
+	}
+
+	if binding.CodexThreadID != "thread-1" {
+		t.Fatalf("CodexThreadID = %q, want %q", binding.CodexThreadID, "thread-1")
+	}
+}
+
+func TestMessageServiceHandleMessageDailyRollsOverOnNextDay(t *testing.T) {
+	t.Parallel()
+
+	store := &memoryThreadStore{}
+	gateway := &fakeCodexGateway{
+		results: []app.RunTurnResult{
+			{ThreadID: "thread-1", ResponseText: "Today"},
+			{ThreadID: "thread-2", ResponseText: "Tomorrow"},
+		},
+	}
+	service := newDailyMessageService(t, store, gateway, &stubExecutionGuard{})
+
+	_, err := service.HandleMessage(context.Background(), app.MessageRequest{
+		MessageID:  "message-1",
+		Content:    "today",
+		Mentioned:  true,
+		ReceivedAt: time.Date(2026, time.April, 5, 0, 0, 0, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatalf("HandleMessage() first error = %v", err)
+	}
+
+	_, err = service.HandleMessage(context.Background(), app.MessageRequest{
+		MessageID:  "message-2",
+		Content:    "tomorrow",
+		Mentioned:  true,
+		ReceivedAt: time.Date(2026, time.April, 5, 15, 1, 0, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatalf("HandleMessage() second error = %v", err)
+	}
+
+	if len(gateway.calls) != 2 {
+		t.Fatalf("RunTurn() call count = %d, want %d", len(gateway.calls), 2)
+	}
+
+	if gateway.calls[0].threadID != "" {
+		t.Fatalf("first thread id = %q, want empty", gateway.calls[0].threadID)
+	}
+
+	if gateway.calls[1].threadID != "" {
+		t.Fatalf("second thread id = %q, want empty", gateway.calls[1].threadID)
+	}
+
+	if _, ok, err := store.GetThreadBinding(context.Background(), "daily", "2026-04-05"); err != nil || !ok {
+		t.Fatalf("same-day binding lookup = ok:%v err:%v, want ok:true err:nil", ok, err)
+	}
+
+	nextBinding, ok, err := store.GetThreadBinding(context.Background(), "daily", "2026-04-06")
+	if err != nil {
+		t.Fatalf("GetThreadBinding() next day error = %v", err)
+	}
+
+	if !ok {
+		t.Fatal("GetThreadBinding() next day ok = false, want true")
+	}
+
+	if nextBinding.CodexThreadID != "thread-2" {
+		t.Fatalf("next day thread id = %q, want %q", nextBinding.CodexThreadID, "thread-2")
+	}
+}
+
+func TestMessageServiceHandleMessageReturnsBusyResponse(t *testing.T) {
+	t.Parallel()
+
+	service := newDailyMessageService(t, &memoryThreadStore{}, &fakeCodexGateway{}, &stubExecutionGuard{
+		err: app.ErrExecutionInProgress,
+	})
+
+	response, err := service.HandleMessage(context.Background(), app.MessageRequest{
+		MessageID:  "message-1",
+		Content:    "hello",
+		Mentioned:  true,
+		ReceivedAt: time.Date(2026, time.April, 5, 0, 0, 0, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatalf("HandleMessage() error = %v", err)
+	}
+
+	if response.Text != "A response is already running for this conversation. Please retry in a moment." {
+		t.Fatalf("busy response text = %q", response.Text)
+	}
+
+	if response.ReplyToID != "message-1" {
+		t.Fatalf("ReplyToID = %q, want %q", response.ReplyToID, "message-1")
+	}
+}
+
+func TestMessageServiceHandleMessageReturnsTaskGuidance(t *testing.T) {
+	t.Parallel()
+
+	service, err := app.NewMessageService(app.MessageServiceDependencies{
+		Mode: config.ModeTask,
+		Policy: stubThreadPolicy{
+			err: app.ErrNoActiveTask,
+		},
+		Store:   &memoryThreadStore{},
+		Gateway: &fakeCodexGateway{},
+		Guard:   &stubExecutionGuard{},
+	})
+	if err != nil {
+		t.Fatalf("NewMessageService() error = %v", err)
+	}
+
+	response, err := service.HandleMessage(context.Background(), app.MessageRequest{
+		MessageID: "message-1",
+		Content:   "do the work",
+		Mentioned: true,
+	})
+	if err != nil {
+		t.Fatalf("HandleMessage() error = %v", err)
+	}
+
+	if response.Text != "No active task is selected. Use `/task new <name>`, `/task list`, or `/task switch <id>` first." {
+		t.Fatalf("guidance text = %q", response.Text)
+	}
+}
+
+func newDailyMessageService(
+	t *testing.T,
+	store app.ThreadStore,
+	gateway app.CodexGateway,
+	guard app.ExecutionGuard,
+) *app.DefaultMessageService {
+	t.Helper()
+
+	tokyo, err := time.LoadLocation("Asia/Tokyo")
+	if err != nil {
+		t.Fatalf("time.LoadLocation() error = %v", err)
+	}
+
+	policy, err := thread.NewPolicy(config.ModeDaily, tokyo, nil)
+	if err != nil {
+		t.Fatalf("thread.NewPolicy() error = %v", err)
+	}
+
+	service, err := app.NewMessageService(app.MessageServiceDependencies{
+		Mode:    config.ModeDaily,
+		Policy:  policy,
+		Store:   store,
+		Gateway: gateway,
+		Guard:   guard,
+	})
+	if err != nil {
+		t.Fatalf("NewMessageService() error = %v", err)
+	}
+
+	return service
+}
+
+type stubThreadPolicy struct {
+	key string
+	err error
+}
+
+func (s stubThreadPolicy) ResolveMessageKey(context.Context, app.MessageRequest) (string, error) {
+	return s.key, s.err
+}
+
+type stubExecutionGuard struct {
+	err error
+}
+
+func (g *stubExecutionGuard) Acquire(string) (app.ReleaseFunc, error) {
+	if g.err != nil {
+		return nil, g.err
+	}
+
+	return func() {}, nil
+}
+
+type fakeCodexGateway struct {
+	calls   []runTurnCall
+	results []app.RunTurnResult
+	err     error
+}
+
+type runTurnCall struct {
+	threadID string
+	prompt   string
+}
+
+func (g *fakeCodexGateway) RunTurn(_ context.Context, threadID string, prompt string) (app.RunTurnResult, error) {
+	g.calls = append(g.calls, runTurnCall{
+		threadID: threadID,
+		prompt:   prompt,
+	})
+
+	if g.err != nil {
+		return app.RunTurnResult{}, g.err
+	}
+
+	if len(g.results) == 0 {
+		return app.RunTurnResult{}, nil
+	}
+
+	result := g.results[0]
+	g.results = g.results[1:]
+	return result, nil
+}
+
+type memoryThreadStore struct {
+	bindings map[string]app.ThreadBinding
+}
+
+func (s *memoryThreadStore) GetThreadBinding(_ context.Context, mode string, logicalThreadKey string) (app.ThreadBinding, bool, error) {
+	if s.bindings == nil {
+		return app.ThreadBinding{}, false, nil
+	}
+
+	binding, ok := s.bindings[mode+":"+logicalThreadKey]
+	return binding, ok, nil
+}
+
+func (s *memoryThreadStore) UpsertThreadBinding(_ context.Context, binding app.ThreadBinding) error {
+	if s.bindings == nil {
+		s.bindings = make(map[string]app.ThreadBinding)
+	}
+
+	s.bindings[binding.Mode+":"+binding.LogicalThreadKey] = binding
+	return nil
+}
+
+func (s *memoryThreadStore) CreateTask(context.Context, app.Task) error {
+	return nil
+}
+
+func (s *memoryThreadStore) GetTask(context.Context, string, string) (app.Task, bool, error) {
+	return app.Task{}, false, nil
+}
+
+func (s *memoryThreadStore) ListOpenTasks(context.Context, string) ([]app.Task, error) {
+	return nil, nil
+}
+
+func (s *memoryThreadStore) SetActiveTask(context.Context, app.ActiveTask) error {
+	return nil
+}
+
+func (s *memoryThreadStore) GetActiveTask(context.Context, string) (app.ActiveTask, bool, error) {
+	return app.ActiveTask{}, false, nil
+}
+
+func (s *memoryThreadStore) ClearActiveTask(context.Context, string) error {
+	return nil
+}
+
+func (s *memoryThreadStore) CloseTask(context.Context, string, string) error {
+	return nil
+}

--- a/internal/store/sqlite/store_test.go
+++ b/internal/store/sqlite/store_test.go
@@ -75,6 +75,64 @@ func TestStoreThreadBindingLifecycle(t *testing.T) {
 	}
 }
 
+func TestStoreThreadBindingPersistsAcrossReopen(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "39claw.db")
+
+	store, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+
+	store.clock = func() time.Time {
+		return time.Date(2026, time.April, 5, 15, 4, 0, 0, time.UTC)
+	}
+
+	if err := store.InitSchema(context.Background()); err != nil {
+		t.Fatalf("InitSchema() error = %v", err)
+	}
+
+	if err := store.UpsertThreadBinding(context.Background(), app.ThreadBinding{
+		Mode:             "daily",
+		LogicalThreadKey: "2026-04-05",
+		CodexThreadID:    "thread-1",
+	}); err != nil {
+		t.Fatalf("UpsertThreadBinding() error = %v", err)
+	}
+
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+
+	reopened, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open() reopen error = %v", err)
+	}
+	defer func() {
+		if closeErr := reopened.Close(); closeErr != nil {
+			t.Fatalf("Close() reopen error = %v", closeErr)
+		}
+	}()
+
+	if err := reopened.InitSchema(context.Background()); err != nil {
+		t.Fatalf("InitSchema() reopen error = %v", err)
+	}
+
+	binding, ok, err := reopened.GetThreadBinding(context.Background(), "daily", "2026-04-05")
+	if err != nil {
+		t.Fatalf("GetThreadBinding() reopen error = %v", err)
+	}
+
+	if !ok {
+		t.Fatal("GetThreadBinding() reopen ok = false, want true")
+	}
+
+	if binding.CodexThreadID != "thread-1" {
+		t.Fatalf("CodexThreadID after reopen = %q, want %q", binding.CodexThreadID, "thread-1")
+	}
+}
+
 func TestStoreTaskLifecycle(t *testing.T) {
 	t.Parallel()
 

--- a/internal/thread/guard.go
+++ b/internal/thread/guard.go
@@ -1,13 +1,10 @@
 package thread
 
 import (
-	"errors"
 	"sync"
+
+	"github.com/HatsuneMiku3939/39claw/internal/app"
 )
-
-var ErrExecutionInProgress = errors.New("execution already in progress for thread key")
-
-type ReleaseFunc func()
 
 type Guard struct {
 	mu      sync.Mutex
@@ -20,12 +17,12 @@ func NewGuard() *Guard {
 	}
 }
 
-func (g *Guard) Acquire(key string) (ReleaseFunc, error) {
+func (g *Guard) Acquire(key string) (app.ReleaseFunc, error) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
 
 	if g.running[key] > 0 {
-		return nil, ErrExecutionInProgress
+		return nil, app.ErrExecutionInProgress
 	}
 
 	g.running[key]++

--- a/internal/thread/policy.go
+++ b/internal/thread/policy.go
@@ -10,8 +10,6 @@ import (
 	"github.com/HatsuneMiku3939/39claw/internal/config"
 )
 
-var ErrNoActiveTask = errors.New("no active task selected")
-
 type Policy struct {
 	mode     config.Mode
 	timezone *time.Location
@@ -45,7 +43,7 @@ func (p *Policy) ResolveMessageKey(ctx context.Context, request app.MessageReque
 		}
 
 		if !ok {
-			return "", ErrNoActiveTask
+			return "", app.ErrNoActiveTask
 		}
 
 		return BuildTaskKey(request.UserID, activeTask.TaskID), nil

--- a/internal/thread/policy_test.go
+++ b/internal/thread/policy_test.go
@@ -44,6 +44,15 @@ func TestPolicyResolveMessageKey(t *testing.T) {
 			want: "2026-04-05",
 		},
 		{
+			name:  "daily rolls over at local midnight",
+			mode:  config.ModeDaily,
+			store: nil,
+			request: app.MessageRequest{
+				ReceivedAt: time.Date(2026, time.April, 5, 15, 1, 0, 0, time.UTC),
+			},
+			want: "2026-04-06",
+		},
+		{
 			name:  "task uses active task binding",
 			mode:  config.ModeTask,
 			store: store,
@@ -59,7 +68,7 @@ func TestPolicyResolveMessageKey(t *testing.T) {
 			request: app.MessageRequest{
 				UserID: "user-1",
 			},
-			wantErr: ErrNoActiveTask,
+			wantErr: app.ErrNoActiveTask,
 		},
 		{
 			name:     "task mode requires store",
@@ -131,8 +140,8 @@ func TestGuardAcquire(t *testing.T) {
 		t.Fatal("Acquire() error = nil, want non-nil")
 	}
 
-	if err != ErrExecutionInProgress {
-		t.Fatalf("Acquire() error = %v, want %v", err, ErrExecutionInProgress)
+	if err != app.ErrExecutionInProgress {
+		t.Fatalf("Acquire() error = %v, want %v", err, app.ErrExecutionInProgress)
 	}
 
 	if secondRelease != nil {


### PR DESCRIPTION
## Summary

- implement the application-layer daily message service for mention-only routing
- persist and reuse daily Codex thread bindings with busy-thread rejection
- add tests and documentation updates for rollover and persistence behavior

## Background

The repository had the startup seams for message handling, but the first complete daily-mode flow was still missing. This change adds the first end-to-end application behavior for normal mention-driven conversation without requiring a live Discord server.

## Related issue(s)

- None.

## Implementation details

- add a concrete message service that ignores unsupported chatter, resolves the daily logical key, acquires a per-key execution guard, loads and upserts thread bindings, and calls the Codex gateway
- move shared busy and missing-task sentinel errors into the app package so the service can translate them into user-facing responses without a package cycle
- extend tests for local-midnight rollover and SQLite binding persistence across reopen, and update architecture and ExecPlan docs to match the implemented thread-ID lifecycle

## Test coverage

- `make test`
- `make lint`
- `go test ./internal/thread ./internal/app ./internal/store/sqlite -run 'TestMessageService|TestPolicy|TestGuard|TestStoreThreadBinding' -v`

## Breaking changes

- None.

## Notes

- The Discord runtime is still intentionally thin; this PR delivers the tested application-layer daily routing behavior that the later runtime plan will call.

Created by Codex