### PR TITLE
Remove verbose output from the default make test target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ help: Makefile
 ## test: Run unittest
 .PHONY: test
 test:
-	@go test -v $(TESTARGS) ./...
+	@go test $(TESTARGS) ./...
 
 ## lint: Run lint
 .PHONY: lint


### PR DESCRIPTION
## Summary

- remove the `-v` flag from the `make test` target
- keep test execution behavior the same while reducing default log noise

## Background

The current `Makefile` runs `go test -v ./...` for the default `make test` target. That produces very verbose output even when contributors only want the default package-level pass/fail summary.

## Related issue(s)

- None

## Implementation details

- update `Makefile` so the `test` target now runs `go test $(TESTARGS) ./...`
- leave the rest of the Makefile and lint workflow unchanged

## Test coverage

- `make test`
- `make lint`

## Breaking changes

- None

## Notes

- contributors can still pass explicit verbosity-related arguments through `TESTARGS` when needed
- the untracked local `run` file was left untouched and is not part of this PR

Created by Codex
