### PR TITLE
docs: archive completed Discord runtime exec plan

### DIFF
--- a/docs/exec-plans/completed/04-discord-runtime-and-presentation.md
+++ b/docs/exec-plans/completed/04-discord-runtime-and-presentation.md
@@ -17,7 +17,7 @@ After this plan, `39claw` should expose the implemented application behavior thr
 - [x] (2026-04-05 03:42Z) Added `/help` and `/task ...` slash-command registration and routing, using `/task current` for the current-task action.
 - [x] (2026-04-05 03:42Z) Added ephemeral task-command responses and Discord-safe response chunking that preserves fenced code blocks when practical.
 - [x] (2026-04-05 03:42Z) Added runtime-level tests and a README smoke-test checklist.
-- [ ] Run the manual smoke test against a disposable Discord server and record the result here.
+- [x] (2026-04-05 08:45Z) Archived this ExecPlan after the implementation merged to `master`; the remaining manual smoke test is now tracked in `docs/exec-plans/tech-debt-tracker.md`.
 
 ## Surprises & Discoveries
 
@@ -51,6 +51,8 @@ After this plan, `39claw` should expose the implemented application behavior thr
 The outcome of this plan should be a bot that is observable from Discord, not just from unit tests. Success means the end-user workflow now matches the product docs closely enough for a real smoke test.
 
 The runtime implementation is now in place and covered by focused tests. `cmd/39claw` boots a real Discord adapter, message mentions route through the app layer, slash commands are registered and presented correctly, task-control responses are ephemeral, and long output is chunked for Discord readability. The remaining gap is only the final real-server smoke test, which still requires disposable Discord credentials.
+
+This document is now archived in `completed/` because the implementation work itself has landed on `master`. The deferred live smoke test remains tracked separately so contributors can still find the one remaining validation gap without keeping the whole plan in `active/`.
 
 ## Context and Orientation
 
@@ -198,3 +200,4 @@ Keep `discordgo` imports inside `internal/runtime/discord` and `cmd/39claw` only
 Revision Note: 2026-04-04 / Codex - Created this smaller child ExecPlan during the split of the original all-in-one runtime plan.
 Revision Note: 2026-04-04 / Codex - Removed the parent-plan dependency and added explicit starting-state and recovery guidance so the document can stand alone.
 Revision Note: 2026-04-05 / Codex - Recorded the implemented runtime progress, the `/task current` command-shape decision, and the optional guild-scoped command-registration path for faster smoke tests.
+Revision Note: 2026-04-05 / Codex - Moved this plan to `completed/` after merge and recorded the deferred manual smoke test in `docs/exec-plans/tech-debt-tracker.md`.

--- a/docs/exec-plans/index.md
+++ b/docs/exec-plans/index.md
@@ -27,8 +27,8 @@ These plans are intended to be executed in numeric order. Each plan is self-cont
 
 - [Build the foundation, contracts, and bootstrap path](./active/01-foundation-and-contracts.md)
 - [Implement `daily` mode routing and persistence](./active/02-daily-mode-routing.md)
-- [Implement the Discord runtime, commands, and response presentation](./active/04-discord-runtime-and-presentation.md)
 
 ## Recently Completed Plans
 
 - [Implement `task` mode task workflow and command orchestration](./completed/03-task-mode-workflow.md)
+- [Implement the Discord runtime, commands, and response presentation](./completed/04-discord-runtime-and-presentation.md)

--- a/docs/exec-plans/tech-debt-tracker.md
+++ b/docs/exec-plans/tech-debt-tracker.md
@@ -31,4 +31,21 @@ Describe the smallest safe follow-up that should address the debt.
 
 ## Current Entries
 
-No tracked follow-up items yet.
+### Discord runtime smoke test follow-up
+
+- Status: open
+- Date: 2026-04-05
+- Related plan: `docs/exec-plans/completed/04-discord-runtime-and-presentation.md`
+- Owner: Unassigned
+
+### Context
+
+The Discord runtime implementation has landed and the delivery plan has been archived, but the final manual smoke test against a disposable Discord server was not run before archival because disposable bot credentials were not available in the implementation environment.
+
+### Risk
+
+Automated tests prove message mapping, command routing, chunking, and presentation behavior, but they cannot prove that live Discord registration and reply flow behave exactly as expected in a real server.
+
+### Next step
+
+Run the documented smoke test from `README.md` with a disposable Discord bot token and guild ID, then either mark this entry resolved or record any runtime-specific fixes in a follow-up ExecPlan.


### PR DESCRIPTION
## Summary

- move the completed Discord runtime ExecPlan from `docs/exec-plans/active` to `docs/exec-plans/completed`
- update the ExecPlan index to reflect the new archive location
- record the deferred live Discord smoke test in the tech-debt tracker

## Background

The Discord runtime work has already landed on `master`, so the corresponding ExecPlan should no longer remain in the active queue. This PR archives the plan while preserving the one remaining manual validation gap as explicit follow-up debt.

## Related issue(s)

- None.

## Implementation details

- rename `docs/exec-plans/active/04-discord-runtime-and-presentation.md` to `docs/exec-plans/completed/04-discord-runtime-and-presentation.md`
- update the archived plan so its progress and retrospective note that the implementation landed and the remaining live smoke test is tracked separately
- refresh `docs/exec-plans/index.md` so plan 04 appears under completed plans instead of active plans
- add a follow-up entry to `docs/exec-plans/tech-debt-tracker.md` for the deferred disposable-server smoke test

## Test coverage

- run `make test`
- run `make lint`

## Breaking changes

- None.

## Notes

- this PR intentionally preserves the deferred live Discord smoke test as tracked follow-up work instead of silently dropping it during archival

Created by Codex
