### PR TITLE
Archive ExecPlan 06 and consolidate Discord smoke-test debt

### DIFF
--- a/docs/exec-plans/completed/06-discord-image-input.md
+++ b/docs/exec-plans/completed/06-discord-image-input.md
@@ -16,7 +16,8 @@ After this plan, a Discord user should be able to mention the bot with one or mo
 - [x] (2026-04-05 20:25Z) Implemented Discord attachment download, validation, and cleanup for qualifying image attachments.
 - [x] (2026-04-05 20:25Z) Implemented mention-plus-image and image-only message handling end to end, including tests and documentation updates.
 - [x] (2026-04-05 20:27Z) Ran `make test` and `make lint` after the implementation landed.
-- [ ] Run a manual Discord smoke test that proves attached images affect the reply in a live server.
+- [x] (2026-04-06 00:39Z) Deferred the remaining live Discord smoke test to the shared Discord runtime tech-debt entry because the implementation, automated validation, and documentation are complete.
+- [x] (2026-04-06 00:39Z) Archived this plan to `docs/exec-plans/completed/06-discord-image-input.md` because no implementation work remains in `active/`.
 
 ## Surprises & Discoveries
 
@@ -43,11 +44,17 @@ After this plan, a Discord user should be able to mention the bot with one or mo
   Rationale: The product goal is to let users ask about attached images naturally. Requiring non-empty typed text would prevent the second requested behavior.
   Date/Author: 2026-04-05 / Codex
 
+- Decision: Archive this plan without a dedicated image-only live Discord smoke run and track that remaining proof in the shared Discord runtime tech-debt entry instead.
+  Rationale: The remaining gap is operational validation, not unfinished implementation. Keeping the plan active would overstate the amount of pending engineering work while duplicating the existing live Discord smoke-test follow-up.
+  Date/Author: 2026-04-06 / Codex
+
 ## Outcomes & Retrospective
 
 This plan is now implemented for code, automated validation, and documentation updates. The intended outcome was a Discord runtime that can transform attached images into local temporary files, carry those file paths through the application layer, and invoke Codex with multipart input that combines optional text and image parts.
 
-The implementation has now landed for the code, automated tests, and documentation updates described above. The remaining gap is only the manual Discord smoke test with disposable credentials so the final proof can show that real Discord-hosted image attachments behave the same way as the automated coverage.
+The implementation has now landed for the code, automated tests, and documentation updates described above. The only remaining gap is live Discord smoke validation with disposable credentials, and that gap is now tracked explicitly in `docs/exec-plans/tech-debt-tracker.md` rather than keeping this completed implementation plan in `active/`.
+
+The plan therefore no longer belongs in `active/`: there is no remaining code, test, or documentation work scoped to this feature. What remains is a shared operational proof task for the Discord runtime as a whole, including image attachments.
 
 Automated proof completed during implementation:
 
@@ -228,3 +235,4 @@ Within `internal/runtime/discord`, keep the Discord SDK details and attachment d
 
 Revision Note: 2026-04-05 / Codex - Created this ExecPlan to add Discord image attachment support for both text-plus-image and image-only mention flows.
 Revision Note: 2026-04-05 / Codex - Renumbered this active ExecPlan from `05` to `06` because `05-queued-message-handling.md` already exists.
+Revision Note: 2026-04-06 / Codex - Archived this plan after implementation completion and moved the remaining live Discord smoke proof into the shared tech-debt tracker entry.

--- a/docs/exec-plans/index.md
+++ b/docs/exec-plans/index.md
@@ -25,7 +25,7 @@ Plans in this directory should be written and maintained in line with `.agents/P
 
 These plans are intended to be executed in numeric order. Each plan is self-contained, but later plans name the repository state they expect to find and explain how to recover if that state is missing.
 
-- [Implement Discord image attachment intake for Codex turns](./active/06-discord-image-input.md)
+- None right now.
 
 ## Recently Completed Plans
 
@@ -34,3 +34,4 @@ These plans are intended to be executed in numeric order. Each plan is self-cont
 - [Implement `task` mode task workflow and command orchestration](./completed/03-task-mode-workflow.md)
 - [Implement the Discord runtime, commands, and response presentation](./completed/04-discord-runtime-and-presentation.md)
 - [Implement capped per-thread message queueing for busy Codex turns](./completed/05-queued-message-handling.md)
+- [Implement Discord image attachment intake for Codex turns](./completed/06-discord-image-input.md)

--- a/docs/exec-plans/tech-debt-tracker.md
+++ b/docs/exec-plans/tech-debt-tracker.md
@@ -35,18 +35,20 @@ Describe the smallest safe follow-up that should address the debt.
 
 - Status: open
 - Date: 2026-04-05
-- Related plan: `docs/exec-plans/completed/04-discord-runtime-and-presentation.md`
+- Related plan: `docs/exec-plans/completed/04-discord-runtime-and-presentation.md`, `docs/exec-plans/completed/06-discord-image-input.md`
 - Owner: Unassigned
 
 ### Context
 
-The Discord runtime implementation has landed and the delivery plan has been archived, but the final manual smoke test against a disposable Discord server was not run before archival because disposable bot credentials were not available in the implementation environment.
+The Discord runtime implementation has landed and the delivery plans have been archived, but the final manual smoke test against a disposable Discord server was not run before archival because disposable bot credentials were not available in the implementation environment.
+
+This gap now covers both the general runtime flow and the live validation of Discord-hosted image attachments. Automated tests prove the image download, cleanup, multipart-input forwarding, and deferred reply behavior, but they do not prove the final live Discord path with real attachment hosting and reply delivery.
 
 This follow-up remains intentionally open. For now, the repository accepts a documented gap instead of trying to automate disposable Discord bot provisioning or full live-server validation inside the normal development workflow.
 
 ### Risk
 
-Automated tests prove message mapping, command routing, chunking, and presentation behavior, but they cannot prove that live Discord registration and reply flow behave exactly as expected in a real server.
+Automated tests prove message mapping, command routing, chunking, presentation behavior, image download handling, and multipart-input forwarding, but they cannot prove that live Discord registration, hosted attachment fetches, and reply flow behave exactly as expected in a real server.
 
 Because the gap is documented rather than closed, contributors may incorrectly assume that the live Discord path has already been validated end to end. Any real-server integration regression would therefore be discovered later than a fully automated or regularly executed smoke test would allow.
 
@@ -58,4 +60,4 @@ Keep this entry open until one of the following becomes true:
 - a release-hardening pass decides that manual real-server validation is now worth the setup cost
 - a production or staging issue suggests the live Discord path needs explicit end-to-end confirmation
 
-Until then, treat this as explicit technical debt rather than an implicit missing task. When one of the triggers above is met, run the documented smoke test from `README.md` with a disposable Discord bot token and guild ID, then either mark this entry resolved or record any runtime-specific fixes in a follow-up ExecPlan.
+Until then, treat this as explicit technical debt rather than an implicit missing task. When one of the triggers above is met, run the documented smoke test from `README.md` with a disposable Discord bot token and guild ID, including both normal reply and image-attachment scenarios, then either mark this entry resolved or record any runtime-specific fixes in a follow-up ExecPlan.


### PR DESCRIPTION
## Summary

- archive ExecPlan 06 as completed now that implementation work is done
- clear the active ExecPlan index and list 06 under recently completed work
- fold the remaining live Discord image proof into the shared Discord runtime tech-debt entry

## Background

ExecPlan 06 was still listed under `docs/exec-plans/active` even though the implementation, automated validation, and documentation work for Discord image attachment intake had already landed. The only remaining gap is a live Discord smoke test, which is shared with the broader runtime validation debt rather than being unfinished feature work.

## Related issue(s)

- None

## Implementation details

- move `docs/exec-plans/active/06-discord-image-input.md` into `docs/exec-plans/completed/`
- update the plan's living-document sections so the archive decision and deferred live proof are recorded explicitly
- update `docs/exec-plans/index.md` so there are no active plans left and 06 appears under recently completed plans
- expand `docs/exec-plans/tech-debt-tracker.md` so the existing Discord smoke-test entry also covers live image-attachment validation

## Test coverage

- `make test`
- `make lint`

## Breaking changes

- None

## Notes

- this PR only changes planning and tracking documents
- the untracked local `run` file was left untouched and is not part of this PR

Created by Codex
