### PR TITLE
docs: clarify Discord smoke test tech debt policy

### DIFF
--- a/docs/exec-plans/tech-debt-tracker.md
+++ b/docs/exec-plans/tech-debt-tracker.md
@@ -42,10 +42,20 @@ Describe the smallest safe follow-up that should address the debt.
 
 The Discord runtime implementation has landed and the delivery plan has been archived, but the final manual smoke test against a disposable Discord server was not run before archival because disposable bot credentials were not available in the implementation environment.
 
+This follow-up remains intentionally open. For now, the repository accepts a documented gap instead of trying to automate disposable Discord bot provisioning or full live-server validation inside the normal development workflow.
+
 ### Risk
 
 Automated tests prove message mapping, command routing, chunking, and presentation behavior, but they cannot prove that live Discord registration and reply flow behave exactly as expected in a real server.
 
+Because the gap is documented rather than closed, contributors may incorrectly assume that the live Discord path has already been validated end to end. Any real-server integration regression would therefore be discovered later than a fully automated or regularly executed smoke test would allow.
+
 ### Next step
 
-Run the documented smoke test from `README.md` with a disposable Discord bot token and guild ID, then either mark this entry resolved or record any runtime-specific fixes in a follow-up ExecPlan.
+Keep this entry open until one of the following becomes true:
+
+- a sustainable disposable-bot workflow is available for repeatable live smoke testing
+- a release-hardening pass decides that manual real-server validation is now worth the setup cost
+- a production or staging issue suggests the live Discord path needs explicit end-to-end confirmation
+
+Until then, treat this as explicit technical debt rather than an implicit missing task. When one of the triggers above is met, run the documented smoke test from `README.md` with a disposable Discord bot token and guild ID, then either mark this entry resolved or record any runtime-specific fixes in a follow-up ExecPlan.


### PR DESCRIPTION
## Summary

- clarify that the live Discord smoke test remains intentional open technical debt
- document why disposable bot credential automation is not part of the normal workflow right now
- add explicit triggers for revisiting the smoke test follow-up

## Background

The repository already tracked the missing live Discord smoke test, but the previous entry did not clearly explain why the work stayed open or when contributors should revisit it. This made the debt easy to misread as an accidental omission rather than an explicit tradeoff.

## Related issue(s)

- None

## Implementation details

- updated `docs/exec-plans/tech-debt-tracker.md`
- expanded the existing Discord runtime smoke test entry
- documented the current decision to keep the gap open until a sustainable workflow or a stronger validation need appears

## Test coverage

- `make test`
- `make lint`

## Breaking changes

- None

## Notes

Created by Codex