### PR TITLE
feat: implement task mode workflow orchestration

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,12 +20,19 @@ The repository now includes a real startup spine for `cmd/39claw`:
 
 The Discord runtime is still intentionally thin in this stage.
 It proves wiring, dependency boundaries, and graceful shutdown, but it does not yet implement the full Discord adapter.
-The core `daily` message-routing path now exists in the application layer with tests for:
+The application layer now covers both the `daily` routing flow and the `task` workflow.
+
+The current test-backed behavior includes:
 
 - mention-only handling versus ignored chatter
 - same-day thread reuse
 - next-day rollover
+- task command orchestration for showing, listing, creating, switching, and closing tasks
+- durable active-task state and open-task records in SQLite
+- task-mode guidance when a normal mention arrives without an active task
+- task thread reuse across days and task switches
 - SQLite-backed thread-binding persistence across reopen
+- SQLite-backed task and active-task persistence across reopen
 - busy-thread rejection
 
 The current direction is documented in the root architecture and product documents rather than in the executable surface alone.

--- a/docs/exec-plans/completed/03-task-mode-workflow.md
+++ b/docs/exec-plans/completed/03-task-mode-workflow.md
@@ -11,17 +11,23 @@ After this plan, `task` mode should support explicit, durable work streams. A us
 ## Progress
 
 - [x] (2026-04-04 15:27Z) Defined the `task` mode plan and its acceptance targets.
-- [ ] Confirm that the repository provides the capabilities listed in `Starting State`.
-- [ ] Implement persistent task records and active-task state in SQLite.
-- [ ] Implement `/task`, `/task list`, `/task new <name>`, `/task switch <id>`, and `/task close <id>` in the app layer.
-- [ ] Implement missing-active-task guidance for normal mentions in `task` mode.
-- [ ] Ensure task-based logical thread keys are stable across days and process restart.
-- [ ] Add tests for task lifecycle transitions, user-scoped active task behavior, and missing-context guidance.
+- [x] (2026-04-04 17:12Z) Confirmed the required starting state with `make test` and `make lint`.
+- [x] (2026-04-04 17:12Z) Verified SQLite already provided persistent task records and active-task state, then extended tests to prove reopen and close behavior.
+- [x] (2026-04-04 17:12Z) Implemented `TaskCommandService` for `/task`, `/task list`, `/task new <name>`, `/task switch <id>`, and `/task close <id>` in the app layer.
+- [x] (2026-04-04 17:12Z) Kept missing-active-task guidance on the normal mention path and ensured task-mode bindings persist the active `task_id`.
+- [x] (2026-04-04 17:12Z) Added task-mode routing tests that prove logical keys stay stable across days and task switches.
+- [x] (2026-04-04 17:12Z) Added task lifecycle, active-task, reopen, and guidance coverage, then reran `make test` and `make lint`.
 
 ## Surprises & Discoveries
 
 - Observation: `task` mode shares the same Codex gateway and thread-binding machinery as `daily` mode, but it introduces extra user-scoped state that must remain correct under closure and switching.
   Evidence: `docs/design-docs/implementation-spec.md`
+
+- Observation: Most of the required SQLite behavior already existed before this plan started, so the main missing slice was application orchestration plus stronger proof around restart and inactive-close cases.
+  Evidence: `internal/store/sqlite/store.go`, `internal/store/sqlite/store_test.go`
+
+- Observation: The normal-message service needed one extra task-mode read after logical-key resolution so persisted task bindings also record `task_id` rather than only the derived `logical_thread_key`.
+  Evidence: `internal/app/message_service_impl.go`
 
 ## Decision Log
 
@@ -33,9 +39,17 @@ After this plan, `task` mode should support explicit, durable work streams. A us
   Rationale: The implementation spec fixes ULID as the v1 identifier format and it keeps task IDs sortable and copyable.
   Date/Author: 2026-04-04 / Codex
 
+- Decision: Make the app-layer task command responses ephemeral by default.
+  Rationale: The implementation spec fixes task-control command responses as ephemeral, and returning that hint from the service keeps the runtime thin later.
+  Date/Author: 2026-04-04 / Codex
+
+- Decision: Keep user-facing task command failures inside `MessageResponse` for expected cases such as missing IDs, unknown tasks, and closed tasks.
+  Rationale: These cases are product-level workflow guidance, not infrastructure failures, so the app layer should return actionable command text instead of surfacing internal errors.
+  Date/Author: 2026-04-04 / Codex
+
 ## Outcomes & Retrospective
 
-The outcome of this plan should be a repository that can support durable work context intentionally instead of guessing. Success means the user can see and control which work stream the bot is continuing.
+This plan now lands the durable `task` workflow in the application and persistence layers. The repository can create, inspect, list, switch, and close user-scoped tasks; task-mode normal mentions refuse to route without an active task; and task thread bindings stay stable across day boundaries and process restart. The remaining Discord slash-command wiring still belongs to the next runtime plan, but that runtime work can now call into finished app-layer services instead of inventing task behavior itself.
 
 ## Context and Orientation
 
@@ -74,15 +88,7 @@ This document is self-contained. The facts you need are repeated here:
 
 ## Plan of Work
 
-Extend `internal/store/sqlite/store.go` with the concrete task operations required here. Add methods for creating a task, listing open tasks for a user, reading the current active task, setting the active task, and closing a task. Closing a task should mark its status as `closed`, set `closed_at`, and remove the `active_tasks` mapping if that task was active.
-
-Implement `TaskCommandService` in `internal/app/task_service.go`. The service should provide separate methods for showing the current task, listing open tasks, creating a task, switching tasks, and closing a task. The response text should clearly describe what changed and what the active task is now when relevant.
-
-Update the normal-message service so that in `task` mode it checks for an active task before routing to Codex. When no active task exists, it must return actionable guidance that points the user toward `/task new <name>`, `/task list`, or `/task switch <id>`. It must not create tasks implicitly and must not route the message anyway.
-
-Reuse the same thread-binding table for task threads. The binding should include the logical key built from user ID and task ID. Add tests that show the same task routes to the same Codex thread across multiple days because task mode is not date-bound.
-
-If you discover that the current normal-message service is too narrow to support both `daily` and `task` behavior cleanly, refactor it here as part of the plan. Do not create a separate parallel orchestration path just for tasks.
+Use the existing SQLite task and active-task operations in `internal/store/sqlite/store.go` as the persistence base for this plan, then strengthen their proof with reopen and inactive-close tests. Implement the missing app-layer orchestration in `internal/app/task_service.go` so task commands can return normalized `MessageResponse` values without Discord SDK types. Update `internal/app/message_service_impl.go` so `task` mode still shares the same orchestration path as `daily`, while also persisting the active `task_id` onto thread bindings. Add message-service and store tests that prove the same task keeps its Codex thread across multiple days, that task switches create distinct logical bindings, and that close behavior preserves or clears the active mapping correctly.
 
 ## Concrete Steps
 
@@ -93,20 +99,42 @@ Run all commands from `/home/filepang/playground/39claw`.
     make test
     make lint
 
-2. Implement task storage operations and command orchestration.
+    Observed result:
+
+        all Go tests passed
+        lint passed with 0 issues
+
+2. Implement task storage proof and command orchestration in:
+
+    - `internal/app/task_service.go`
+    - `internal/app/message_service_impl.go`
+    - `internal/app/task_service_test.go`
+    - `internal/app/message_service_test.go`
+    - `internal/store/sqlite/store_test.go`
+    - `README.md`
 
 3. Run focused tests while iterating.
 
-    go test ./internal/app ./internal/store/sqlite -run 'TestTask|TestActiveTask|TestCloseTask|TestMissingActiveTask'
+    go test ./internal/app ./internal/store/sqlite -run 'Test(TaskCommandService|MessageServiceHandleMessageTask|StoreTask|StoreCloseTask)'
+
+    Observed result:
+
+        ok   github.com/HatsuneMiku3939/39claw/internal/app
+        ok   github.com/HatsuneMiku3939/39claw/internal/store/sqlite
 
 4. Run the full repository checks after the plan lands.
 
     make test
     make lint
 
+    Observed result:
+
+        all Go tests passed
+        lint passed with 0 issues
+
 5. Record a short proof artifact for the next contributor:
 
-    go test ./internal/app ./internal/store/sqlite -run 'TestTask|TestActiveTask|TestCloseTask|TestMissingActiveTask' -v
+    go test ./internal/app ./internal/store/sqlite -run 'Test(TaskCommandService|MessageServiceHandleMessageTask|StoreTask|StoreCloseTask)' -v
 
 ## Validation and Acceptance
 
@@ -143,9 +171,16 @@ Keep this user-flow reminder visible:
     next normal mention -> routes to release task thread
     /task close <id> -> task closed, active mapping cleared if applicable
 
+Key proof points captured during implementation:
+
+    task command responses are normalized in the app layer and marked ephemeral
+    task bindings persist both logical_thread_key and task_id
+    the same task binding survives later-day messages and SQLite reopen
+    closing a non-active task does not clear a different active task
+
 ## Interfaces and Dependencies
 
-This plan should rely on store methods shaped like these examples:
+This plan now relies on store and service methods shaped like these repository interfaces:
 
     type Task struct {
         TaskID        string
@@ -158,14 +193,17 @@ This plan should rely on store methods shaped like these examples:
     }
 
     type ThreadStore interface {
-        CreateTask(ctx context.Context, params CreateTaskParams) (Task, error)
+        CreateTask(ctx context.Context, task Task) error
+        GetTask(ctx context.Context, discordUserID string, taskID string) (Task, bool, error)
         ListOpenTasks(ctx context.Context, userID string) ([]Task, error)
-        GetActiveTask(ctx context.Context, userID string) (Task, bool, error)
-        SetActiveTask(ctx context.Context, userID string, taskID string) error
-        CloseTask(ctx context.Context, userID string, taskID string, closedAt time.Time) error
+        SetActiveTask(ctx context.Context, activeTask ActiveTask) error
+        GetActiveTask(ctx context.Context, userID string) (ActiveTask, bool, error)
+        ClearActiveTask(ctx context.Context, userID string) error
+        CloseTask(ctx context.Context, userID string, taskID string) error
     }
 
 Any later Discord runtime work should call into this service rather than rebuilding task logic itself.
 
 Revision Note: 2026-04-04 / Codex - Created this smaller child ExecPlan during the split of the original all-in-one runtime plan.
 Revision Note: 2026-04-04 / Codex - Removed the parent-plan dependency and added explicit starting-state and recovery guidance so the document can stand alone.
+Revision Note: 2026-04-04 / Codex - Updated progress, decisions, proof commands, and outcomes after completing the task-mode workflow implementation and validation.

--- a/docs/exec-plans/index.md
+++ b/docs/exec-plans/index.md
@@ -27,5 +27,8 @@ These plans are intended to be executed in numeric order. Each plan is self-cont
 
 - [Build the foundation, contracts, and bootstrap path](./active/01-foundation-and-contracts.md)
 - [Implement `daily` mode routing and persistence](./active/02-daily-mode-routing.md)
-- [Implement `task` mode task workflow and command orchestration](./active/03-task-mode-workflow.md)
 - [Implement the Discord runtime, commands, and response presentation](./active/04-discord-runtime-and-presentation.md)
+
+## Recently Completed Plans
+
+- [Implement `task` mode task workflow and command orchestration](./completed/03-task-mode-workflow.md)

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect
+	github.com/oklog/ulid/v2 v2.1.1 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	golang.org/x/sys v0.42.0 // indirect
 	modernc.org/libc v1.70.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,9 @@ github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWE
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOFAw7w=
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
+github.com/oklog/ulid/v2 v2.1.1 h1:suPZ4ARWLOJLegGFiZZ1dFAkqzhMjL3J1TzI+5wHz8s=
+github.com/oklog/ulid/v2 v2.1.1/go.mod h1:rcEKHmBBKfef9DhnvX7y1HZBYxjXb0cP5ExxNsTT1QQ=
+github.com/pborman/getopt v0.0.0-20170112200414-7148bc3a4c30/go.mod h1:85jBQOZwpVEaDAr341tbn15RS4fCAsIst0qp7i8ex1o=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/internal/app/message_service_impl.go
+++ b/internal/app/message_service_impl.go
@@ -111,6 +111,22 @@ func (s *DefaultMessageService) HandleMessage(ctx context.Context, request Messa
 		}
 	}
 
+	if s.mode == config.ModeTask {
+		activeTask, activeTaskOK, err := s.store.GetActiveTask(ctx, request.UserID)
+		if err != nil {
+			return MessageResponse{}, fmt.Errorf("load active task for binding: %w", err)
+		}
+
+		if !activeTaskOK {
+			return MessageResponse{
+				Text:      noActiveTaskMessage,
+				ReplyToID: request.MessageID,
+			}, nil
+		}
+
+		binding.TaskID = activeTask.TaskID
+	}
+
 	result, err := s.gateway.RunTurn(ctx, threadID, strings.TrimSpace(request.Content))
 	if err != nil {
 		return MessageResponse{}, fmt.Errorf("run codex turn: %w", err)

--- a/internal/app/message_service_test.go
+++ b/internal/app/message_service_test.go
@@ -2,6 +2,8 @@ package app_test
 
 import (
 	"context"
+	"database/sql"
+	"sort"
 	"testing"
 	"time"
 
@@ -218,6 +220,158 @@ func TestMessageServiceHandleMessageReturnsTaskGuidance(t *testing.T) {
 	}
 }
 
+func TestMessageServiceHandleMessageTaskReusesTaskBindingAcrossDays(t *testing.T) {
+	t.Parallel()
+
+	store := &memoryThreadStore{
+		tasks: map[string]app.Task{
+			"user-1:task-1": {
+				TaskID:        "task-1",
+				DiscordUserID: "user-1",
+				TaskName:      "Release work",
+				Status:        app.TaskStatusOpen,
+				CreatedAt:     time.Date(2026, time.April, 5, 0, 0, 0, 0, time.UTC),
+			},
+		},
+		activeTasks: map[string]app.ActiveTask{
+			"user-1": {
+				DiscordUserID: "user-1",
+				TaskID:        "task-1",
+			},
+		},
+	}
+	gateway := &fakeCodexGateway{
+		results: []app.RunTurnResult{
+			{ThreadID: "thread-task-1", ResponseText: "First response"},
+			{ThreadID: "thread-task-1", ResponseText: "Second response"},
+		},
+	}
+	service := newTaskMessageService(t, store, gateway, &stubExecutionGuard{})
+
+	for _, request := range []app.MessageRequest{
+		{
+			UserID:     "user-1",
+			MessageID:  "message-1",
+			Content:    "start release",
+			Mentioned:  true,
+			ReceivedAt: time.Date(2026, time.April, 5, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			UserID:     "user-1",
+			MessageID:  "message-2",
+			Content:    "continue release",
+			Mentioned:  true,
+			ReceivedAt: time.Date(2026, time.April, 7, 0, 0, 0, 0, time.UTC),
+		},
+	} {
+		if _, err := service.HandleMessage(context.Background(), request); err != nil {
+			t.Fatalf("HandleMessage(%s) error = %v", request.MessageID, err)
+		}
+	}
+
+	if len(gateway.calls) != 2 {
+		t.Fatalf("RunTurn() call count = %d, want %d", len(gateway.calls), 2)
+	}
+
+	if gateway.calls[0].threadID != "" {
+		t.Fatalf("first thread id = %q, want empty", gateway.calls[0].threadID)
+	}
+
+	if gateway.calls[1].threadID != "thread-task-1" {
+		t.Fatalf("second thread id = %q, want %q", gateway.calls[1].threadID, "thread-task-1")
+	}
+
+	binding, ok, err := store.GetThreadBinding(context.Background(), "task", "user-1:task-1")
+	if err != nil {
+		t.Fatalf("GetThreadBinding() error = %v", err)
+	}
+
+	if !ok {
+		t.Fatal("GetThreadBinding() ok = false, want true")
+	}
+
+	if binding.TaskID != "task-1" {
+		t.Fatalf("TaskID = %q, want %q", binding.TaskID, "task-1")
+	}
+}
+
+func TestMessageServiceHandleMessageTaskSwitchesThreadsByActiveTask(t *testing.T) {
+	t.Parallel()
+
+	store := &memoryThreadStore{
+		tasks: map[string]app.Task{
+			"user-1:task-1": {
+				TaskID:        "task-1",
+				DiscordUserID: "user-1",
+				TaskName:      "Release work",
+				Status:        app.TaskStatusOpen,
+				CreatedAt:     time.Date(2026, time.April, 5, 0, 0, 0, 0, time.UTC),
+			},
+			"user-1:task-2": {
+				TaskID:        "task-2",
+				DiscordUserID: "user-1",
+				TaskName:      "Docs update",
+				Status:        app.TaskStatusOpen,
+				CreatedAt:     time.Date(2026, time.April, 5, 1, 0, 0, 0, time.UTC),
+			},
+		},
+		activeTasks: map[string]app.ActiveTask{
+			"user-1": {
+				DiscordUserID: "user-1",
+				TaskID:        "task-1",
+			},
+		},
+	}
+	gateway := &fakeCodexGateway{
+		results: []app.RunTurnResult{
+			{ThreadID: "thread-task-1", ResponseText: "Release response"},
+			{ThreadID: "thread-task-2", ResponseText: "Docs response"},
+		},
+	}
+	service := newTaskMessageService(t, store, gateway, &stubExecutionGuard{})
+
+	if _, err := service.HandleMessage(context.Background(), app.MessageRequest{
+		UserID:     "user-1",
+		MessageID:  "message-1",
+		Content:    "release task",
+		Mentioned:  true,
+		ReceivedAt: time.Date(2026, time.April, 5, 0, 0, 0, 0, time.UTC),
+	}); err != nil {
+		t.Fatalf("HandleMessage() first error = %v", err)
+	}
+
+	if err := store.SetActiveTask(context.Background(), app.ActiveTask{
+		DiscordUserID: "user-1",
+		TaskID:        "task-2",
+	}); err != nil {
+		t.Fatalf("SetActiveTask() error = %v", err)
+	}
+
+	if _, err := service.HandleMessage(context.Background(), app.MessageRequest{
+		UserID:     "user-1",
+		MessageID:  "message-2",
+		Content:    "docs task",
+		Mentioned:  true,
+		ReceivedAt: time.Date(2026, time.April, 8, 0, 0, 0, 0, time.UTC),
+	}); err != nil {
+		t.Fatalf("HandleMessage() second error = %v", err)
+	}
+
+	if len(gateway.calls) != 2 {
+		t.Fatalf("RunTurn() call count = %d, want %d", len(gateway.calls), 2)
+	}
+
+	if gateway.calls[1].threadID != "" {
+		t.Fatalf("second thread id = %q, want empty", gateway.calls[1].threadID)
+	}
+
+	for _, key := range []string{"user-1:task-1", "user-1:task-2"} {
+		if _, ok, err := store.GetThreadBinding(context.Background(), "task", key); err != nil || !ok {
+			t.Fatalf("GetThreadBinding(%s) = ok:%v err:%v, want ok:true err:nil", key, ok, err)
+		}
+	}
+}
+
 func newDailyMessageService(
 	t *testing.T,
 	store app.ThreadStore,
@@ -238,6 +392,38 @@ func newDailyMessageService(
 
 	service, err := app.NewMessageService(app.MessageServiceDependencies{
 		Mode:    config.ModeDaily,
+		Policy:  policy,
+		Store:   store,
+		Gateway: gateway,
+		Guard:   guard,
+	})
+	if err != nil {
+		t.Fatalf("NewMessageService() error = %v", err)
+	}
+
+	return service
+}
+
+func newTaskMessageService(
+	t *testing.T,
+	store app.ThreadStore,
+	gateway app.CodexGateway,
+	guard app.ExecutionGuard,
+) *app.DefaultMessageService {
+	t.Helper()
+
+	tokyo, err := time.LoadLocation("Asia/Tokyo")
+	if err != nil {
+		t.Fatalf("time.LoadLocation() error = %v", err)
+	}
+
+	policy, err := thread.NewPolicy(config.ModeTask, tokyo, store)
+	if err != nil {
+		t.Fatalf("thread.NewPolicy() error = %v", err)
+	}
+
+	service, err := app.NewMessageService(app.MessageServiceDependencies{
+		Mode:    config.ModeTask,
 		Policy:  policy,
 		Store:   store,
 		Gateway: gateway,
@@ -302,7 +488,9 @@ func (g *fakeCodexGateway) RunTurn(_ context.Context, threadID string, prompt st
 }
 
 type memoryThreadStore struct {
-	bindings map[string]app.ThreadBinding
+	bindings    map[string]app.ThreadBinding
+	tasks       map[string]app.Task
+	activeTasks map[string]app.ActiveTask
 }
 
 func (s *memoryThreadStore) GetThreadBinding(_ context.Context, mode string, logicalThreadKey string) (app.ThreadBinding, bool, error) {
@@ -323,30 +511,101 @@ func (s *memoryThreadStore) UpsertThreadBinding(_ context.Context, binding app.T
 	return nil
 }
 
-func (s *memoryThreadStore) CreateTask(context.Context, app.Task) error {
+func (s *memoryThreadStore) CreateTask(_ context.Context, task app.Task) error {
+	if s.tasks == nil {
+		s.tasks = make(map[string]app.Task)
+	}
+
+	if task.Status == "" {
+		task.Status = app.TaskStatusOpen
+	}
+
+	if task.CreatedAt.IsZero() {
+		task.CreatedAt = time.Date(2026, time.April, 5, 0, 0, 0, 0, time.UTC)
+	}
+
+	task.UpdatedAt = task.CreatedAt
+	s.tasks[task.DiscordUserID+":"+task.TaskID] = task
 	return nil
 }
 
-func (s *memoryThreadStore) GetTask(context.Context, string, string) (app.Task, bool, error) {
-	return app.Task{}, false, nil
+func (s *memoryThreadStore) GetTask(_ context.Context, userID string, taskID string) (app.Task, bool, error) {
+	if s.tasks == nil {
+		return app.Task{}, false, nil
+	}
+
+	task, ok := s.tasks[userID+":"+taskID]
+	return task, ok, nil
 }
 
-func (s *memoryThreadStore) ListOpenTasks(context.Context, string) ([]app.Task, error) {
-	return nil, nil
+func (s *memoryThreadStore) ListOpenTasks(_ context.Context, userID string) ([]app.Task, error) {
+	if s.tasks == nil {
+		return nil, nil
+	}
+
+	tasks := make([]app.Task, 0)
+	for _, task := range s.tasks {
+		if task.DiscordUserID == userID && task.Status == app.TaskStatusOpen {
+			tasks = append(tasks, task)
+		}
+	}
+
+	sort.Slice(tasks, func(i, j int) bool {
+		if tasks[i].CreatedAt.Equal(tasks[j].CreatedAt) {
+			return tasks[i].TaskID < tasks[j].TaskID
+		}
+		return tasks[i].CreatedAt.Before(tasks[j].CreatedAt)
+	})
+
+	return tasks, nil
 }
 
-func (s *memoryThreadStore) SetActiveTask(context.Context, app.ActiveTask) error {
+func (s *memoryThreadStore) SetActiveTask(_ context.Context, activeTask app.ActiveTask) error {
+	if s.activeTasks == nil {
+		s.activeTasks = make(map[string]app.ActiveTask)
+	}
+
+	s.activeTasks[activeTask.DiscordUserID] = activeTask
 	return nil
 }
 
-func (s *memoryThreadStore) GetActiveTask(context.Context, string) (app.ActiveTask, bool, error) {
-	return app.ActiveTask{}, false, nil
+func (s *memoryThreadStore) GetActiveTask(_ context.Context, userID string) (app.ActiveTask, bool, error) {
+	if s.activeTasks == nil {
+		return app.ActiveTask{}, false, nil
+	}
+
+	activeTask, ok := s.activeTasks[userID]
+	return activeTask, ok, nil
 }
 
-func (s *memoryThreadStore) ClearActiveTask(context.Context, string) error {
+func (s *memoryThreadStore) ClearActiveTask(_ context.Context, userID string) error {
+	if s.activeTasks != nil {
+		delete(s.activeTasks, userID)
+	}
 	return nil
 }
 
-func (s *memoryThreadStore) CloseTask(context.Context, string, string) error {
+func (s *memoryThreadStore) CloseTask(_ context.Context, userID string, taskID string) error {
+	if s.tasks == nil {
+		return sql.ErrNoRows
+	}
+
+	key := userID + ":" + taskID
+	task, ok := s.tasks[key]
+	if !ok {
+		return sql.ErrNoRows
+	}
+
+	closedAt := time.Date(2026, time.April, 5, 12, 0, 0, 0, time.UTC)
+	task.Status = app.TaskStatusClosed
+	task.ClosedAt = &closedAt
+	s.tasks[key] = task
+
+	if s.activeTasks != nil {
+		if activeTask, ok := s.activeTasks[userID]; ok && activeTask.TaskID == taskID {
+			delete(s.activeTasks, userID)
+		}
+	}
+
 	return nil
 }

--- a/internal/app/task_service.go
+++ b/internal/app/task_service.go
@@ -1,6 +1,20 @@
 package app
 
-import "context"
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/oklog/ulid/v2"
+)
+
+const (
+	noOpenTasksMessage      = "No open tasks yet. Use `/task new <name>` to create one."
+	taskIDRequiredMessage   = "A task ID is required. Use `/task list` to find an open task."
+	taskNameRequiredMessage = "A task name is required. Use `/task new <name>` to create one."
+)
 
 type TaskCommandService interface {
 	ShowCurrentTask(ctx context.Context, userID string) (MessageResponse, error)
@@ -8,4 +22,254 @@ type TaskCommandService interface {
 	CreateTask(ctx context.Context, userID string, taskName string) (MessageResponse, error)
 	SwitchTask(ctx context.Context, userID string, taskID string) (MessageResponse, error)
 	CloseTask(ctx context.Context, userID string, taskID string) (MessageResponse, error)
+}
+
+type TaskCommandServiceDependencies struct {
+	Store     ThreadStore
+	NewTaskID func() string
+}
+
+type DefaultTaskCommandService struct {
+	store     ThreadStore
+	newTaskID func() string
+}
+
+func NewTaskCommandService(deps TaskCommandServiceDependencies) (*DefaultTaskCommandService, error) {
+	if deps.Store == nil {
+		return nil, errors.New("thread store must not be nil")
+	}
+
+	newTaskID := deps.NewTaskID
+	if newTaskID == nil {
+		newTaskID = func() string {
+			return ulid.Make().String()
+		}
+	}
+
+	return &DefaultTaskCommandService{
+		store:     deps.Store,
+		newTaskID: newTaskID,
+	}, nil
+}
+
+func (s *DefaultTaskCommandService) ShowCurrentTask(ctx context.Context, userID string) (MessageResponse, error) {
+	activeTask, ok, err := s.store.GetActiveTask(ctx, userID)
+	if err != nil {
+		return MessageResponse{}, fmt.Errorf("load active task: %w", err)
+	}
+
+	if !ok {
+		return taskCommandResponse(noActiveTaskMessage), nil
+	}
+
+	task, ok, err := s.store.GetTask(ctx, userID, activeTask.TaskID)
+	if err != nil {
+		return MessageResponse{}, fmt.Errorf("load active task details: %w", err)
+	}
+
+	if !ok {
+		return taskCommandResponse(
+			fmt.Sprintf(
+				"Active task `%s` could not be loaded. Use `/task list` or `/task switch <id>` to recover.",
+				activeTask.TaskID,
+			),
+		), nil
+	}
+
+	return taskCommandResponse(
+		fmt.Sprintf(
+			"Active task: %s. Use `/task list` to see open tasks or `/task close %s` when you're done.",
+			renderTask(task),
+			task.TaskID,
+		),
+	), nil
+}
+
+func (s *DefaultTaskCommandService) ListTasks(ctx context.Context, userID string) (MessageResponse, error) {
+	tasks, err := s.store.ListOpenTasks(ctx, userID)
+	if err != nil {
+		return MessageResponse{}, fmt.Errorf("list open tasks: %w", err)
+	}
+
+	if len(tasks) == 0 {
+		return taskCommandResponse(noOpenTasksMessage), nil
+	}
+
+	activeTask, ok, err := s.store.GetActiveTask(ctx, userID)
+	if err != nil {
+		return MessageResponse{}, fmt.Errorf("load active task: %w", err)
+	}
+
+	lines := make([]string, 0, len(tasks))
+	lines = append(lines, "Open tasks:")
+	for _, task := range tasks {
+		line := "- " + renderTask(task)
+		if ok && activeTask.TaskID == task.TaskID {
+			line += " [active]"
+		}
+		lines = append(lines, line)
+	}
+	lines = append(lines, "Use `/task switch <id>` to change the active task.")
+
+	return taskCommandResponse(strings.Join(lines, "\n")), nil
+}
+
+func (s *DefaultTaskCommandService) CreateTask(ctx context.Context, userID string, taskName string) (MessageResponse, error) {
+	taskName = strings.TrimSpace(taskName)
+	if taskName == "" {
+		return taskCommandResponse(taskNameRequiredMessage), nil
+	}
+
+	task := Task{
+		TaskID:        s.newTaskID(),
+		DiscordUserID: userID,
+		TaskName:      taskName,
+		Status:        TaskStatusOpen,
+	}
+
+	if err := s.store.CreateTask(ctx, task); err != nil {
+		return MessageResponse{}, fmt.Errorf("create task: %w", err)
+	}
+
+	if err := s.store.SetActiveTask(ctx, ActiveTask{
+		DiscordUserID: userID,
+		TaskID:        task.TaskID,
+	}); err != nil {
+		return MessageResponse{}, fmt.Errorf("set active task: %w", err)
+	}
+
+	return taskCommandResponse(
+		fmt.Sprintf(
+			"Created task %s and made it active. Your next message will continue this task.",
+			renderTask(task),
+		),
+	), nil
+}
+
+func (s *DefaultTaskCommandService) SwitchTask(ctx context.Context, userID string, taskID string) (MessageResponse, error) {
+	taskID = strings.TrimSpace(taskID)
+	if taskID == "" {
+		return taskCommandResponse(taskIDRequiredMessage), nil
+	}
+
+	task, ok, err := s.store.GetTask(ctx, userID, taskID)
+	if err != nil {
+		return MessageResponse{}, fmt.Errorf("load task: %w", err)
+	}
+
+	if !ok {
+		return taskCommandResponse(
+			fmt.Sprintf("Task `%s` was not found. Use `/task list` to find an open task.", taskID),
+		), nil
+	}
+
+	if task.Status != TaskStatusOpen {
+		return taskCommandResponse(
+			fmt.Sprintf(
+				"Task `%s` is closed. Use `/task list` to find an open task or `/task new <name>` to create another one.",
+				taskID,
+			),
+		), nil
+	}
+
+	if err := s.store.SetActiveTask(ctx, ActiveTask{
+		DiscordUserID: userID,
+		TaskID:        task.TaskID,
+	}); err != nil {
+		return MessageResponse{}, fmt.Errorf("set active task: %w", err)
+	}
+
+	return taskCommandResponse(
+		fmt.Sprintf("Active task is now %s. Your next message will continue this task.", renderTask(task)),
+	), nil
+}
+
+func (s *DefaultTaskCommandService) CloseTask(ctx context.Context, userID string, taskID string) (MessageResponse, error) {
+	taskID = strings.TrimSpace(taskID)
+	if taskID == "" {
+		return taskCommandResponse(taskIDRequiredMessage), nil
+	}
+
+	task, ok, err := s.store.GetTask(ctx, userID, taskID)
+	if err != nil {
+		return MessageResponse{}, fmt.Errorf("load task: %w", err)
+	}
+
+	if !ok {
+		return taskCommandResponse(
+			fmt.Sprintf("Task `%s` was not found. Use `/task list` to find an open task.", taskID),
+		), nil
+	}
+
+	if task.Status == TaskStatusClosed {
+		return taskCommandResponse(
+			fmt.Sprintf(
+				"Task `%s` is already closed. Use `/task list` to find an open task or `/task new <name>` to create another one.",
+				taskID,
+			),
+		), nil
+	}
+
+	activeTask, hasActiveTask, err := s.store.GetActiveTask(ctx, userID)
+	if err != nil {
+		return MessageResponse{}, fmt.Errorf("load active task before close: %w", err)
+	}
+
+	if err := s.store.CloseTask(ctx, userID, task.TaskID); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return taskCommandResponse(
+				fmt.Sprintf("Task `%s` was not found. Use `/task list` to find an open task.", taskID),
+			), nil
+		}
+
+		return MessageResponse{}, fmt.Errorf("close task: %w", err)
+	}
+
+	if hasActiveTask && activeTask.TaskID == task.TaskID {
+		return taskCommandResponse(
+			fmt.Sprintf("Closed task %s. No active task is selected now.", renderTask(task)),
+		), nil
+	}
+
+	nextActiveTaskLine, err := s.renderActiveTaskSuffix(ctx, userID)
+	if err != nil {
+		return MessageResponse{}, err
+	}
+
+	return taskCommandResponse(
+		fmt.Sprintf("Closed task %s.%s", renderTask(task), nextActiveTaskLine),
+	), nil
+}
+
+func (s *DefaultTaskCommandService) renderActiveTaskSuffix(ctx context.Context, userID string) (string, error) {
+	activeTask, ok, err := s.store.GetActiveTask(ctx, userID)
+	if err != nil {
+		return "", fmt.Errorf("load active task after close: %w", err)
+	}
+
+	if !ok {
+		return " No active task is selected now.", nil
+	}
+
+	task, ok, err := s.store.GetTask(ctx, userID, activeTask.TaskID)
+	if err != nil {
+		return "", fmt.Errorf("load remaining active task details: %w", err)
+	}
+
+	if !ok {
+		return " No active task is selected now.", nil
+	}
+
+	return " Active task remains " + renderTask(task) + ".", nil
+}
+
+func renderTask(task Task) string {
+	return fmt.Sprintf("`%s` (`%s`)", task.TaskName, task.TaskID)
+}
+
+func taskCommandResponse(text string) MessageResponse {
+	return MessageResponse{
+		Text:      text,
+		Ephemeral: true,
+	}
 }

--- a/internal/app/task_service_test.go
+++ b/internal/app/task_service_test.go
@@ -1,0 +1,278 @@
+package app_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/HatsuneMiku3939/39claw/internal/app"
+)
+
+func TestTaskCommandServiceShowCurrentTask(t *testing.T) {
+	t.Parallel()
+
+	service := newTaskCommandService(t, &memoryThreadStore{
+		tasks: map[string]app.Task{
+			"user-1:task-1": {
+				TaskID:        "task-1",
+				DiscordUserID: "user-1",
+				TaskName:      "Release work",
+				Status:        app.TaskStatusOpen,
+				CreatedAt:     time.Date(2026, time.April, 5, 0, 0, 0, 0, time.UTC),
+			},
+		},
+		activeTasks: map[string]app.ActiveTask{
+			"user-1": {
+				DiscordUserID: "user-1",
+				TaskID:        "task-1",
+			},
+		},
+	})
+
+	response, err := service.ShowCurrentTask(context.Background(), "user-1")
+	if err != nil {
+		t.Fatalf("ShowCurrentTask() error = %v", err)
+	}
+
+	if !response.Ephemeral {
+		t.Fatal("Ephemeral = false, want true")
+	}
+
+	want := "Active task: `Release work` (`task-1`). Use `/task list` to see open tasks or `/task close task-1` when you're done."
+	if response.Text != want {
+		t.Fatalf("Text = %q, want %q", response.Text, want)
+	}
+}
+
+func TestTaskCommandServiceShowCurrentTaskWithoutActiveTaskReturnsGuidance(t *testing.T) {
+	t.Parallel()
+
+	service := newTaskCommandService(t, &memoryThreadStore{})
+
+	response, err := service.ShowCurrentTask(context.Background(), "user-1")
+	if err != nil {
+		t.Fatalf("ShowCurrentTask() error = %v", err)
+	}
+
+	want := "No active task is selected. Use `/task new <name>`, `/task list`, or `/task switch <id>` first."
+	if response.Text != want {
+		t.Fatalf("Text = %q, want %q", response.Text, want)
+	}
+}
+
+func TestTaskCommandServiceCreateTaskMakesTaskActive(t *testing.T) {
+	t.Parallel()
+
+	store := &memoryThreadStore{}
+	service := newTaskCommandServiceWithID(t, store, func() string {
+		return "01JABCDEF0123456789TASK000"
+	})
+
+	response, err := service.CreateTask(context.Background(), "user-1", "  Release work  ")
+	if err != nil {
+		t.Fatalf("CreateTask() error = %v", err)
+	}
+
+	want := "Created task `Release work` (`01JABCDEF0123456789TASK000`) and made it active. Your next message will continue this task."
+	if response.Text != want {
+		t.Fatalf("Text = %q, want %q", response.Text, want)
+	}
+
+	task, ok, err := store.GetTask(context.Background(), "user-1", "01JABCDEF0123456789TASK000")
+	if err != nil {
+		t.Fatalf("GetTask() error = %v", err)
+	}
+
+	if !ok {
+		t.Fatal("GetTask() ok = false, want true")
+	}
+
+	if task.TaskName != "Release work" {
+		t.Fatalf("TaskName = %q, want %q", task.TaskName, "Release work")
+	}
+
+	activeTask, ok, err := store.GetActiveTask(context.Background(), "user-1")
+	if err != nil {
+		t.Fatalf("GetActiveTask() error = %v", err)
+	}
+
+	if !ok {
+		t.Fatal("GetActiveTask() ok = false, want true")
+	}
+
+	if activeTask.TaskID != "01JABCDEF0123456789TASK000" {
+		t.Fatalf("TaskID = %q, want %q", activeTask.TaskID, "01JABCDEF0123456789TASK000")
+	}
+}
+
+func TestTaskCommandServiceListTasksMarksActiveTask(t *testing.T) {
+	t.Parallel()
+
+	service := newTaskCommandService(t, &memoryThreadStore{
+		tasks: map[string]app.Task{
+			"user-1:task-1": {
+				TaskID:        "task-1",
+				DiscordUserID: "user-1",
+				TaskName:      "Release work",
+				Status:        app.TaskStatusOpen,
+				CreatedAt:     time.Date(2026, time.April, 5, 0, 0, 0, 0, time.UTC),
+			},
+			"user-1:task-2": {
+				TaskID:        "task-2",
+				DiscordUserID: "user-1",
+				TaskName:      "Docs update",
+				Status:        app.TaskStatusOpen,
+				CreatedAt:     time.Date(2026, time.April, 5, 1, 0, 0, 0, time.UTC),
+			},
+			"user-1:task-3": {
+				TaskID:        "task-3",
+				DiscordUserID: "user-1",
+				TaskName:      "Closed work",
+				Status:        app.TaskStatusClosed,
+				CreatedAt:     time.Date(2026, time.April, 5, 2, 0, 0, 0, time.UTC),
+			},
+		},
+		activeTasks: map[string]app.ActiveTask{
+			"user-1": {
+				DiscordUserID: "user-1",
+				TaskID:        "task-2",
+			},
+		},
+	})
+
+	response, err := service.ListTasks(context.Background(), "user-1")
+	if err != nil {
+		t.Fatalf("ListTasks() error = %v", err)
+	}
+
+	want := "Open tasks:\n- `Release work` (`task-1`)\n- `Docs update` (`task-2`) [active]\nUse `/task switch <id>` to change the active task."
+	if response.Text != want {
+		t.Fatalf("Text = %q, want %q", response.Text, want)
+	}
+}
+
+func TestTaskCommandServiceSwitchTaskRequiresOpenTask(t *testing.T) {
+	t.Parallel()
+
+	service := newTaskCommandService(t, &memoryThreadStore{
+		tasks: map[string]app.Task{
+			"user-1:task-1": {
+				TaskID:        "task-1",
+				DiscordUserID: "user-1",
+				TaskName:      "Closed work",
+				Status:        app.TaskStatusClosed,
+				CreatedAt:     time.Date(2026, time.April, 5, 0, 0, 0, 0, time.UTC),
+			},
+		},
+	})
+
+	response, err := service.SwitchTask(context.Background(), "user-1", "task-1")
+	if err != nil {
+		t.Fatalf("SwitchTask() error = %v", err)
+	}
+
+	want := "Task `task-1` is closed. Use `/task list` to find an open task or `/task new <name>` to create another one."
+	if response.Text != want {
+		t.Fatalf("Text = %q, want %q", response.Text, want)
+	}
+}
+
+func TestTaskCommandServiceCloseTaskClearsActiveTaskWhenClosingCurrentTask(t *testing.T) {
+	t.Parallel()
+
+	store := &memoryThreadStore{
+		tasks: map[string]app.Task{
+			"user-1:task-1": {
+				TaskID:        "task-1",
+				DiscordUserID: "user-1",
+				TaskName:      "Release work",
+				Status:        app.TaskStatusOpen,
+				CreatedAt:     time.Date(2026, time.April, 5, 0, 0, 0, 0, time.UTC),
+			},
+		},
+		activeTasks: map[string]app.ActiveTask{
+			"user-1": {
+				DiscordUserID: "user-1",
+				TaskID:        "task-1",
+			},
+		},
+	}
+	service := newTaskCommandService(t, store)
+
+	response, err := service.CloseTask(context.Background(), "user-1", "task-1")
+	if err != nil {
+		t.Fatalf("CloseTask() error = %v", err)
+	}
+
+	want := "Closed task `Release work` (`task-1`). No active task is selected now."
+	if response.Text != want {
+		t.Fatalf("Text = %q, want %q", response.Text, want)
+	}
+
+	if _, ok, err := store.GetActiveTask(context.Background(), "user-1"); err != nil || ok {
+		t.Fatalf("GetActiveTask() = ok:%v err:%v, want ok:false err:nil", ok, err)
+	}
+}
+
+func TestTaskCommandServiceCloseTaskKeepsDifferentActiveTask(t *testing.T) {
+	t.Parallel()
+
+	store := &memoryThreadStore{
+		tasks: map[string]app.Task{
+			"user-1:task-1": {
+				TaskID:        "task-1",
+				DiscordUserID: "user-1",
+				TaskName:      "Release work",
+				Status:        app.TaskStatusOpen,
+				CreatedAt:     time.Date(2026, time.April, 5, 0, 0, 0, 0, time.UTC),
+			},
+			"user-1:task-2": {
+				TaskID:        "task-2",
+				DiscordUserID: "user-1",
+				TaskName:      "Docs update",
+				Status:        app.TaskStatusOpen,
+				CreatedAt:     time.Date(2026, time.April, 5, 1, 0, 0, 0, time.UTC),
+			},
+		},
+		activeTasks: map[string]app.ActiveTask{
+			"user-1": {
+				DiscordUserID: "user-1",
+				TaskID:        "task-2",
+			},
+		},
+	}
+	service := newTaskCommandService(t, store)
+
+	response, err := service.CloseTask(context.Background(), "user-1", "task-1")
+	if err != nil {
+		t.Fatalf("CloseTask() error = %v", err)
+	}
+
+	want := "Closed task `Release work` (`task-1`). Active task remains `Docs update` (`task-2`)."
+	if response.Text != want {
+		t.Fatalf("Text = %q, want %q", response.Text, want)
+	}
+}
+
+func newTaskCommandService(t *testing.T, store app.ThreadStore) *app.DefaultTaskCommandService {
+	t.Helper()
+	return newTaskCommandServiceWithID(t, store, nil)
+}
+
+func newTaskCommandServiceWithID(
+	t *testing.T,
+	store app.ThreadStore,
+	newTaskID func() string,
+) *app.DefaultTaskCommandService {
+	t.Helper()
+
+	service, err := app.NewTaskCommandService(app.TaskCommandServiceDependencies{
+		Store:     store,
+		NewTaskID: newTaskID,
+	})
+	if err != nil {
+		t.Fatalf("NewTaskCommandService() error = %v", err)
+	}
+
+	return service
+}

--- a/internal/store/sqlite/store_test.go
+++ b/internal/store/sqlite/store_test.go
@@ -133,6 +133,85 @@ func TestStoreThreadBindingPersistsAcrossReopen(t *testing.T) {
 	}
 }
 
+func TestStoreTaskStatePersistsAcrossReopen(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "39claw.db")
+
+	store, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+
+	store.clock = func() time.Time {
+		return time.Date(2026, time.April, 5, 15, 4, 0, 0, time.UTC)
+	}
+
+	ctx := context.Background()
+	if err := store.InitSchema(ctx); err != nil {
+		t.Fatalf("InitSchema() error = %v", err)
+	}
+
+	if err := store.CreateTask(ctx, app.Task{
+		TaskID:        "task-1",
+		DiscordUserID: "user-1",
+		TaskName:      "Release work",
+	}); err != nil {
+		t.Fatalf("CreateTask() error = %v", err)
+	}
+
+	if err := store.SetActiveTask(ctx, app.ActiveTask{
+		DiscordUserID: "user-1",
+		TaskID:        "task-1",
+	}); err != nil {
+		t.Fatalf("SetActiveTask() error = %v", err)
+	}
+
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+
+	reopened, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open() reopen error = %v", err)
+	}
+	defer func() {
+		if closeErr := reopened.Close(); closeErr != nil {
+			t.Fatalf("Close() reopen error = %v", closeErr)
+		}
+	}()
+
+	if err := reopened.InitSchema(ctx); err != nil {
+		t.Fatalf("InitSchema() reopen error = %v", err)
+	}
+
+	task, ok, err := reopened.GetTask(ctx, "user-1", "task-1")
+	if err != nil {
+		t.Fatalf("GetTask() reopen error = %v", err)
+	}
+
+	if !ok {
+		t.Fatal("GetTask() reopen ok = false, want true")
+	}
+
+	if task.TaskName != "Release work" {
+		t.Fatalf("TaskName = %q, want %q", task.TaskName, "Release work")
+	}
+
+	activeTask, ok, err := reopened.GetActiveTask(ctx, "user-1")
+	if err != nil {
+		t.Fatalf("GetActiveTask() reopen error = %v", err)
+	}
+
+	if !ok {
+		t.Fatal("GetActiveTask() reopen ok = false, want true")
+	}
+
+	if activeTask.TaskID != "task-1" {
+		t.Fatalf("TaskID = %q, want %q", activeTask.TaskID, "task-1")
+	}
+}
+
 func TestStoreTaskLifecycle(t *testing.T) {
 	t.Parallel()
 
@@ -228,6 +307,54 @@ func TestStoreCloseTaskRejectsUnknownTask(t *testing.T) {
 	err := store.CloseTask(context.Background(), "user-1", "missing")
 	if !errors.Is(err, sql.ErrNoRows) {
 		t.Fatalf("CloseTask() error = %v, want %v", err, sql.ErrNoRows)
+	}
+}
+
+func TestStoreCloseTaskKeepsDifferentActiveTask(t *testing.T) {
+	t.Parallel()
+
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	for _, task := range []app.Task{
+		{
+			TaskID:        "task-1",
+			DiscordUserID: "user-1",
+			TaskName:      "Release work",
+		},
+		{
+			TaskID:        "task-2",
+			DiscordUserID: "user-1",
+			TaskName:      "Docs update",
+		},
+	} {
+		if err := store.CreateTask(ctx, task); err != nil {
+			t.Fatalf("CreateTask(%s) error = %v", task.TaskID, err)
+		}
+	}
+
+	if err := store.SetActiveTask(ctx, app.ActiveTask{
+		DiscordUserID: "user-1",
+		TaskID:        "task-2",
+	}); err != nil {
+		t.Fatalf("SetActiveTask() error = %v", err)
+	}
+
+	if err := store.CloseTask(ctx, "user-1", "task-1"); err != nil {
+		t.Fatalf("CloseTask() error = %v", err)
+	}
+
+	activeTask, ok, err := store.GetActiveTask(ctx, "user-1")
+	if err != nil {
+		t.Fatalf("GetActiveTask() error = %v", err)
+	}
+
+	if !ok {
+		t.Fatal("GetActiveTask() ok = false, want true")
+	}
+
+	if activeTask.TaskID != "task-2" {
+		t.Fatalf("TaskID = %q, want %q", activeTask.TaskID, "task-2")
 	}
 }
 


### PR DESCRIPTION
## Summary

- implement task-mode command orchestration in the application layer
- persist task-aware thread bindings and strengthen task-mode routing coverage
- update README and move the completed ExecPlan into the completed set

## Background

`task` mode needed an explicit workflow for creating, selecting, listing, and closing durable work streams before the Discord runtime command layer could be finished. The repository already had the core SQLite task tables, but it still needed application orchestration and proof that task context survives day changes and restarts.

## Related issue(s)

- None.

## Implementation details

- add `DefaultTaskCommandService` with normalized ephemeral responses for `/task`, `/task list`, `/task new <name>`, `/task switch <id>`, and `/task close <id>`
- generate task IDs with ULIDs via `github.com/oklog/ulid/v2`
- persist the active `task_id` onto task-mode thread bindings in the normal message service
- extend app and SQLite tests for task lifecycle, task routing across days, task switches, and reopen behavior
- move ExecPlan 03 into the completed directory and refresh documentation status

## Test coverage

- `make test`
- `make lint`
- `go test ./internal/app ./internal/store/sqlite -run 'Test(TaskCommandService|MessageServiceHandleMessageTask|StoreTask|StoreCloseTask)' -v`

## Breaking changes

- None.

## Notes

- the Discord slash-command runtime wiring is still deferred to the next ExecPlan, but it can now call into the completed app-layer task workflow directly.

Created by Codex
