### PR TITLE
docs: define task mode worktree isolation

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -55,7 +55,7 @@ Instead, it routes Discord interactions into Codex threads that operate against 
 The distinction between `daily` mode and `task` mode is therefore not a different execution engine.
 It is a difference in the role of the repository that Codex is operating against.
 
-- In `task` mode, the repository is an execution-oriented work repository where Codex can help perform operational tasks such as code changes, pull request handling, and release workflows.
+- In `task` mode, the configured workdir must be a Git repository that serves as the source repository for task-isolated worktrees, allowing Codex to help perform operational tasks such as code changes, pull request handling, and release workflows.
 - In `daily` mode, the repository is a knowledge-oriented repository that primarily contains instructions and documentation, allowing Codex to answer questions by following local guidance and searching the knowledge base.
 
 Both modes share the same Codex-native foundation.
@@ -165,7 +165,7 @@ The thread store persists the mapping between:
 - logical thread key
 - Codex thread ID
 
-In `task` mode, a separate state store is also needed to track the currently selected task for a user within the current bot instance.
+In `task` mode, the thread store must also track task records, the currently selected task for a user within the current bot instance, and task worktree metadata such as branch name, worktree path, and worktree lifecycle state.
 
 ### 6.5 Queue Coordinator
 
@@ -189,6 +189,7 @@ Responsibilities:
 
 - resume remote threads by ID
 - send a turn to Codex
+- accept the effective working directory for the turn
 - return the resulting remote thread ID for persistence when the first turn creates it
 - normalize Codex output for the application layer
 
@@ -244,7 +245,7 @@ Tradeoffs:
 Purpose:
 
 - support longer-running work streams with explicit task identity
-- support execution-oriented repository work through Discord
+- support execution-oriented repository work through Discord using task-isolated Git worktrees
 
 Logical key concept:
 
@@ -254,10 +255,13 @@ thread_key = user + task_id
 
 Behavior:
 
+- `task` mode requires `CLAW_CODEX_WORKDIR` to be a Git repository
 - normal messages require an active task context
+- each task reserves its own branch identity and eventually its own Git worktree
 - messages route to the thread bound to the active task
+- the first normal message for a task may lazily create the task worktree before Codex runs
 - changing the active task changes the target thread
-- each task maps to a distinct Codex conversation thread, so switching tasks also switches execution context
+- each task maps to a distinct Codex conversation thread, so switching tasks also switches execution context and working directory once the task worktree exists
 
 Minimum v1 UX requirements:
 
@@ -276,6 +280,7 @@ Tradeoffs:
 
 - requires more explicit user interaction
 - requires task-state persistence in addition to thread binding
+- requires Git worktree lifecycle management and cleanup policy
 
 ## 8. Request Flow
 
@@ -308,6 +313,7 @@ The minimum persistent state for v1 is:
 
 - thread bindings
 - active task selection for `task` mode
+- task records with task worktree metadata for `task` mode
 
 The bounded queued-message backlog is not persisted.
 It exists only in memory while the process is running.
@@ -340,6 +346,7 @@ v1 should include:
 - `task` mode
 - local persistent thread binding
 - local persistent active task state
+- task-isolated Git worktrees for `task` mode
 - structured logging with `log/slog`
 
 v1 should not include:

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Use `daily` mode when you want a lightweight shared assistant for day-to-day wor
 Use `task` mode when you want durable work streams that continue across multiple days.
 
 - each user works through an explicit active task
+- each task eventually runs in its own task-specific Git worktree
 - `/<instance-command> action:task-*` controls which task is active
 - normal conversation does not run until a task is selected
 
@@ -88,6 +89,7 @@ Before you start, make sure you have:
 - the `codex` executable available on the machine that runs 39claw
 - a writable SQLite file path
 - a working directory that Codex should operate in
+- a Git repository workdir if you plan to use `task` mode
 - Go installed if you plan to run from source
 
 ## Local Secret Workflow
@@ -221,6 +223,9 @@ Pick one:
 
 - `CLAW_MODE=daily`
 - `CLAW_MODE=task`
+
+If you choose `task`, `CLAW_CODEX_WORKDIR` must point to a Git repository.
+39claw treats that repository as the source repository for task-specific worktrees stored under `CLAW_DATADIR`.
 
 ### 2. Set the required environment variables
 

--- a/docs/design-docs/architecture-overview.md
+++ b/docs/design-docs/architecture-overview.md
@@ -24,7 +24,7 @@ This leads to two distinct mode families on the same foundation:
 - `daily`
   - knowledge-oriented interaction against repository instructions and documentation
 - `task`
-  - execution-oriented interaction against a work repository where Codex can help perform operational tasks
+  - execution-oriented interaction against a Git work repository where each task eventually runs inside its own task-specific worktree
 
 The detailed rationale for these modes lives in `ARCHITECTURE.md` and `thread-modes.md`.
 
@@ -55,11 +55,11 @@ Converts Discord context into a logical thread key according to the globally con
 
 ### Thread Store
 
-Persists the local continuity data that lets 39claw resume the correct Codex thread.
+Persists the local continuity data that lets 39claw resume the correct Codex thread, plus task and task-worktree metadata in `task` mode.
 
 ### Codex Gateway
 
-Owns the direct integration with the Codex SDK or Codex API layer.
+Owns the direct integration with the Codex SDK or Codex API layer, including the effective working directory for each turn.
 
 ### Response Presenter
 

--- a/docs/design-docs/implementation-spec.md
+++ b/docs/design-docs/implementation-spec.md
@@ -19,7 +19,7 @@ Discord runtime -> application service -> thread policy -> SQLite store -> Codex
 The bot runs with one global configuration per instance:
 
 - one thread mode
-- one working directory
+- one source working directory
 - one timezone
 
 v1 does not introduce a local agent loop or local tool orchestration.
@@ -82,7 +82,7 @@ The storage model uses three tables:
   - stores `mode`, `logical_thread_key`, `codex_thread_id`, nullable `task_id`, `created_at`, and `updated_at`
   - enforces one binding per `(mode, logical_thread_key)`
 - `tasks`
-  - stores `task_id`, `discord_user_id`, `task_name`, `status`, `created_at`, `updated_at`, and nullable `closed_at`
+  - stores `task_id`, `discord_user_id`, `task_name`, `status`, `branch_name`, nullable `base_ref`, nullable `worktree_path`, `worktree_status`, `created_at`, `updated_at`, nullable `closed_at`, nullable `worktree_created_at`, nullable `worktree_pruned_at`, and nullable `last_used_at`
   - uses ULID strings for `task_id`
   - allows duplicate task names for the same user
 - `active_tasks`
@@ -90,6 +90,7 @@ The storage model uses three tables:
   - enforces one active task per Discord user within a bot instance
 
 Task status is `open` or `closed`.
+Task worktree status is `pending`, `ready`, `failed`, or `pruned`.
 Closing a task marks it `closed` and removes its `active_tasks` mapping when that task is currently active.
 `action:task-list` should show open tasks and clearly mark the active task for the requesting user.
 
@@ -112,6 +113,10 @@ When a bot instance runs in `task` mode, the root command should expose `action:
 
 When a bot instance runs in `task` mode, normal messages without an active task must not be routed to Codex.
 They should return actionable guidance that points the user to `action:task-new`, `action:task-list`, or `action:task-switch` on the configured root command.
+When a bot instance runs in `task` mode, `CLAW_CODEX_WORKDIR` must be a Git repository.
+`task-new` creates task metadata only; the first normal message for a pending or failed task creates the task worktree lazily from `main` or `master`.
+Once the task worktree is ready, Codex runs with the task-specific `worktree_path` as the effective working directory for that turn.
+Closed tasks keep their task branches, but only the fifteen most recently closed ready tasks keep their worktrees; older closed ready worktrees are force-pruned.
 
 Unsupported non-mention chatter is ignored.
 Mention-only posts that contain no text and no usable image attachments are also ignored.
@@ -151,6 +156,7 @@ The expected variables are:
 `CLAW_MODE` accepts `daily` or `task`.
 `CLAW_TIMEZONE` must be set explicitly for each deployment.
 `CLAW_DISCORD_COMMAND_NAME` must be unique per bot instance, normalized to lowercase, and validated conservatively before Discord registration.
+When `CLAW_MODE=task`, `CLAW_CODEX_WORKDIR` must point to a Git repository and acts as the source repository root for task worktree creation.
 `CLAW_LOG_LEVEL` defaults to `info` when omitted.
 When `CLAW_DISCORD_GUILD_ID` is set, slash commands are overwritten in that guild for faster development feedback.
 `CLAW_CODEX_SANDBOX_MODE` defaults to `workspace-write` when omitted.
@@ -171,8 +177,10 @@ The initial implementation should demonstrate the following observable behavior:
 - In `task` mode, a normal mention without an active task returns guidance instead of routing to Codex.
 - `/<instance-command> action:task-current` shows the active task for the requesting user.
 - `/<instance-command> action:task-new task_name:<name>` creates a task and sets it active for the requesting user.
+- The first normal message for a new task creates a task worktree lazily under `${CLAW_DATADIR}/worktrees/<task_id>` and then runs Codex inside that worktree.
 - `/<instance-command> action:task-switch task_id:<id>` changes the routing target for subsequent normal messages.
 - `/<instance-command> action:task-close task_id:<id>` closes the task and clears active state when the closed task was active.
+- Closed-task worktree retention keeps only the fifteen most recently closed ready worktrees and never deletes the task branches.
 - Existing `daily` and `task` bindings survive process restart through SQLite-backed state.
 - Non-mention chatter is ignored, unsupported non-image-only mention posts stay silent, supported slash commands respond correctly, and long replies are chunked cleanly.
 - Simultaneous requests for the same logical thread do not execute overlapping Codex turns.

--- a/docs/design-docs/index.md
+++ b/docs/design-docs/index.md
@@ -19,6 +19,7 @@ The project direction is intentionally small and opinionated:
 - [Implementation Spec](./implementation-spec.md) - fixes the concrete v1 implementation defaults that sit between the architecture and product specs
 - [Thread Modes](./thread-modes.md) - explains the mode model, behavior, and tradeoffs
 - [State and Storage](./state-and-storage.md) - explains persistence requirements and storage boundaries
+- [Task Mode Worktrees](./task-mode-worktrees.md) - defines task-isolated Git worktrees, lazy creation, and closed-task pruning
 
 ## Current v1 Direction
 

--- a/docs/design-docs/state-and-storage.md
+++ b/docs/design-docs/state-and-storage.md
@@ -48,6 +48,22 @@ user -> active_task_id
 
 This allows ordinary messages to be routed without forcing the user to repeat the task identifier in every message.
 
+### 3. Task Worktree Metadata
+
+This state is only required for `task` mode.
+
+Each task needs enough metadata to create and later manage an isolated Git worktree.
+
+That includes:
+
+- reserved branch name
+- detected base ref
+- worktree path
+- worktree lifecycle state
+- creation, prune, and last-used timestamps
+
+This metadata lets 39claw decide whether a task needs lazy worktree creation, whether a closed task is eligible for pruning, and which working directory Codex should use for the next turn.
+
 ## Storage Direction for v1
 
 SQLite is the preferred v1 storage backend.
@@ -61,9 +77,10 @@ Reasons:
 
 ## Schema Direction
 
-The exact schema is not fixed yet, but the current concept points toward:
+The current concept points toward:
 
 - `thread_bindings`
+- `tasks`
 - `active_tasks`
 
 The design should favor explicit structured columns over packing all data into a single opaque key string, unless implementation simplicity proves more valuable.
@@ -75,5 +92,6 @@ The following are not currently required:
 - full local transcript storage for every message
 - analytics-oriented event warehousing
 - cross-instance distributed coordination
+- pruning or deleting task branches automatically
 
 The initial storage model should stay focused on continuity and thread routing.

--- a/docs/design-docs/task-mode-worktrees.md
+++ b/docs/design-docs/task-mode-worktrees.md
@@ -1,0 +1,184 @@
+# Task Mode Worktrees
+
+This document defines the current v1 design for task-isolated Git worktrees in `task` mode.
+
+The goal is to make a `task` mean more than a saved conversation label.
+Each task should represent an isolated repository workspace with its own Codex thread, branch name, and working directory lifecycle.
+
+## Why This Exists
+
+Without filesystem isolation, `task` mode can preserve conversation context but still mixes file edits in one shared checkout.
+That weakens the meaning of task switching and makes later task-oriented features harder to define.
+
+With task-isolated worktrees:
+
+- each task owns its own working directory
+- switching tasks also switches the Codex execution workspace
+- repository state for one task does not silently leak into another task
+
+This turns `task` mode into an execution-oriented workflow instead of a long-lived chat label.
+
+## Core Decisions
+
+- `task` mode is valid only when `CLAW_CODEX_WORKDIR` points to a Git repository.
+- In `task` mode, `CLAW_CODEX_WORKDIR` is the source repository root, not the final Codex working directory for every turn.
+- Each task owns one task-specific branch name.
+- Each task may also own one task-specific Git worktree created from that source repository.
+- Worktrees are created lazily on the first normal message that needs to run Codex for the task.
+- The base ref for worktree creation is detected automatically by checking `main` first and `master` second.
+- Closing a task does not delete its branch.
+- Closed-task worktrees are treated as disposable cache-like workspaces.
+- The system keeps the most recent fifteen closed-task worktrees and prunes older closed-task worktrees with forced removal.
+
+## Repository Model
+
+In `daily` mode, the configured Codex working directory remains the directory passed through `CLAW_CODEX_WORKDIR`.
+
+In `task` mode, the repository model changes:
+
+- source repository root: `CLAW_CODEX_WORKDIR`
+- task worktree root: `${CLAW_DATADIR}/worktrees/<task_id>`
+- Codex working directory for a task turn: the task's `worktree_path` once the worktree is ready
+
+This means the configured workdir remains globally important, but in `task` mode it acts as the shared Git source from which task worktrees are derived.
+
+## Task State Model
+
+The task record keeps both task lifecycle state and worktree lifecycle state.
+Those are separate concerns and must not be collapsed into one field.
+
+### Task status
+
+- `open`
+- `closed`
+
+### Worktree status
+
+- `pending`
+  - the task exists but no worktree has been created yet
+- `ready`
+  - the worktree exists and can be used for Codex turns
+- `failed`
+  - a worktree creation attempt failed and should be retried on the next normal message
+- `pruned`
+  - the task once had a worktree, but that worktree was removed during closed-task cleanup
+
+## Task Creation
+
+`/<instance-command> action:task-new task_name:<name>` creates the task record and sets it active.
+
+Task creation does not create a worktree immediately.
+Instead, it records the metadata needed for later creation:
+
+- `task_id`
+- `task_name`
+- `discord_user_id`
+- `branch_name`
+- `status=open`
+- `worktree_status=pending`
+
+The branch name should be generated once at task creation time and treated as immutable task identity metadata.
+
+## Lazy Worktree Creation
+
+The first normal message sent to an active task with `worktree_status=pending` or `worktree_status=failed` triggers worktree preparation.
+
+The preparation flow is:
+
+1. load the active task record
+2. detect the base ref by checking for `main`, then `master`, in the source repository
+3. create the task worktree under `${CLAW_DATADIR}/worktrees/<task_id>`
+4. create or attach the reserved task branch for that worktree
+5. persist `base_ref`, `worktree_path`, `worktree_created_at`, and `worktree_status=ready`
+6. run Codex with the task-specific worktree path as the working directory
+
+If any step fails, Codex must not run for that turn.
+
+## Task Switching
+
+Task switching remains intentionally small.
+
+`/<instance-command> action:task-switch task_id:<id>` changes only the active task pointer for the requesting user.
+It does not:
+
+- run Git checkout in the current shell
+- mutate another task's worktree
+- eagerly prepare the destination task worktree
+
+The next normal message determines whether the destination task needs lazy worktree creation before Codex runs.
+
+## Task Closing and Worktree Retention
+
+Closing a task changes the task status to `closed` and clears active-task state if the closed task was active.
+
+Closing a task does not delete:
+
+- the task record
+- the task branch
+- the task's Codex thread binding
+
+After close succeeds, the system applies closed-task worktree retention:
+
+- open-task worktrees are never pruned
+- closed tasks are sorted by `closed_at` descending
+- the most recent fifteen closed tasks with `worktree_status=ready` keep their worktrees
+- older closed tasks with `worktree_status=ready` are pruned by `git worktree remove --force`
+- when pruning succeeds, the task becomes `worktree_status=pruned` and records `worktree_pruned_at`
+
+The branch is intentionally left behind so repository history and manual recovery options remain available even after workspace cleanup.
+
+## Failure and Retry Model
+
+Task creation should fail only if the task record itself cannot be created or activated.
+No Git operation should run during `task-new`.
+
+Lazy worktree creation failure is handled at normal-message time:
+
+- the user receives a short actionable failure message
+- the server logs the detailed cause
+- the task remains `open`
+- the task moves to `worktree_status=failed`
+- the next normal message retries worktree preparation automatically
+
+Pruning failure must not reopen or invalidate the closed task.
+If pruning fails, the system should keep the task in `closed + ready`, log the failure, and try again during a later cleanup opportunity.
+
+## Persistence Direction
+
+The `tasks` table now carries task worktree metadata in addition to task identity:
+
+- `branch_name`
+- `base_ref`
+- `worktree_path`
+- `worktree_status`
+- `worktree_created_at`
+- `worktree_pruned_at`
+- `last_used_at`
+
+`branch_name` is fixed at task creation.
+`base_ref` and `worktree_path` are populated on first successful worktree creation and remain stable afterward.
+`last_used_at` is updated whenever a normal message successfully uses the task context.
+
+## User Experience Consequences
+
+This design changes the meaning of `task` mode in important ways:
+
+- a task is now an isolated workspace, not only an isolated conversation
+- task switching becomes a context switch between independent repository workspaces
+- task creation is fast because the filesystem cost is deferred
+- old closed-task workspaces do not grow without bound on disk
+
+The tradeoff is that the first normal message for a task may perform extra Git setup work before Codex can answer.
+
+## Implementation Notes
+
+This design affects:
+
+- startup validation for `task` mode
+- task persistence schema
+- task command orchestration
+- normal-message orchestration before Codex execution
+- Codex working-directory resolution
+- task-close cleanup behavior
+
+Implementation sequencing belongs in the active ExecPlan, but all later implementation work should preserve the product and lifecycle rules in this document.

--- a/docs/design-docs/thread-modes.md
+++ b/docs/design-docs/thread-modes.md
@@ -57,6 +57,7 @@ Costs:
 
 `task` mode is designed for longer-running, explicit work streams.
 The user should be able to keep context attached to a named task instead of a date bucket.
+Each task should also map to an isolated Git worktree instead of sharing one mutable checkout.
 
 ### Thread Key Concept
 
@@ -73,9 +74,13 @@ thread_key = user + task_id
 
 ### Behavior
 
+- the configured `CLAW_CODEX_WORKDIR` must be a Git repository
 - a current task must exist before normal messages can be routed
-- messages are sent to the Codex thread associated with the active task
+- `task-new` creates task metadata immediately but defers worktree creation
+- the first normal message for a task creates the task worktree lazily when needed
+- messages are sent to the Codex thread associated with the active task and use that task's worktree once it exists
 - changing tasks changes the target logical thread
+- closed-task worktrees are retained only for the fifteen most recently closed ready tasks
 
 ### UX Requirements
 
@@ -99,11 +104,14 @@ Benefits:
 
 - strong control over context boundaries
 - better fit for issue-based or project-based workflows
+- task switching changes both conversation context and filesystem workspace
 
 Costs:
 
 - more operational and UX complexity
 - requires explicit task lifecycle management
+- requires Git-only startup validation for `task` mode
+- requires worktree creation, retry, and pruning behavior
 
 ## Why Both Modes Exist
 

--- a/docs/exec-plans/active/08-task-mode-worktree-isolation.md
+++ b/docs/exec-plans/active/08-task-mode-worktree-isolation.md
@@ -1,0 +1,243 @@
+# Add task-isolated Git worktrees to `task` mode
+
+This ExecPlan is a living document. The sections `Progress`, `Surprises & Discoveries`, `Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work proceeds.
+
+This document must be maintained in accordance with `.agents/PLANS.md`.
+
+## Purpose / Big Picture
+
+After this plan, `task` mode should no longer run every task inside one shared checkout. A user should be able to create a task, send the first normal message, and have 39claw prepare a task-specific Git worktree under `CLAW_DATADIR` before Codex runs. Switching tasks should then switch both the Codex thread context and the isolated working directory used for execution.
+
+The user-visible proof is practical. In `task` mode, creating two tasks and sending one normal message to each should produce two distinct task worktrees under `${CLAW_DATADIR}/worktrees`, each bound to its own task branch and Codex thread. Closing many tasks should retain only the fifteen most recently closed ready worktrees while leaving the task branches intact.
+
+## Progress
+
+- [x] (2026-04-04 23:57Z) Captured the new task-mode worktree direction, hard Git-repository requirement, lazy creation flow, and closed-task pruning policy in repository documentation.
+- [ ] Extend startup validation so `task` mode refuses non-Git `CLAW_CODEX_WORKDIR` values.
+- [ ] Add task worktree metadata to persistence and migrate the SQLite schema safely.
+- [ ] Route task-mode Codex turns through task-specific worktree paths instead of the global workdir.
+- [ ] Implement lazy worktree creation, retry behavior, and closed-task pruning.
+- [ ] Add unit and integration coverage for startup validation, lazy creation, retry, and pruning.
+- [ ] Run `make test` and `make lint` after the implementation lands.
+
+## Surprises & Discoveries
+
+- Observation: The current repository already has a useful separation between task lifecycle and thread binding lifecycle, but it does not yet have any persistent concept of task worktree state.
+  Evidence: `internal/app/types.go` and `internal/store/sqlite/store.go`
+
+- Observation: `CLAW_CODEX_SKIP_GIT_REPO_CHECK` already exists because the Codex CLI supports bypassing its own Git validation, but the current application does not impose a task-mode-specific repository requirement before Codex runs.
+  Evidence: `internal/config/config.go`, `cmd/39claw/main.go`, and `internal/codex/exec.go`
+
+- Observation: The current architecture and implementation spec still describe one working directory per bot instance, so both documents must be updated before implementation to avoid misleading later contributors.
+  Evidence: `ARCHITECTURE.md` and `docs/design-docs/implementation-spec.md`
+
+## Decision Log
+
+- Decision: Treat `CLAW_CODEX_WORKDIR` as a hard Git-repository requirement in `task` mode.
+  Rationale: Task switching should mean switching between isolated repository workspaces, not only between saved conversation labels.
+  Date/Author: 2026-04-04 / Codex
+
+- Decision: Create task worktrees lazily on the first normal message instead of during `task-new`.
+  Rationale: Task creation should remain lightweight, and filesystem cost should be paid only when a task is actually used for execution.
+  Date/Author: 2026-04-04 / Codex
+
+- Decision: Detect the task base ref by checking `main` first and `master` second.
+  Rationale: The repository should prefer a simple, fixed v1 rule over additional configuration.
+  Date/Author: 2026-04-04 / Codex
+
+- Decision: Prune only worktrees, not task branches, when closed-task retention exceeds fifteen ready worktrees.
+  Rationale: This keeps disk usage bounded while preserving repository history and manual recovery options.
+  Date/Author: 2026-04-04 / Codex
+
+- Decision: Failed lazy worktree creation should be retried automatically on the next normal message.
+  Rationale: Many failure causes are transient or operator-fixable, so the product should recover without introducing extra task-repair commands in v1.
+  Date/Author: 2026-04-04 / Codex
+
+## Outcomes & Retrospective
+
+This plan is not yet implemented. At this stage, the repository has the architectural and product decisions needed to start coding without reopening the core behavior questions. The main remaining risk is keeping schema migration, task orchestration, and Codex workdir selection aligned so task-mode behavior remains understandable and testable.
+
+## Context and Orientation
+
+39claw is a Discord bot that routes user messages into Codex threads. In `daily` mode, one bot instance uses one shared working directory and one date-derived logical thread key at a time. In `task` mode today, the logical thread key is already `discord_user_id + task_id`, but execution still assumes one global Codex working directory per bot instance.
+
+This plan changes that assumption. In the new design, `task` mode still stores task identity and active-task state in SQLite, but each task also owns metadata for a lazily created Git worktree. The source repository root remains the configured `CLAW_CODEX_WORKDIR`, while the actual Codex working directory for a ready task becomes `${CLAW_DATADIR}/worktrees/<task_id>`.
+
+The most relevant files are:
+
+- `cmd/39claw/main.go`
+  - startup wiring, thread options, and integration assembly
+- `internal/config/config.go`
+  - environment loading and validation
+- `internal/app/types.go`
+  - task and thread-binding data shapes
+- `internal/app/task_service.go`
+  - task command orchestration
+- `internal/app/message_service_impl.go`
+  - normal-message orchestration before Codex runs
+- `internal/store/sqlite/store.go`
+  - schema creation and task persistence
+- `internal/thread`
+  - task-mode key resolution
+- `internal/codex`
+  - Codex gateway and CLI execution wrapper
+- `ARCHITECTURE.md`
+  - authoritative architecture document
+- `docs/design-docs/task-mode-worktrees.md`
+  - design rules this plan must implement
+
+Terms used in this plan:
+
+- source repository: the Git repository configured by `CLAW_CODEX_WORKDIR`
+- task worktree: the task-specific checkout stored under `CLAW_DATADIR`
+- base ref: the Git branch used as the starting point for creating the task worktree, chosen from `main` or `master`
+- prune: remove an old closed-task worktree from disk while leaving the task branch in Git
+
+## Plan of Work
+
+Start by updating startup validation. In `internal/config` or a nearby validation layer, detect whether the configured workdir is a Git repository whenever `CLAW_MODE=task`. Fail startup with a clear error if the path is missing, not a directory, or not a Git repository. Keep `daily` mode behavior unchanged.
+
+Next, extend the task data model in `internal/app/types.go` and the SQLite schema in `internal/store/sqlite/store.go`. Add persistent task fields for `branch_name`, `base_ref`, `worktree_path`, `worktree_status`, `worktree_created_at`, `worktree_pruned_at`, and `last_used_at`. Because the repository already has live schema creation through `CREATE TABLE IF NOT EXISTS`, add additive migration logic that checks for missing columns and adds them. Preserve existing task rows by giving the new fields safe defaults such as `worktree_status='pending'` when older rows are encountered.
+
+Then implement a small task workspace service in the app layer or a focused internal package. That service should generate branch names during `task-new`, detect the base ref, create task worktrees lazily, and prune old closed-task worktrees. Keep the task command service responsible for user-facing task workflow, but move Git-specific worktree operations out of it if that keeps the task command layer readable.
+
+After that, update normal-message handling in `internal/app/message_service_impl.go` so `task` mode resolves the active task, ensures a usable worktree when the task is `pending` or `failed`, and only then calls the Codex gateway. The Codex gateway path must accept a per-turn working directory override so task-mode turns can use the task worktree while `daily` mode continues using the global workdir. Record `last_used_at` for successful task use.
+
+Finally, update close behavior. When `task-close` succeeds, trigger closed-task pruning for tasks with `worktree_status=ready`. Sort closed tasks by `closed_at` descending, keep the most recent fifteen ready worktrees, and remove older ready worktrees with `git worktree remove --force`. If pruning fails for a task, log the failure and leave that task in `closed + ready` so a later cleanup pass can try again.
+
+## Concrete Steps
+
+Run all commands from `/home/filepang/playground/39claw`.
+
+1. Confirm the current repository state before implementation.
+
+    make test
+    make lint
+
+    Expected result:
+
+        all Go tests pass
+        lint passes with 0 issues
+
+2. Update documentation first so implementation has a fixed target.
+
+    Edit:
+
+    - `ARCHITECTURE.md`
+    - `docs/design-docs/architecture-overview.md`
+    - `docs/design-docs/implementation-spec.md`
+    - `docs/design-docs/state-and-storage.md`
+    - `docs/design-docs/thread-modes.md`
+    - `docs/design-docs/task-mode-worktrees.md`
+    - `docs/product-specs/task-mode-user-flow.md`
+    - `docs/product-specs/discord-command-behavior.md`
+    - `README.md`
+
+3. Implement startup validation, schema changes, and task workspace orchestration in:
+
+    - `internal/config/config.go`
+    - `internal/config/config_test.go`
+    - `internal/app/types.go`
+    - `internal/app/task_service.go`
+    - `internal/app/message_service_impl.go`
+    - `internal/store/sqlite/store.go`
+    - new focused worktree helper package or service files if needed
+
+4. Add or update tests in:
+
+    - `cmd/39claw/main_test.go`
+    - `internal/app/task_service_test.go`
+    - `internal/app/message_service_test.go`
+    - `internal/store/sqlite/store_test.go`
+    - any new package-specific tests for Git worktree behavior and pruning logic
+
+5. Run focused tests while iterating.
+
+    go test ./cmd/39claw ./internal/app ./internal/config ./internal/store/sqlite
+
+    Expected result:
+
+        ok   github.com/HatsuneMiku3939/39claw/cmd/39claw
+        ok   github.com/HatsuneMiku3939/39claw/internal/app
+        ok   github.com/HatsuneMiku3939/39claw/internal/config
+        ok   github.com/HatsuneMiku3939/39claw/internal/store/sqlite
+
+6. Run the full repository checks after the implementation lands.
+
+    make test
+    make lint
+
+7. Record proof artifacts showing:
+
+    - `task` mode startup fails when `CLAW_CODEX_WORKDIR` is not a Git repository
+    - the first message for a new task creates a worktree under `${CLAW_DATADIR}/worktrees/<task_id>`
+    - switching tasks routes later turns through different worktree paths
+    - closing enough tasks prunes only old ready worktrees, not branches
+
+## Validation and Acceptance
+
+This plan is complete when all of the following are true:
+
+- `task` mode startup rejects a non-Git `CLAW_CODEX_WORKDIR`
+- `daily` mode startup still accepts a non-Git workdir when other requirements are met
+- `task-new` creates a task with reserved branch metadata and `worktree_status=pending`
+- the first normal message for a pending task creates the task worktree lazily and then runs Codex in that worktree
+- a failed worktree creation returns a user-facing failure response and retries on the next normal message
+- `task-switch` changes only active task selection, not eager Git state
+- `task-close` keeps task branches but prunes ready worktrees beyond the fifteen most recent closed tasks
+- open-task worktrees are never pruned
+- existing task-mode thread continuity still works across days and restarts
+- `make test` passes
+- `make lint` passes
+
+The acceptance bar is behavioral. A contributor should be able to observe isolated worktree directories on disk and prove that different tasks execute against different task-specific working directories.
+
+## Idempotence and Recovery
+
+Schema migration must be additive and safe to rerun. Startup or test code should tolerate a database that already contains the new columns. Worktree creation should be written so a repeated attempt can recover from partial failure by cleaning up any incomplete worktree directory before retrying, while still leaving the reserved task branch intact.
+
+Pruning is intentionally best-effort after the task close operation succeeds. If pruning fails, do not reopen the task or clear its `closed_at`. Log the failure, keep the worktree metadata in `ready`, and allow later cleanup to retry. Forced worktree removal is allowed because the task is already closed and old closed-task worktrees are treated as disposable local workspace state.
+
+## Artifacts and Notes
+
+Important expected task-mode lifecycle after this plan:
+
+    /<instance-command> action:task-new task_name:Release prep
+    -> task created with branch metadata, no worktree yet
+
+    mention bot with normal prompt
+    -> lazy worktree creation
+    -> Codex runs in ${CLAW_DATADIR}/worktrees/<task_id>
+
+    /<instance-command> action:task-switch task_id:<other>
+    -> active task changes only
+
+    /<instance-command> action:task-close task_id:<id>
+    -> task closes
+    -> old closed ready worktrees beyond retention are force-pruned
+    -> task branch remains in the source repository
+
+## Interfaces and Dependencies
+
+At the end of this plan, the repository should expose a task model shaped like:
+
+    type Task struct {
+        TaskID             string
+        DiscordUserID      string
+        TaskName           string
+        Status             TaskStatus
+        BranchName         string
+        BaseRef            string
+        WorktreePath       string
+        WorktreeStatus     TaskWorktreeStatus
+        CreatedAt          time.Time
+        UpdatedAt          time.Time
+        ClosedAt           *time.Time
+        WorktreeCreatedAt  *time.Time
+        WorktreePrunedAt   *time.Time
+        LastUsedAt         *time.Time
+    }
+
+The persistence layer should support reading and updating those fields without the app layer needing raw SQL knowledge. The Codex execution path should accept a task-specific working directory override while preserving the existing global configuration path for `daily` mode.
+
+Revision Note: 2026-04-04 / Codex - Created this active ExecPlan after the task worktree isolation design was agreed and documented.

--- a/docs/exec-plans/index.md
+++ b/docs/exec-plans/index.md
@@ -26,6 +26,7 @@ Plans in this directory should be written and maintained in line with `.agents/P
 These plans are intended to be executed in numeric order. Each plan is self-contained, but later plans name the repository state they expect to find and explain how to recover if that state is missing.
 
 - [Replace shared `/help` and `/task` slash commands with one instance-specific root command](./active/07-instance-specific-root-command.md)
+- [Add task-isolated Git worktrees to `task` mode](./active/08-task-mode-worktree-isolation.md)
 
 ## Recently Completed Plans
 

--- a/docs/product-specs/discord-command-behavior.md
+++ b/docs/product-specs/discord-command-behavior.md
@@ -153,6 +153,10 @@ When a task action succeeds, the response should tell the user:
 - what the active task is now, if relevant
 - what they can do next
 
+For `action:task-new`, the success response should set the expectation that the first normal message may prepare the task workspace before Codex answers.
+
+For `action:task-close`, the success response does not need to describe background worktree pruning in detail, but the product behavior should remain consistent with the task retention policy.
+
 When `action:help` succeeds, the response should give a concise list of supported actions and a short explanation of when to use them.
 
 ### Failure behavior
@@ -171,6 +175,11 @@ If a task action is invoked against a bot instance running in `daily` mode, the 
 
 If `task` mode requires an active task and none exists, the bot should not guess.
 It should tell the user what is missing and what `/<instance-command> action:task-*` command to use next.
+
+### Workspace preparation failure
+
+If a normal message targets a task whose workspace cannot be prepared yet, the bot should not claim that Codex processed the turn.
+It should explain that the task workspace could not be prepared and tell the user to retry.
 
 ### Ambiguous command intent
 
@@ -244,3 +253,4 @@ This command behavior layer is not intended to:
 - each bot instance should register exactly one slash command whose name identifies that instance in Discord search.
 - `action:help` should stay structurally simple in v1, but it should only describe commands that are actually available in the current bot instance.
 - Unsupported invocation patterns should be ignored rather than acknowledged with lightweight feedback.
+- In `task` mode, the configured workdir is a Git repository source for task worktrees rather than only one shared execution directory.

--- a/docs/product-specs/task-mode-user-flow.md
+++ b/docs/product-specs/task-mode-user-flow.md
@@ -19,6 +19,7 @@ In `task` mode, the bot should feel like:
 
 - a tool for focused ongoing work
 - a system with explicit context boundaries
+- a system that gives each task its own isolated repository workspace
 - a bot that does not guess the wrong long-lived context silently
 
 ## Core Experience Rules
@@ -39,6 +40,11 @@ The product should make that behavior understandable to the user.
 ### 4. Missing context should produce actionable guidance
 
 If the user tries to work without an active task, the response should tell them what to do next in simple language and point them toward the `/<instance-command> action:task-*` command flow.
+
+### 5. Task work should be isolated
+
+Each task should run inside its own repository workspace rather than sharing one mutable checkout with other tasks.
+That isolation should make task switching feel like switching work streams, not only switching chat memory.
 
 ## Primary Flow
 
@@ -63,13 +69,16 @@ Expected flow:
 
 1. The user uses `/<instance-command> action:task-new task_name:<name>`, `/<instance-command> action:task-switch task_id:<id>`, or `/<instance-command> action:task-current` plus other task actions to establish the desired task context.
 2. 39claw records that task as the active context for the user within the current bot instance.
-3. The next normal message routes to the thread associated with that task.
-4. If the task has no bound thread yet, 39claw creates one.
+3. A newly created task reserves its own task branch identity even before worktree creation.
+4. The next normal message routes to the thread associated with that task.
+5. If the task has no ready worktree yet, 39claw prepares the task workspace lazily before running Codex.
+6. If the task has no bound thread yet, 39claw creates one.
 
 Expected user perception:
 
 - “I chose the work context.”
 - “The bot now knows what I mean by continuing this task.”
+- “This task has its own workspace.”
 
 ### Scenario: User continues an active task on a later day
 
@@ -83,6 +92,7 @@ Expected user perception:
 
 - “This task keeps its context over time.”
 - “I do not need to start over just because the date changed.”
+- “My task workspace is still separate from other tasks.”
 
 ### Scenario: User switches to another task
 
@@ -96,6 +106,22 @@ Expected user perception:
 
 - “I intentionally switched work contexts.”
 - “The bot should now respond in terms of the new task.”
+- “The switch changes both the Codex context and the task workspace used for later work.”
+
+### Scenario: The first normal message for a task needs workspace preparation
+
+Expected flow:
+
+1. The user creates or switches to a task that has no ready task worktree yet.
+2. The user sends a normal message to continue that task.
+3. 39claw detects that the task worktree is still pending or previously failed.
+4. 39claw prepares the task-specific Git worktree under the bot data directory.
+5. After workspace preparation succeeds, 39claw runs the Codex turn in that task worktree.
+
+Expected user perception:
+
+- “The bot prepared this task's workspace when I first used it.”
+- “Later turns for this task should continue in the same isolated workspace.”
 
 ### Scenario: A message is queued for the active task and the user switches tasks before it runs
 
@@ -153,6 +179,7 @@ That is especially important for `action:task-current`, `action:task-list`, and 
 
 Active task state should be scoped to the user within the current bot instance.
 Shared-task state across multiple users is out of scope for v1.
+Task worktree isolation is also user-scoped through the task identity.
 
 ## Failure and Edge Cases
 
@@ -172,10 +199,21 @@ In `task` mode, normal messages should not trigger task creation or implicit rec
 
 If a task exists but its thread binding cannot be resumed, the bot should explain that continuity could not be restored and indicate whether retrying or re-establishing the task is needed.
 
+### Workspace preparation failure
+
+If the task workspace cannot be prepared, the bot should explain that the task workspace is not ready and tell the user to retry.
+The bot should not pretend that Codex processed the message normally.
+
 ### Incorrect task risk
 
 If the product is not certain which task should receive a message, it should prefer asking for explicit user action rather than guessing and contaminating the wrong context.
 That same safety rule applies to queued work: the task context must be frozen at queue-admission time rather than re-read later.
+
+### Closed-task workspace retention
+
+Closing a task should not imply immediate deletion of its task branch.
+However, the product may prune older closed-task worktrees to keep local disk usage bounded.
+The most recent closed task workspaces should remain available longer than older ones.
 
 ## Non-Goals
 
@@ -190,3 +228,7 @@ That same safety rule applies to queued work: the task context must be frozen at
 - Active task state is always user-scoped within a bot instance in v1.
 - The active task should remain active until the user explicitly closes it or switches to another task.
 - If a task is closed and the user then sends a normal message, the bot should respond with missing-active-task guidance rather than routing the message normally.
+- `task` mode assumes the configured workdir is a Git repository.
+- New tasks create metadata first and prepare their task worktree lazily on the first normal message.
+- Closed-task retention keeps only the fifteen most recently closed ready task worktrees.
+- Task branches are retained even when older closed-task worktrees are pruned.


### PR DESCRIPTION
## Summary

- document task-mode Git worktree isolation as the new design direction
- add a dedicated design doc for task worktrees and an active ExecPlan for implementation
- align architecture, implementation, product, and README docs with the new task-mode model

## Background

`task` mode is moving from a shared-checkout model to task-isolated Git worktrees. The repository needed a clear design record before implementation so startup validation, schema changes, runtime behavior, and user expectations stay aligned.

## Related issue(s)

- None.

## Implementation details

- added `docs/design-docs/task-mode-worktrees.md` to define the repository model, task/worktree state model, lazy creation flow, retention policy, and failure/retry rules
- added `docs/exec-plans/active/08-task-mode-worktree-isolation.md` to guide the implementation work
- updated `ARCHITECTURE.md`, design docs, product specs, and `README.md` to describe the Git repo requirement for `task` mode and the lazy worktree lifecycle

## Test coverage

- `make test`
- `make lint`

## Breaking changes

- `task` mode now documents a hard requirement that `CLAW_CODEX_WORKDIR` be a Git repository

## Notes

- this PR is documentation-only and prepares the repository for the follow-up implementation work

Created by Codex
