### PR TITLE
Use CLAW_DATADIR for sqlite storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ These variables are required:
 - `CLAW_TIMEZONE`
 - `CLAW_DISCORD_TOKEN`
 - `CLAW_CODEX_WORKDIR`
-- `CLAW_SQLITE_PATH`
+- `CLAW_DATADIR`
 - `CLAW_CODEX_EXECUTABLE`
 
 Example launch:
@@ -218,10 +218,12 @@ CLAW_TIMEZONE=Asia/Tokyo \
 CLAW_DISCORD_TOKEN=your-discord-token \
 CLAW_DISCORD_GUILD_ID=your-test-guild-id \
 CLAW_CODEX_WORKDIR=/absolute/path/to/workdir \
-CLAW_SQLITE_PATH=/tmp/39claw.sqlite \
+CLAW_DATADIR=/tmp/39claw \
 CLAW_CODEX_EXECUTABLE=/absolute/path/to/codex \
 go run ./cmd/39claw
 ```
+
+39claw stores its SQLite database at `39claw.sqlite` inside `CLAW_DATADIR`.
 
 If `CLAW_DISCORD_GUILD_ID` is set, 39claw registers commands in that guild for faster testing. If it is omitted, commands are registered globally.
 
@@ -247,8 +249,8 @@ If you are running in `task` mode, create a task first with `/task new <name>`.
   - Discord bot token
 - `CLAW_CODEX_WORKDIR`
   - working directory passed to Codex
-- `CLAW_SQLITE_PATH`
-  - SQLite database path
+- `CLAW_DATADIR`
+  - directory used for local state; the SQLite database path is fixed to `39claw.sqlite` inside this directory
 - `CLAW_CODEX_EXECUTABLE`
   - path to the `codex` executable
 

--- a/cmd/39claw/main_test.go
+++ b/cmd/39claw/main_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"path/filepath"
 	"testing"
 	"time"
 
@@ -46,7 +45,6 @@ func TestRun(t *testing.T) {
 				"CLAW_TIMEZONE":         "Asia/Tokyo",
 				"CLAW_DISCORD_TOKEN":    "discord-token",
 				"CLAW_CODEX_WORKDIR":    "/workspace/project",
-				"CLAW_SQLITE_PATH":      "",
 				"CLAW_CODEX_EXECUTABLE": "codex",
 				"CLAW_LOG_LEVEL":        "debug",
 			},
@@ -64,7 +62,6 @@ func TestRun(t *testing.T) {
 				"CLAW_TIMEZONE":                     "Asia/Tokyo",
 				"CLAW_DISCORD_TOKEN":                "discord-token",
 				"CLAW_CODEX_WORKDIR":                "/workspace/project",
-				"CLAW_SQLITE_PATH":                  "",
 				"CLAW_CODEX_EXECUTABLE":             "codex",
 				"CLAW_CODEX_MODEL":                  "gpt-test",
 				"CLAW_CODEX_SANDBOX_MODE":           "danger-full-access",
@@ -114,7 +111,7 @@ func TestRun(t *testing.T) {
 			}
 
 			if tt.wantErr == "" {
-				env["CLAW_SQLITE_PATH"] = filepath.Join(t.TempDir(), "39claw.db")
+				env["CLAW_DATADIR"] = t.TempDir()
 			}
 
 			err := run(ctx, func(key string) (string, bool) {

--- a/docs/design-docs/implementation-spec.md
+++ b/docs/design-docs/implementation-spec.md
@@ -129,7 +129,7 @@ The expected variables are:
 - `CLAW_DISCORD_TOKEN`
 - `CLAW_DISCORD_GUILD_ID`
 - `CLAW_CODEX_WORKDIR`
-- `CLAW_SQLITE_PATH`
+- `CLAW_DATADIR`
 - `CLAW_CODEX_EXECUTABLE`
 - `CLAW_CODEX_BASE_URL`
 - `CLAW_CODEX_API_KEY`
@@ -143,7 +143,7 @@ The expected variables are:
 - `CLAW_CODEX_NETWORK_ACCESS`
 - `CLAW_LOG_LEVEL`
 
-`CLAW_MODE`, `CLAW_TIMEZONE`, `CLAW_DISCORD_TOKEN`, `CLAW_CODEX_WORKDIR`, `CLAW_SQLITE_PATH`, and `CLAW_CODEX_EXECUTABLE` are required.
+`CLAW_MODE`, `CLAW_TIMEZONE`, `CLAW_DISCORD_TOKEN`, `CLAW_CODEX_WORKDIR`, `CLAW_DATADIR`, and `CLAW_CODEX_EXECUTABLE` are required.
 `CLAW_DISCORD_GUILD_ID`, `CLAW_CODEX_BASE_URL`, `CLAW_CODEX_API_KEY`, `CLAW_CODEX_MODEL`, `CLAW_CODEX_SANDBOX_MODE`, `CLAW_CODEX_ADDITIONAL_DIRECTORIES`, `CLAW_CODEX_SKIP_GIT_REPO_CHECK`, `CLAW_CODEX_APPROVAL_POLICY`, `CLAW_CODEX_MODEL_REASONING_EFFORT`, `CLAW_CODEX_WEB_SEARCH_MODE`, `CLAW_CODEX_NETWORK_ACCESS`, and `CLAW_LOG_LEVEL` are optional.
 `CLAW_MODE` accepts `daily` or `task`.
 `CLAW_TIMEZONE` must be set explicitly for each deployment.
@@ -153,6 +153,7 @@ When `CLAW_DISCORD_GUILD_ID` is set, slash commands are overwritten in that guil
 `CLAW_CODEX_APPROVAL_POLICY` defaults to `never` when omitted.
 `CLAW_CODEX_WEB_SEARCH_MODE` defaults to `live` when omitted.
 `CLAW_CODEX_ADDITIONAL_DIRECTORIES` uses the OS path-list separator such as `:` on Unix systems.
+`CLAW_DATADIR` points to a directory, and the SQLite database file is always stored as `39claw.sqlite` inside that directory.
 
 ## Validation Targets
 

--- a/docs/exec-plans/active/07-instance-specific-root-command.md
+++ b/docs/exec-plans/active/07-instance-specific-root-command.md
@@ -169,7 +169,7 @@ Run all commands from `/home/filepang/playground/39claw`.
     CLAW_DISCORD_GUILD_ID=...
     CLAW_DISCORD_COMMAND_NAME=release
     CLAW_CODEX_WORKDIR=/absolute/path/to/workdir
-    CLAW_SQLITE_PATH=/tmp/39claw.sqlite
+    CLAW_DATADIR=/tmp/39claw
     CLAW_CODEX_EXECUTABLE=/absolute/path/to/codex
     go run ./cmd/39claw
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -22,6 +22,7 @@ type Config struct {
 	TimezoneName               string
 	DiscordToken               string
 	DiscordGuildID             string
+	DataDir                    string
 	SQLitePath                 string
 	CodexExecutable            string
 	CodexBaseURL               string
@@ -48,7 +49,7 @@ func LoadFromLookup(lookup func(string) (string, bool)) (Config, error) {
 		"CLAW_TIMEZONE",
 		"CLAW_DISCORD_TOKEN",
 		"CLAW_CODEX_WORKDIR",
-		"CLAW_SQLITE_PATH",
+		"CLAW_DATADIR",
 		"CLAW_CODEX_EXECUTABLE",
 	}
 
@@ -115,7 +116,8 @@ func LoadFromLookup(lookup func(string) (string, bool)) (Config, error) {
 		TimezoneName:               values["CLAW_TIMEZONE"],
 		DiscordToken:               values["CLAW_DISCORD_TOKEN"],
 		DiscordGuildID:             values["CLAW_DISCORD_GUILD_ID"],
-		SQLitePath:                 values["CLAW_SQLITE_PATH"],
+		DataDir:                    values["CLAW_DATADIR"],
+		SQLitePath:                 sqlitePath(values["CLAW_DATADIR"]),
 		CodexExecutable:            values["CLAW_CODEX_EXECUTABLE"],
 		CodexBaseURL:               values["CLAW_CODEX_BASE_URL"],
 		CodexAPIKey:                values["CLAW_CODEX_API_KEY"],
@@ -130,6 +132,10 @@ func LoadFromLookup(lookup func(string) (string, bool)) (Config, error) {
 		CodexNetworkAccess:         networkAccess,
 		LogLevel:                   logLevel,
 	}, nil
+}
+
+func sqlitePath(dataDir string) string {
+	return filepath.Join(dataDir, "39claw.sqlite")
 }
 
 func parseMode(raw string) (Mode, error) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -22,7 +23,7 @@ func TestLoadFromLookup(t *testing.T) {
 				"CLAW_DISCORD_TOKEN":                "discord-token",
 				"CLAW_DISCORD_GUILD_ID":             "guild-1",
 				"CLAW_CODEX_WORKDIR":                "/workspace/project",
-				"CLAW_SQLITE_PATH":                  "/tmp/39claw.db",
+				"CLAW_DATADIR":                      "/tmp/39claw-data",
 				"CLAW_CODEX_EXECUTABLE":             "/usr/local/bin/codex",
 				"CLAW_CODEX_BASE_URL":               "https://example.test",
 				"CLAW_CODEX_API_KEY":                "api-key",
@@ -41,7 +42,8 @@ func TestLoadFromLookup(t *testing.T) {
 				TimezoneName:               "Asia/Tokyo",
 				DiscordToken:               "discord-token",
 				DiscordGuildID:             "guild-1",
-				SQLitePath:                 "/tmp/39claw.db",
+				DataDir:                    "/tmp/39claw-data",
+				SQLitePath:                 filepath.Join("/tmp/39claw-data", "39claw.sqlite"),
 				CodexExecutable:            "/usr/local/bin/codex",
 				CodexBaseURL:               "https://example.test",
 				CodexAPIKey:                "api-key",
@@ -64,14 +66,15 @@ func TestLoadFromLookup(t *testing.T) {
 				"CLAW_TIMEZONE":         "UTC",
 				"CLAW_DISCORD_TOKEN":    "discord-token",
 				"CLAW_CODEX_WORKDIR":    "/workspace/project",
-				"CLAW_SQLITE_PATH":      "/tmp/39claw.db",
+				"CLAW_DATADIR":          "/tmp/39claw-data",
 				"CLAW_CODEX_EXECUTABLE": "codex",
 			},
 			want: Config{
 				Mode:            ModeDaily,
 				TimezoneName:    "UTC",
 				DiscordToken:    "discord-token",
-				SQLitePath:      "/tmp/39claw.db",
+				DataDir:         "/tmp/39claw-data",
+				SQLitePath:      filepath.Join("/tmp/39claw-data", "39claw.sqlite"),
 				CodexExecutable: "codex",
 				CodexWorkdir:    "/workspace/project",
 				LogLevel:        "info",
@@ -91,7 +94,7 @@ func TestLoadFromLookup(t *testing.T) {
 				"CLAW_TIMEZONE":         "UTC",
 				"CLAW_DISCORD_TOKEN":    "discord-token",
 				"CLAW_CODEX_WORKDIR":    "/workspace/project",
-				"CLAW_SQLITE_PATH":      "/tmp/39claw.db",
+				"CLAW_DATADIR":          "/tmp/39claw-data",
 				"CLAW_CODEX_EXECUTABLE": "codex",
 			},
 			wantErr: `unsupported CLAW_MODE "nightly"`,
@@ -103,7 +106,7 @@ func TestLoadFromLookup(t *testing.T) {
 				"CLAW_TIMEZONE":                  "UTC",
 				"CLAW_DISCORD_TOKEN":             "discord-token",
 				"CLAW_CODEX_WORKDIR":             "/workspace/project",
-				"CLAW_SQLITE_PATH":               "/tmp/39claw.db",
+				"CLAW_DATADIR":                   "/tmp/39claw-data",
 				"CLAW_CODEX_EXECUTABLE":          "codex",
 				"CLAW_CODEX_SKIP_GIT_REPO_CHECK": "not-bool",
 			},
@@ -116,7 +119,7 @@ func TestLoadFromLookup(t *testing.T) {
 				"CLAW_TIMEZONE":             "UTC",
 				"CLAW_DISCORD_TOKEN":        "discord-token",
 				"CLAW_CODEX_WORKDIR":        "/workspace/project",
-				"CLAW_SQLITE_PATH":          "/tmp/39claw.db",
+				"CLAW_DATADIR":              "/tmp/39claw-data",
 				"CLAW_CODEX_EXECUTABLE":     "codex",
 				"CLAW_CODEX_NETWORK_ACCESS": "maybe",
 			},
@@ -129,7 +132,7 @@ func TestLoadFromLookup(t *testing.T) {
 				"CLAW_TIMEZONE":         "Mars/Olympus",
 				"CLAW_DISCORD_TOKEN":    "discord-token",
 				"CLAW_CODEX_WORKDIR":    "/workspace/project",
-				"CLAW_SQLITE_PATH":      "/tmp/39claw.db",
+				"CLAW_DATADIR":          "/tmp/39claw-data",
 				"CLAW_CODEX_EXECUTABLE": "codex",
 			},
 			wantErr: `load timezone "Mars/Olympus": unknown time zone Mars/Olympus`,
@@ -180,6 +183,10 @@ func TestLoadFromLookup(t *testing.T) {
 
 			if got.DiscordGuildID != tt.want.DiscordGuildID {
 				t.Fatalf("DiscordGuildID = %q, want %q", got.DiscordGuildID, tt.want.DiscordGuildID)
+			}
+
+			if got.DataDir != tt.want.DataDir {
+				t.Fatalf("DataDir = %q, want %q", got.DataDir, tt.want.DataDir)
 			}
 
 			if got.SQLitePath != tt.want.SQLitePath {


### PR DESCRIPTION
## Summary
- replace `CLAW_SQLITE_PATH` with `CLAW_DATADIR`
- derive the SQLite database path as `<CLAW_DATADIR>/39claw.sqlite`
- update config tests, startup tests, and docs for the new environment contract

## Background
The runtime previously required a full SQLite file path through `CLAW_SQLITE_PATH`. This change simplifies deployment configuration by accepting a data directory instead and standardizing the database filename.

## Related issue(s)
- None

## Implementation details
- added `DataDir` to the loaded config and compute `SQLitePath` from it
- kept store initialization behavior unchanged by continuing to open the computed SQLite path
- updated startup/config tests to pass `CLAW_DATADIR`
- updated README and implementation docs to describe the fixed database filename

## Test coverage
- `go test ./internal/config ./cmd/39claw`
- `make test`
- `make lint`

## Breaking changes
- `CLAW_SQLITE_PATH` is no longer accepted
- deployments must now set `CLAW_DATADIR`

## Notes
- the SQLite database file is always created as `39claw.sqlite` inside the configured data directory

Created by Codex