### PR TITLE
[codex] Support Discord image attachments in normal messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ The repository now includes a real startup spine for `cmd/39claw`:
 The runtime now handles:
 
 - mention-only normal conversation
+- mention-triggered image attachments for normal conversation
 - `/help`
 - `/task current`, `/task list`, `/task new <name>`, `/task switch <id>`, and `/task close <id>`
 - same-channel reply targeting for normal conversation
@@ -30,6 +31,7 @@ The runtime now handles:
 The current test-backed behavior includes:
 
 - mention-only handling versus ignored chatter
+- mention-plus-image and image-only mention handling
 - same-day thread reuse
 - next-day rollover
 - task command orchestration for showing, listing, creating, switching, and closing tasks
@@ -104,6 +106,8 @@ Optional Codex thread-option overrides:
 Smoke-test checklist:
 
 - mention the bot in `daily` mode and confirm the reply targets the original message
+- mention the bot with text plus an image attachment and confirm the reply reflects both inputs
+- mention the bot with only an image attachment and confirm the bot still answers
 - send unrelated chatter without a mention and confirm the bot stays silent
 - run `/help` and confirm it matches the configured mode
 - run `/task current` in `daily` mode and confirm the bot returns a clear not-available response

--- a/cmd/39claw/main_test.go
+++ b/cmd/39claw/main_test.go
@@ -259,7 +259,7 @@ func (r *stubDiscordRuntime) Close() error {
 
 type stubCodexGateway struct{}
 
-func (stubCodexGateway) RunTurn(ctx context.Context, threadID string, prompt string) (app.RunTurnResult, error) {
+func (stubCodexGateway) RunTurn(ctx context.Context, threadID string, input app.CodexTurnInput) (app.RunTurnResult, error) {
 	return app.RunTurnResult{}, nil
 }
 

--- a/docs/design-docs/implementation-spec.md
+++ b/docs/design-docs/implementation-spec.md
@@ -47,7 +47,7 @@ The recommended delivery order is:
 The following internal contracts should be treated as stable v1 design targets even if exact Go type names evolve during implementation.
 
 - `MessageRequest`
-  - carries Discord user ID, channel ID, message ID, message content, mention or command metadata, and received time
+  - carries Discord user ID, channel ID, message ID, optional message content, optional local image paths, mention or command metadata, and received time
 - `MessageResponse`
   - carries rendered response text and presentation hints needed for Discord reply, chunking, and ephemeral command responses
 - `ThreadPolicy`
@@ -102,6 +102,7 @@ The logical thread key defaults are:
 
 Normal conversation is mention-only in v1.
 When a qualifying normal message is handled, the bot replies in the same channel and targets the triggering message as the reply root.
+Qualifying normal messages may include text, image attachments, or both as long as the bot mention is present and at least one usable input remains after attachment filtering.
 
 `/help` and `/task ...` are slash-command surfaces.
 Task-control command responses are ephemeral by default.
@@ -111,6 +112,7 @@ When a bot instance runs in `task` mode, normal messages without an active task 
 They should return actionable guidance that points the user to `/task new <name>`, `/task list`, or `/task switch <id>`.
 
 Unsupported non-mention chatter is ignored.
+Mention-only posts that contain no text and no usable image attachments are also ignored.
 Long responses are chunked into Discord-safe messages while preserving code fences when practical.
 Only one Codex turn may run at a time for a given logical thread key.
 If another message arrives for the same logical thread while a turn is running, the bot should return a busy or retry response rather than queueing implicitly.
@@ -155,11 +157,13 @@ When `CLAW_DISCORD_GUILD_ID` is set, slash commands are overwritten in that guil
 The initial implementation should demonstrate the following observable behavior:
 
 - In `daily` mode, the first qualifying mention creates a thread binding, a second same-day mention reuses it, and the first mention on the next local date creates a new binding.
+- A mention-triggered message with text plus image attachments reaches Codex as multipart input.
+- A mention-triggered message with only one or more usable image attachments is accepted and answered.
 - In `task` mode, a normal mention without an active task returns guidance instead of routing to Codex.
 - `/task current` shows the active task for the requesting user.
 - `/task new <name>` creates a task and sets it active for the requesting user.
 - `/task switch <id>` changes the routing target for subsequent normal messages.
 - `/task close <id>` closes the task and clears active state when the closed task was active.
 - Existing `daily` and `task` bindings survive process restart through SQLite-backed state.
-- Non-mention chatter is ignored, supported slash commands respond correctly, and long replies are chunked cleanly.
+- Non-mention chatter is ignored, unsupported non-image-only mention posts stay silent, supported slash commands respond correctly, and long replies are chunked cleanly.
 - Simultaneous requests for the same logical thread do not execute overlapping Codex turns.

--- a/docs/exec-plans/active/06-discord-image-input.md
+++ b/docs/exec-plans/active/06-discord-image-input.md
@@ -12,10 +12,11 @@ After this plan, a Discord user should be able to mention the bot with one or mo
 
 - [x] (2026-04-05 17:20Z) Defined the image-attachment intake plan and acceptance targets.
 - [x] (2026-04-05 17:20Z) Confirmed the current repository state: Discord message intake only forwards text content, while the Codex input layer already supports local image parts.
-- [ ] Extend the normalized message request and Codex gateway contracts so a turn can carry text plus zero or more local image paths.
-- [ ] Implement Discord attachment download, validation, and cleanup for qualifying image attachments.
-- [ ] Implement mention-plus-image and image-only message handling end to end, including tests and documentation updates.
-- [ ] Run `make test`, `make lint`, and a manual Discord smoke test that proves attached images affect the reply.
+- [x] (2026-04-05 20:25Z) Extended the normalized message request and Codex gateway contracts so a turn can carry text plus zero or more local image paths.
+- [x] (2026-04-05 20:25Z) Implemented Discord attachment download, validation, and cleanup for qualifying image attachments.
+- [x] (2026-04-05 20:25Z) Implemented mention-plus-image and image-only message handling end to end, including tests and documentation updates.
+- [x] (2026-04-05 20:27Z) Ran `make test` and `make lint` after the implementation landed.
+- [ ] Run a manual Discord smoke test that proves attached images affect the reply in a live server.
 
 ## Surprises & Discoveries
 
@@ -44,7 +45,15 @@ After this plan, a Discord user should be able to mention the bot with one or mo
 
 ## Outcomes & Retrospective
 
-This plan is not implemented yet. Its intended outcome is a Discord runtime that can transform attached images into local temporary files, carry those file paths through the application layer, and invoke Codex with multipart input that combines optional text and image parts. When complete, the repository should also document the new behavior and include automated coverage for mapper behavior, gateway multipart forwarding, cleanup paths, and at least one end-to-end application scenario.
+This plan is now implemented for code, automated validation, and documentation updates. The intended outcome was a Discord runtime that can transform attached images into local temporary files, carry those file paths through the application layer, and invoke Codex with multipart input that combines optional text and image parts.
+
+The implementation has now landed for the code, automated tests, and documentation updates described above. The remaining gap is only the manual Discord smoke test with disposable credentials so the final proof can show that real Discord-hosted image attachments behave the same way as the automated coverage.
+
+Automated proof completed during implementation:
+
+- `go test ./internal/runtime/discord ./internal/app ./internal/codex ./cmd/39claw`
+- `make test`
+- `make lint`
 
 ## Context and Orientation
 

--- a/docs/product-specs/discord-command-behavior.md
+++ b/docs/product-specs/discord-command-behavior.md
@@ -81,6 +81,8 @@ Examples:
 - explicit mention required
 
 v1 should use mention-only triggering for normal-message interaction.
+When the bot is mentioned, a normal message may contain typed text, one or more image attachments, or both.
+If the mention is present but the message contains neither text nor a usable image attachment, the bot should stay silent.
 
 ### 3. Command interactions should always be explicit
 

--- a/internal/app/message_service.go
+++ b/internal/app/message_service.go
@@ -19,7 +19,7 @@ type ThreadStore interface {
 }
 
 type CodexGateway interface {
-	RunTurn(ctx context.Context, threadID string, prompt string) (RunTurnResult, error)
+	RunTurn(ctx context.Context, threadID string, input CodexTurnInput) (RunTurnResult, error)
 }
 
 type MessageService interface {

--- a/internal/app/message_service_impl.go
+++ b/internal/app/message_service_impl.go
@@ -127,7 +127,10 @@ func (s *DefaultMessageService) HandleMessage(ctx context.Context, request Messa
 		binding.TaskID = activeTask.TaskID
 	}
 
-	result, err := s.gateway.RunTurn(ctx, threadID, strings.TrimSpace(request.Content))
+	result, err := s.gateway.RunTurn(ctx, threadID, CodexTurnInput{
+		Prompt:     request.Content,
+		ImagePaths: append([]string(nil), request.ImagePaths...),
+	})
 	if err != nil {
 		return MessageResponse{}, fmt.Errorf("run codex turn: %w", err)
 	}

--- a/internal/app/message_service_test.go
+++ b/internal/app/message_service_test.go
@@ -100,6 +100,14 @@ func TestMessageServiceHandleMessageDailyReusesSameDayBinding(t *testing.T) {
 	if binding.CodexThreadID != "thread-1" {
 		t.Fatalf("CodexThreadID = %q, want %q", binding.CodexThreadID, "thread-1")
 	}
+
+	if gateway.calls[0].input.Prompt != "hello there" {
+		t.Fatalf("first prompt = %q, want %q", gateway.calls[0].input.Prompt, "hello there")
+	}
+
+	if len(gateway.calls[0].input.ImagePaths) != 0 {
+		t.Fatalf("first image path count = %d, want %d", len(gateway.calls[0].input.ImagePaths), 0)
+	}
 }
 
 func TestMessageServiceHandleMessageDailyRollsOverOnNextDay(t *testing.T) {
@@ -372,6 +380,40 @@ func TestMessageServiceHandleMessageTaskSwitchesThreadsByActiveTask(t *testing.T
 	}
 }
 
+func TestMessageServiceHandleMessageForwardsImagePathsToGateway(t *testing.T) {
+	t.Parallel()
+
+	gateway := &fakeCodexGateway{
+		results: []app.RunTurnResult{
+			{ThreadID: "thread-1", ResponseText: "Image response"},
+		},
+	}
+	service := newDailyMessageService(t, &memoryThreadStore{}, gateway, &stubExecutionGuard{})
+
+	_, err := service.HandleMessage(context.Background(), app.MessageRequest{
+		MessageID:  "message-1",
+		Content:    "describe this screenshot",
+		ImagePaths: []string{"/tmp/one.png", "/tmp/two.png"},
+		Mentioned:  true,
+		ReceivedAt: time.Date(2026, time.April, 5, 0, 0, 0, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatalf("HandleMessage() error = %v", err)
+	}
+
+	if len(gateway.calls) != 1 {
+		t.Fatalf("RunTurn() call count = %d, want %d", len(gateway.calls), 1)
+	}
+
+	if gateway.calls[0].input.Prompt != "describe this screenshot" {
+		t.Fatalf("prompt = %q, want %q", gateway.calls[0].input.Prompt, "describe this screenshot")
+	}
+
+	if got := gateway.calls[0].input.ImagePaths; len(got) != 2 || got[0] != "/tmp/one.png" || got[1] != "/tmp/two.png" {
+		t.Fatalf("image paths = %v, want [/tmp/one.png /tmp/two.png]", got)
+	}
+}
+
 func newDailyMessageService(
 	t *testing.T,
 	store app.ThreadStore,
@@ -465,13 +507,16 @@ type fakeCodexGateway struct {
 
 type runTurnCall struct {
 	threadID string
-	prompt   string
+	input    app.CodexTurnInput
 }
 
-func (g *fakeCodexGateway) RunTurn(_ context.Context, threadID string, prompt string) (app.RunTurnResult, error) {
+func (g *fakeCodexGateway) RunTurn(_ context.Context, threadID string, input app.CodexTurnInput) (app.RunTurnResult, error) {
 	g.calls = append(g.calls, runTurnCall{
 		threadID: threadID,
-		prompt:   prompt,
+		input: app.CodexTurnInput{
+			Prompt:     input.Prompt,
+			ImagePaths: append([]string(nil), input.ImagePaths...),
+		},
 	})
 
 	if g.err != nil {

--- a/internal/app/types.go
+++ b/internal/app/types.go
@@ -7,6 +7,7 @@ type MessageRequest struct {
 	ChannelID   string
 	MessageID   string
 	Content     string
+	ImagePaths  []string
 	Mentioned   bool
 	CommandName string
 	CommandArgs []string
@@ -62,4 +63,9 @@ type RunTurnResult struct {
 	ThreadID     string
 	ResponseText string
 	Usage        *TokenUsage
+}
+
+type CodexTurnInput struct {
+	Prompt     string
+	ImagePaths []string
 }

--- a/internal/codex/gateway.go
+++ b/internal/codex/gateway.go
@@ -24,13 +24,14 @@ func NewGateway(client *Client, options GatewayOptions) *Gateway {
 	}
 }
 
-func (g *Gateway) RunTurn(ctx context.Context, threadID string, prompt string) (app.RunTurnResult, error) {
+func (g *Gateway) RunTurn(ctx context.Context, threadID string, input app.CodexTurnInput) (app.RunTurnResult, error) {
 	if g.client == nil {
 		return app.RunTurnResult{}, errors.New("codex client must not be nil")
 	}
 
-	if strings.TrimSpace(prompt) == "" {
-		return app.RunTurnResult{}, errors.New("prompt must not be empty")
+	codexInput, err := buildGatewayInput(input)
+	if err != nil {
+		return app.RunTurnResult{}, err
 	}
 
 	thread := g.client.StartThread(g.threadOptions)
@@ -38,7 +39,7 @@ func (g *Gateway) RunTurn(ctx context.Context, threadID string, prompt string) (
 		thread = g.client.ResumeThread(threadID, g.threadOptions)
 	}
 
-	turn, err := thread.Run(ctx, TextInput(prompt))
+	turn, err := thread.Run(ctx, codexInput)
 	if err != nil {
 		return app.RunTurnResult{}, err
 	}
@@ -57,4 +58,25 @@ func (g *Gateway) RunTurn(ctx context.Context, threadID string, prompt string) (
 	}
 
 	return result, nil
+}
+
+func buildGatewayInput(input app.CodexTurnInput) (Input, error) {
+	parts := make([]InputPart, 0, len(input.ImagePaths)+1)
+	if prompt := strings.TrimSpace(input.Prompt); prompt != "" {
+		parts = append(parts, TextPart(prompt))
+	}
+
+	for _, imagePath := range input.ImagePaths {
+		if strings.TrimSpace(imagePath) == "" {
+			continue
+		}
+
+		parts = append(parts, LocalImagePart(imagePath))
+	}
+
+	if len(parts) == 0 {
+		return Input{}, errors.New("turn input must include text or at least one image")
+	}
+
+	return MultiPartInput(parts...), nil
 }

--- a/internal/codex/gateway_test.go
+++ b/internal/codex/gateway_test.go
@@ -14,7 +14,7 @@ func TestGatewayRunTurn(t *testing.T) {
 		name         string
 		mode         string
 		threadID     string
-		prompt       string
+		input        app.CodexTurnInput
 		wantThreadID string
 		wantText     string
 		wantUsage    *app.TokenUsage
@@ -23,7 +23,7 @@ func TestGatewayRunTurn(t *testing.T) {
 		{
 			name:         "starts a new thread when thread id is empty",
 			mode:         "single-success",
-			prompt:       "hello",
+			input:        app.CodexTurnInput{Prompt: "hello"},
 			wantThreadID: "thread_test",
 			wantText:     "Hi from helper",
 			wantUsage: &app.TokenUsage{
@@ -36,7 +36,7 @@ func TestGatewayRunTurn(t *testing.T) {
 			name:         "resumes an existing thread",
 			mode:         "resume-success",
 			threadID:     "thread_saved",
-			prompt:       "continue",
+			input:        app.CodexTurnInput{Prompt: "continue"},
 			wantThreadID: "thread_saved",
 			wantText:     "Resumed helper response",
 			wantUsage: &app.TokenUsage{
@@ -46,10 +46,22 @@ func TestGatewayRunTurn(t *testing.T) {
 			},
 		},
 		{
-			name:    "rejects empty prompt",
+			name:         "accepts image-only input",
+			mode:         "single-success",
+			input:        app.CodexTurnInput{ImagePaths: []string{"/tmp/screenshot.png"}},
+			wantThreadID: "thread_test",
+			wantText:     "Hi from helper",
+			wantUsage: &app.TokenUsage{
+				InputTokens:       42,
+				CachedInputTokens: 12,
+				OutputTokens:      5,
+			},
+		},
+		{
+			name:    "rejects empty turn input",
 			mode:    "single-success",
-			prompt:  "  ",
-			wantErr: "prompt must not be empty",
+			input:   app.CodexTurnInput{Prompt: "  "},
+			wantErr: "turn input must include text or at least one image",
 		},
 	}
 
@@ -62,7 +74,7 @@ func TestGatewayRunTurn(t *testing.T) {
 			client, _ := newTestClient(t, tt.mode)
 			gateway := NewGateway(client, GatewayOptions{})
 
-			result, err := gateway.RunTurn(context.Background(), tt.threadID, tt.prompt)
+			result, err := gateway.RunTurn(context.Background(), tt.threadID, tt.input)
 			if tt.wantErr != "" {
 				if err == nil {
 					t.Fatalf("RunTurn() error = nil, want %q", tt.wantErr)

--- a/internal/runtime/discord/attachments.go
+++ b/internal/runtime/discord/attachments.go
@@ -1,0 +1,154 @@
+package discord
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"mime"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/bwmarrin/discordgo"
+)
+
+type attachmentHTTPClient interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+var supportedImageExtensions = map[string]struct{}{
+	".apng": {},
+	".bmp":  {},
+	".gif":  {},
+	".jpeg": {},
+	".jpg":  {},
+	".png":  {},
+	".tif":  {},
+	".tiff": {},
+	".webp": {},
+}
+
+func prepareImageAttachments(
+	ctx context.Context,
+	client attachmentHTTPClient,
+	attachments []*discordgo.MessageAttachment,
+) ([]string, func(), error) {
+	imageAttachments := filterImageAttachments(attachments)
+	if len(imageAttachments) == 0 {
+		return nil, nil, nil
+	}
+
+	tempDir, err := os.MkdirTemp("", "39claw-discord-images-*")
+	if err != nil {
+		return nil, nil, fmt.Errorf("create temporary image directory: %w", err)
+	}
+
+	cleanup := func() {
+		_ = os.RemoveAll(tempDir)
+	}
+
+	paths := make([]string, 0, len(imageAttachments))
+	for index, attachment := range imageAttachments {
+		path, err := downloadAttachment(ctx, client, tempDir, index, attachment)
+		if err != nil {
+			cleanup()
+			return nil, nil, err
+		}
+
+		paths = append(paths, path)
+	}
+
+	return paths, cleanup, nil
+}
+
+func filterImageAttachments(attachments []*discordgo.MessageAttachment) []*discordgo.MessageAttachment {
+	filtered := make([]*discordgo.MessageAttachment, 0, len(attachments))
+	for _, attachment := range attachments {
+		if isSupportedImageAttachment(attachment) {
+			filtered = append(filtered, attachment)
+		}
+	}
+
+	return filtered
+}
+
+func isSupportedImageAttachment(attachment *discordgo.MessageAttachment) bool {
+	if attachment == nil {
+		return false
+	}
+
+	contentType := strings.ToLower(strings.TrimSpace(attachment.ContentType))
+	if strings.HasPrefix(contentType, "image/") {
+		return true
+	}
+
+	_, ok := supportedImageExtensions[strings.ToLower(filepath.Ext(attachment.Filename))]
+	return ok
+}
+
+func downloadAttachment(
+	ctx context.Context,
+	client attachmentHTTPClient,
+	tempDir string,
+	index int,
+	attachment *discordgo.MessageAttachment,
+) (string, error) {
+	if client == nil {
+		return "", fmt.Errorf("attachment http client must not be nil")
+	}
+
+	url := strings.TrimSpace(attachment.URL)
+	if url == "" {
+		return "", fmt.Errorf("attachment %q is missing a download URL", attachment.Filename)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return "", fmt.Errorf("build attachment request: %w", err)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("download attachment %q: %w", attachment.Filename, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return "", fmt.Errorf("download attachment %q: unexpected status %s", attachment.Filename, resp.Status)
+	}
+
+	filePath := filepath.Join(tempDir, fmt.Sprintf("attachment-%02d%s", index+1, attachmentExtension(attachment)))
+	file, err := os.Create(filePath)
+	if err != nil {
+		return "", fmt.Errorf("create attachment file %q: %w", filePath, err)
+	}
+
+	if _, err := io.Copy(file, resp.Body); err != nil {
+		_ = file.Close()
+		_ = os.Remove(filePath)
+		return "", fmt.Errorf("write attachment file %q: %w", filePath, err)
+	}
+
+	if err := file.Close(); err != nil {
+		_ = os.Remove(filePath)
+		return "", fmt.Errorf("close attachment file %q: %w", filePath, err)
+	}
+
+	return filePath, nil
+}
+
+func attachmentExtension(attachment *discordgo.MessageAttachment) string {
+	if ext := strings.ToLower(filepath.Ext(attachment.Filename)); ext != "" {
+		return ext
+	}
+
+	if attachment.ContentType != "" {
+		extensions, err := mime.ExtensionsByType(attachment.ContentType)
+		if err == nil && len(extensions) > 0 {
+			return extensions[0]
+		}
+	}
+
+	return ".img"
+}

--- a/internal/runtime/discord/commands.go
+++ b/internal/runtime/discord/commands.go
@@ -10,6 +10,7 @@ import (
 
 const (
 	internalErrorMessage      = "Something went wrong while handling that request. Please retry in a moment."
+	imageDownloadErrorMessage = "I couldn't download one of the image attachments. Please retry in a moment."
 	taskUnavailableDailyMode  = "Task commands are not available in this daily-mode bot. Mention the bot to continue today's conversation."
 	unsupportedTaskActionText = "Unsupported task command. Use `/task current`, `/task list`, `/task new`, `/task switch`, or `/task close`."
 )

--- a/internal/runtime/discord/message_mapper.go
+++ b/internal/runtime/discord/message_mapper.go
@@ -22,9 +22,6 @@ func mapMessageCreate(selfUserID string, event *discordgo.MessageCreate) (app.Me
 	}
 
 	content := strings.TrimSpace(stripSelfMentions(event.Content, selfUserID))
-	if content == "" {
-		return app.MessageRequest{}, false
-	}
 
 	receivedAt := event.Timestamp
 	if receivedAt.IsZero() {

--- a/internal/runtime/discord/runtime.go
+++ b/internal/runtime/discord/runtime.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"net/http"
+	"strings"
 	"sync"
 
 	"github.com/HatsuneMiku3939/39claw/internal/app"
@@ -18,6 +20,7 @@ type Dependencies struct {
 	Message        app.MessageService
 	TaskCommand    app.TaskCommandService
 	SessionFactory sessionFactory
+	HTTPClient     attachmentHTTPClient
 }
 
 type Runtime struct {
@@ -27,6 +30,7 @@ type Runtime struct {
 	taskCommand app.TaskCommandService
 
 	sessionFactory sessionFactory
+	httpClient     attachmentHTTPClient
 
 	mu       sync.Mutex
 	session  session
@@ -55,12 +59,18 @@ func NewRuntime(deps Dependencies) (*Runtime, error) {
 		factory = newLiveSession
 	}
 
+	httpClient := deps.HTTPClient
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+
 	return &Runtime{
 		config:         deps.Config,
 		logger:         deps.Logger,
 		message:        deps.Message,
 		taskCommand:    deps.TaskCommand,
 		sessionFactory: factory,
+		httpClient:     httpClient,
 	}, nil
 }
 
@@ -158,6 +168,26 @@ func (r *Runtime) handleMessageCreate(_ *discordgo.Session, event *discordgo.Mes
 
 	request, ok := mapMessageCreate(discordSession.SelfUserID(), event)
 	if !ok {
+		return
+	}
+
+	imagePaths, cleanup, err := prepareImageAttachments(context.Background(), r.httpClient, event.Attachments)
+	if cleanup != nil {
+		defer cleanup()
+	}
+	if err != nil {
+		r.logger.Error("prepare image attachments", "error", err, "channel_id", request.ChannelID, "message_id", request.MessageID)
+		if err := presentMessage(discordSession, request.ChannelID, app.MessageResponse{
+			Text:      imageDownloadErrorMessage,
+			ReplyToID: request.MessageID,
+		}); err != nil {
+			r.logger.Error("present attachment error response", "error", err, "channel_id", request.ChannelID, "message_id", request.MessageID)
+		}
+		return
+	}
+
+	request.ImagePaths = imagePaths
+	if strings.TrimSpace(request.Content) == "" && len(request.ImagePaths) == 0 {
 		return
 	}
 

--- a/internal/runtime/discord/runtime_test.go
+++ b/internal/runtime/discord/runtime_test.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"io"
 	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 
@@ -82,12 +85,223 @@ func TestRuntimeMentionHandlingRepliesToTriggerMessage(t *testing.T) {
 		t.Fatalf("mapped content = %q, want %q", messageService.requests[0].Content, "hello there")
 	}
 
+	if len(messageService.requests[0].ImagePaths) != 0 {
+		t.Fatalf("image path count = %d, want %d", len(messageService.requests[0].ImagePaths), 0)
+	}
+
 	if len(fakeSession.sentMessages) != 1 {
 		t.Fatalf("sent message count = %d, want %d", len(fakeSession.sentMessages), 1)
 	}
 
 	if fakeSession.sentMessages[0].Reference == nil || fakeSession.sentMessages[0].Reference.MessageID != "message-1" {
 		t.Fatal("first sent message missing reply reference")
+	}
+}
+
+func TestRuntimeMentionHandlingDownloadsImageAttachments(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "image/png")
+		_, _ = w.Write([]byte("png-bytes"))
+	}))
+	t.Cleanup(server.Close)
+
+	messageService := &fakeMessageService{
+		response: app.MessageResponse{
+			Text:      "Image-aware response",
+			ReplyToID: "message-1",
+		},
+	}
+	fakeSession := newFakeSession("bot-user")
+	runtime := newTestRuntimeWithServicesAndClient(t, config.ModeDaily, fakeSession, messageService, &fakeTaskCommandService{}, server.Client())
+
+	if err := runtime.Start(context.Background()); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	t.Cleanup(func() {
+		_ = runtime.Close()
+	})
+
+	fakeSession.dispatchMessage(&discordgo.MessageCreate{
+		Message: &discordgo.Message{
+			ID:        "message-1",
+			ChannelID: "channel-1",
+			Content:   "<@bot-user> describe this",
+			Author:    &discordgo.User{ID: "user-1"},
+			Mentions: []*discordgo.User{
+				{ID: "bot-user"},
+			},
+			Attachments: []*discordgo.MessageAttachment{
+				{
+					Filename:    "sample.png",
+					ContentType: "image/png",
+					URL:         server.URL + "/sample.png",
+				},
+			},
+		},
+	})
+
+	if len(messageService.requests) != 1 {
+		t.Fatalf("message request count = %d, want %d", len(messageService.requests), 1)
+	}
+
+	request := messageService.requests[0]
+	if request.Content != "describe this" {
+		t.Fatalf("content = %q, want %q", request.Content, "describe this")
+	}
+
+	if len(request.ImagePaths) != 1 {
+		t.Fatalf("image path count = %d, want %d", len(request.ImagePaths), 1)
+	}
+
+	if _, err := os.Stat(request.ImagePaths[0]); !os.IsNotExist(err) {
+		t.Fatalf("downloaded image path should be cleaned up, stat err = %v", err)
+	}
+}
+
+func TestRuntimeMentionHandlingAcceptsImageOnlyMessage(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "image/png")
+		_, _ = w.Write([]byte("png-bytes"))
+	}))
+	t.Cleanup(server.Close)
+
+	messageService := &fakeMessageService{
+		response: app.MessageResponse{
+			Text:      "Image-only response",
+			ReplyToID: "message-1",
+		},
+	}
+	fakeSession := newFakeSession("bot-user")
+	runtime := newTestRuntimeWithServicesAndClient(t, config.ModeDaily, fakeSession, messageService, &fakeTaskCommandService{}, server.Client())
+
+	if err := runtime.Start(context.Background()); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	t.Cleanup(func() {
+		_ = runtime.Close()
+	})
+
+	fakeSession.dispatchMessage(&discordgo.MessageCreate{
+		Message: &discordgo.Message{
+			ID:        "message-1",
+			ChannelID: "channel-1",
+			Content:   "<@bot-user>",
+			Author:    &discordgo.User{ID: "user-1"},
+			Mentions: []*discordgo.User{
+				{ID: "bot-user"},
+			},
+			Attachments: []*discordgo.MessageAttachment{
+				{
+					Filename:    "sample.png",
+					ContentType: "image/png",
+					URL:         server.URL + "/sample.png",
+				},
+			},
+		},
+	})
+
+	if len(messageService.requests) != 1 {
+		t.Fatalf("message request count = %d, want %d", len(messageService.requests), 1)
+	}
+
+	if messageService.requests[0].Content != "" {
+		t.Fatalf("content = %q, want empty", messageService.requests[0].Content)
+	}
+
+	if len(messageService.requests[0].ImagePaths) != 1 {
+		t.Fatalf("image path count = %d, want %d", len(messageService.requests[0].ImagePaths), 1)
+	}
+}
+
+func TestRuntimeMentionHandlingIgnoresImageOnlyMessageWithoutUsableImages(t *testing.T) {
+	t.Parallel()
+
+	messageService := &fakeMessageService{}
+	fakeSession := newFakeSession("bot-user")
+	runtime := newTestRuntimeWithServices(t, config.ModeDaily, fakeSession, messageService, &fakeTaskCommandService{})
+
+	if err := runtime.Start(context.Background()); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	t.Cleanup(func() {
+		_ = runtime.Close()
+	})
+
+	fakeSession.dispatchMessage(&discordgo.MessageCreate{
+		Message: &discordgo.Message{
+			ID:        "message-1",
+			ChannelID: "channel-1",
+			Content:   "<@bot-user>",
+			Author:    &discordgo.User{ID: "user-1"},
+			Mentions: []*discordgo.User{
+				{ID: "bot-user"},
+			},
+			Attachments: []*discordgo.MessageAttachment{
+				{
+					Filename:    "notes.txt",
+					ContentType: "text/plain",
+					URL:         "https://example.test/notes.txt",
+				},
+			},
+		},
+	})
+
+	if len(messageService.requests) != 0 {
+		t.Fatalf("message request count = %d, want %d", len(messageService.requests), 0)
+	}
+
+	if len(fakeSession.sentMessages) != 0 {
+		t.Fatalf("sent message count = %d, want %d", len(fakeSession.sentMessages), 0)
+	}
+}
+
+func TestRuntimeMentionHandlingReturnsErrorWhenAttachmentDownloadFails(t *testing.T) {
+	t.Parallel()
+
+	messageService := &fakeMessageService{}
+	fakeSession := newFakeSession("bot-user")
+	runtime := newTestRuntimeWithServicesAndClient(t, config.ModeDaily, fakeSession, messageService, &fakeTaskCommandService{}, http.DefaultClient)
+
+	if err := runtime.Start(context.Background()); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	t.Cleanup(func() {
+		_ = runtime.Close()
+	})
+
+	fakeSession.dispatchMessage(&discordgo.MessageCreate{
+		Message: &discordgo.Message{
+			ID:        "message-1",
+			ChannelID: "channel-1",
+			Content:   "<@bot-user> describe this",
+			Author:    &discordgo.User{ID: "user-1"},
+			Mentions: []*discordgo.User{
+				{ID: "bot-user"},
+			},
+			Attachments: []*discordgo.MessageAttachment{
+				{
+					Filename:    "sample.png",
+					ContentType: "image/png",
+					URL:         "http://127.0.0.1:1/unreachable.png",
+				},
+			},
+		},
+	})
+
+	if len(messageService.requests) != 0 {
+		t.Fatalf("message request count = %d, want %d", len(messageService.requests), 0)
+	}
+
+	if len(fakeSession.sentMessages) != 1 {
+		t.Fatalf("sent message count = %d, want %d", len(fakeSession.sentMessages), 1)
+	}
+
+	if fakeSession.sentMessages[0].Content != imageDownloadErrorMessage {
+		t.Fatalf("error message = %q, want %q", fakeSession.sentMessages[0].Content, imageDownloadErrorMessage)
 	}
 }
 
@@ -250,7 +464,7 @@ func TestChunkTextPreservesCodeFences(t *testing.T) {
 
 func newTestRuntime(t *testing.T, mode config.Mode, fakeSession *fakeSession) *Runtime {
 	t.Helper()
-	return newTestRuntimeWithServices(t, mode, fakeSession, &fakeMessageService{}, &fakeTaskCommandService{})
+	return newTestRuntimeWithServicesAndClient(t, mode, fakeSession, &fakeMessageService{}, &fakeTaskCommandService{}, http.DefaultClient)
 }
 
 func newTestRuntimeWithServices(
@@ -259,6 +473,18 @@ func newTestRuntimeWithServices(
 	fakeSession *fakeSession,
 	messageService app.MessageService,
 	taskService app.TaskCommandService,
+) *Runtime {
+	t.Helper()
+	return newTestRuntimeWithServicesAndClient(t, mode, fakeSession, messageService, taskService, http.DefaultClient)
+}
+
+func newTestRuntimeWithServicesAndClient(
+	t *testing.T,
+	mode config.Mode,
+	fakeSession *fakeSession,
+	messageService app.MessageService,
+	taskService app.TaskCommandService,
+	httpClient attachmentHTTPClient,
 ) *Runtime {
 	t.Helper()
 
@@ -271,6 +497,7 @@ func newTestRuntimeWithServices(
 		Logger:      slog.New(slog.NewTextHandler(io.Discard, nil)),
 		Message:     messageService,
 		TaskCommand: taskService,
+		HTTPClient:  httpClient,
 		SessionFactory: func(token string) (session, error) {
 			return fakeSession, nil
 		},


### PR DESCRIPTION
## Summary

- add Discord image attachment intake for normal message turns
- pass text-plus-image or image-only inputs through the app layer into Codex multipart input
- document the new behavior and update the active ExecPlan status

## Background

The repository already supported multipart Codex input through the internal Codex layer, but the Discord runtime only forwarded trimmed text content. This meant users could not ask about attached screenshots or send image-only mention posts even though the lower-level Codex integration already understood local image paths.

## Related issue(s)

- None

## Implementation details

- added image path support to the normalized app request and Codex gateway contract
- updated the Discord runtime to filter supported image attachments, download them to temporary files, clean them up after handling, and return a user-facing error if a download fails
- relaxed mention handling so image-only mention posts are accepted when at least one usable image remains
- updated the Codex gateway to build multipart input from optional text plus image paths
- added automated coverage for runtime attachment handling, gateway input building, and app-layer forwarding
- updated README, the implementation spec, the Discord product behavior doc, and the active image-input ExecPlan

## Test coverage

- `make test`
- `make lint`
- focused runtime tests for text-plus-image, image-only, ignored non-image-only posts, cleanup, and failed downloads

## Breaking changes

- Internal only: `app.CodexGateway` now accepts structured turn input instead of a plain prompt string

## Notes

- The remaining gap is the manual Discord smoke test against a live disposable bot environment; automated coverage and documentation are updated, but that final live proof is still pending.

Created by Codex