### PR TITLE
Harden local secret setup for Discord and Codex credentials

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,25 @@
+# Copy this file to .env.local and replace every placeholder before running 39claw.
+# Keep real secrets only in ignored local files such as .env.local.
+
+CLAW_MODE=task
+CLAW_TIMEZONE=Asia/Tokyo
+CLAW_DISCORD_TOKEN=replace-with-your-discord-token
+CLAW_DISCORD_GUILD_ID=replace-with-your-test-guild-id
+CLAW_CODEX_WORKDIR=/absolute/path/to/workdir
+CLAW_DATADIR=/tmp/39claw
+CLAW_CODEX_EXECUTABLE=/absolute/path/to/codex
+
+# Optional Codex configuration.
+CLAW_CODEX_BASE_URL=
+CLAW_CODEX_API_KEY=
+CLAW_CODEX_MODEL=
+CLAW_CODEX_SANDBOX_MODE=
+CLAW_CODEX_ADDITIONAL_DIRECTORIES=
+CLAW_CODEX_SKIP_GIT_REPO_CHECK=
+CLAW_CODEX_APPROVAL_POLICY=
+CLAW_CODEX_MODEL_REASONING_EFFORT=
+CLAW_CODEX_WEB_SEARCH_MODE=
+CLAW_CODEX_NETWORK_ACCESS=
+
+# Optional runtime configuration.
+CLAW_LOG_LEVEL=info

--- a/.envrc.example
+++ b/.envrc.example
@@ -1,0 +1,4 @@
+# Copy this file to .envrc, then run `direnv allow`.
+# Keep secrets in .env.local rather than in .envrc itself.
+
+dotenv_if_exists .env.local

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
+.direnv/
+.env
+.env.local
+.env.*.local
 .envrc
 .tools

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,6 +58,15 @@ The repository includes a `Makefile` for common development checks.
 - run unit tests with `make test`
 - run lint checks with `make lint`
 
+### 5. Keep local secrets out of tracked files
+
+For local development:
+
+- store real credentials in ignored local files such as `.env.local`
+- load local environment variables through an ignored `.envrc`
+- keep checked-in examples such as `.env.example` and `.envrc.example` placeholder-only
+- do not add plaintext bot tokens or API keys to tracked helper scripts, launcher snippets, or documentation examples
+
 ## Reference Documents
 
 ### Primary implementation reference

--- a/README.md
+++ b/README.md
@@ -82,6 +82,21 @@ Before you start, make sure you have:
 - a working directory that Codex should operate in
 - Go installed if you plan to run from source
 
+## Local Secret Workflow
+
+The recommended local-development workflow is:
+
+1. copy `.env.example` to `.env.local`
+2. replace every placeholder in `.env.local`
+3. copy `.envrc.example` to `.envrc`
+4. run `direnv allow`
+5. start 39claw without pasting secrets into shell history
+
+`.env.local`, `.envrc`, and `.direnv/` are ignored by Git in this repository.
+Keep real Discord tokens, Codex API keys, and any other credentials only in those ignored files.
+Checked-in examples must contain placeholders only.
+If you do not use `direnv`, keep the same rule: load secrets from an ignored local file instead of tracked scripts or inline launch snippets.
+
 <details>
 <summary>Codex Installation Guide</summary>
 
@@ -138,7 +153,7 @@ If this is your first time running a Discord bot, do this before the quick start
 - open the Discord Developer Portal
 - create a new application
 - add a Bot user to that application
-- copy the bot token and use it as `CLAW_DISCORD_TOKEN`
+- copy the bot token and store it in your ignored `.env.local` file as `CLAW_DISCORD_TOKEN`
 
 ### 2. Enable the required intent
 
@@ -201,7 +216,10 @@ Pick one:
 
 ### 2. Set the required environment variables
 
-These variables are required:
+The safe-default setup is to keep your local values in `.env.local` and load them through `.envrc`.
+Start by copying `.env.example` to `.env.local`, then replace the placeholders with real local values.
+
+These variables are required in `.env.local`:
 
 - `CLAW_MODE`
 - `CLAW_TIMEZONE`
@@ -210,16 +228,12 @@ These variables are required:
 - `CLAW_DATADIR`
 - `CLAW_CODEX_EXECUTABLE`
 
-Example launch:
+Recommended startup flow:
 
 ```bash
-CLAW_MODE=task \
-CLAW_TIMEZONE=Asia/Tokyo \
-CLAW_DISCORD_TOKEN=your-discord-token \
-CLAW_DISCORD_GUILD_ID=your-test-guild-id \
-CLAW_CODEX_WORKDIR=/absolute/path/to/workdir \
-CLAW_DATADIR=/tmp/39claw \
-CLAW_CODEX_EXECUTABLE=/absolute/path/to/codex \
+cp .env.example .env.local
+cp .envrc.example .envrc
+direnv allow
 go run ./cmd/39claw
 ```
 
@@ -246,7 +260,7 @@ If you are running in `task` mode, create a task first with `/task new <name>`.
 - `CLAW_TIMEZONE`
   - the timezone used for daily rollover
 - `CLAW_DISCORD_TOKEN`
-  - Discord bot token
+  - Discord bot token stored in your ignored local env file
 - `CLAW_CODEX_WORKDIR`
   - working directory passed to Codex
 - `CLAW_DATADIR`

--- a/docs/design-docs/implementation-spec.md
+++ b/docs/design-docs/implementation-spec.md
@@ -154,6 +154,8 @@ When `CLAW_DISCORD_GUILD_ID` is set, slash commands are overwritten in that guil
 `CLAW_CODEX_WEB_SEARCH_MODE` defaults to `live` when omitted.
 `CLAW_CODEX_ADDITIONAL_DIRECTORIES` uses the OS path-list separator such as `:` on Unix systems.
 `CLAW_DATADIR` points to a directory, and the SQLite database file is always stored as `39claw.sqlite` inside that directory.
+For local development, the safe-default workflow is an ignored `.env.local` file loaded through an ignored `.envrc`.
+Checked-in examples such as `.env.example` and `.envrc.example` must use placeholders only and must not contain live credentials.
 
 ## Validation Targets
 


### PR DESCRIPTION
## Summary

- add ignored local-secret file patterns for local development
- add placeholder-only `.env.example` and `.envrc.example` files
- update contributor and setup docs to recommend a safe local secret workflow

## Background

Local development previously relied on inline environment-variable examples that made it easy to paste live Discord or Codex credentials into shell history or tracked helper snippets.
This change introduces one documented safe-default workflow without changing the existing `CLAW_*` configuration interface.

## Related issue(s)

- Closes #28

## Implementation details

- ignore `.env`, `.env.local`, `.env.*.local`, and `.direnv/` in Git
- add `.env.example` with placeholder values only
- add `.envrc.example` that loads `.env.local` through `direnv`
- update `README.md` quick start and Discord setup guidance to keep secrets in ignored local files
- update `AGENTS.md` and `docs/design-docs/implementation-spec.md` so contributor guidance matches the new workflow

## Test coverage

- `make test`
- `make lint`

## Breaking changes

None.

## Notes

- The remote repository does not currently expose `origin/main`, so this work was branched from `origin/master`, which is the current default branch.
- Contributors who do not use `direnv` should still keep the same safety rule and load secrets from ignored local files rather than tracked scripts or inline shell snippets.

Created by Codex
