### PR TITLE
Add task mode Git worktree isolation

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,7 @@ Pick one:
 
 If you choose `task`, `CLAW_CODEX_WORKDIR` must point to a Git repository.
 39claw treats that repository as the source repository for task-specific worktrees stored under `CLAW_DATADIR`.
+If startup finds a missing or non-Git task workdir, the bot exits with a clear configuration error before it connects to Discord.
 
 ### 2. Set the required environment variables
 
@@ -264,6 +265,7 @@ Try one of these:
 - mention the bot with only an image
 
 If you are running in `task` mode, create a task first with `/<your-command> action:task-new task_name:<name>`.
+The first normal message for a new task may spend a moment preparing that task's dedicated worktree before Codex replies.
 
 ## Configuration Reference
 

--- a/cmd/39claw/main.go
+++ b/cmd/39claw/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"os"
 	"os/signal"
 	"syscall"
@@ -48,10 +49,15 @@ func run(ctx context.Context, lookupEnv func(string) (string, bool)) error {
 		return err
 	}
 
+	if err := config.ValidateRuntimePaths(cfg); err != nil {
+		return err
+	}
+
 	logger, err := observe.NewLogger(cfg.LogLevel)
 	if err != nil {
 		return err
 	}
+	slog.SetDefault(logger)
 
 	store, err := sqlitestore.Open(cfg.SQLitePath)
 	if err != nil {
@@ -83,26 +89,41 @@ func run(ctx context.Context, lookupEnv func(string) (string, bool)) error {
 		ThreadOptions: threadOptions,
 	})
 
+	var workspaceManager app.TaskWorkspaceManager
+	if cfg.Mode == config.ModeTask {
+		workspaceManager, err = app.NewTaskWorkspaceManager(app.TaskWorkspaceManagerDependencies{
+			Store:            store,
+			SourceRepository: cfg.CodexWorkdir,
+			DataDir:          cfg.DataDir,
+			Logger:           logger,
+		})
+		if err != nil {
+			return fmt.Errorf("build task workspace manager: %w", err)
+		}
+	}
+
 	policy, err := thread.NewPolicy(cfg.Mode, cfg.Timezone, store)
 	if err != nil {
 		return fmt.Errorf("build thread policy: %w", err)
 	}
 
 	messageService, err := app.NewMessageService(app.MessageServiceDependencies{
-		Mode:        cfg.Mode,
-		CommandName: cfg.DiscordCommandName,
-		Policy:      policy,
-		Store:       store,
-		Gateway:     gateway,
-		Coordinator: thread.NewQueueCoordinator(),
+		Mode:             cfg.Mode,
+		CommandName:      cfg.DiscordCommandName,
+		Policy:           policy,
+		Store:            store,
+		WorkspaceManager: workspaceManager,
+		Gateway:          gateway,
+		Coordinator:      thread.NewQueueCoordinator(),
 	})
 	if err != nil {
 		return fmt.Errorf("build message service: %w", err)
 	}
 
 	taskService, err := app.NewTaskCommandService(app.TaskCommandServiceDependencies{
-		CommandName: cfg.DiscordCommandName,
-		Store:       store,
+		CommandName:      cfg.DiscordCommandName,
+		Store:            store,
+		WorkspaceManager: workspaceManager,
 	})
 	if err != nil {
 		return fmt.Errorf("build task service: %w", err)

--- a/cmd/39claw/main_test.go
+++ b/cmd/39claw/main_test.go
@@ -2,6 +2,9 @@ package main
 
 import (
 	"context"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -87,6 +90,19 @@ func TestRun(t *testing.T) {
 				ApprovalPolicy:        codex.ApprovalModeOnRequest,
 			},
 		},
+		{
+			name: "rejects non-git workdir in task mode during startup",
+			env: map[string]string{
+				"CLAW_MODE":                 "task",
+				"CLAW_TIMEZONE":             "Asia/Tokyo",
+				"CLAW_DISCORD_TOKEN":        "discord-token",
+				"CLAW_DISCORD_COMMAND_NAME": "release",
+				"CLAW_CODEX_WORKDIR":        "/workspace/not-a-repo",
+				"CLAW_DATADIR":              "/tmp/39claw-data",
+				"CLAW_CODEX_EXECUTABLE":     "codex",
+			},
+			wantErr: "task mode requires CLAW_CODEX_WORKDIR to exist",
+		},
 	}
 
 	for _, tt := range tests {
@@ -117,6 +133,15 @@ func TestRun(t *testing.T) {
 				env["CLAW_DATADIR"] = t.TempDir()
 			}
 
+			if env["CLAW_MODE"] == "task" && tt.wantErr == "" {
+				workdir := filepath.Join(t.TempDir(), "repo")
+				if err := os.MkdirAll(filepath.Join(workdir, ".git"), 0o755); err != nil {
+					t.Fatalf("MkdirAll(.git) error = %v", err)
+				}
+				env["CLAW_CODEX_WORKDIR"] = workdir
+				tt.wantThreadOptions.WorkingDirectory = workdir
+			}
+
 			err := run(ctx, func(key string) (string, bool) {
 				value, ok := env[key]
 				return value, ok
@@ -126,8 +151,8 @@ func TestRun(t *testing.T) {
 					t.Fatalf("run() error = nil, want %q", tt.wantErr)
 				}
 
-				if err.Error() != tt.wantErr {
-					t.Fatalf("run() error = %q, want %q", err.Error(), tt.wantErr)
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("run() error = %q, want substring %q", err.Error(), tt.wantErr)
 				}
 
 				return

--- a/docs/exec-plans/active/08-task-mode-worktree-isolation.md
+++ b/docs/exec-plans/active/08-task-mode-worktree-isolation.md
@@ -13,12 +13,12 @@ The user-visible proof is practical. In `task` mode, creating two tasks and send
 ## Progress
 
 - [x] (2026-04-04 23:57Z) Captured the new task-mode worktree direction, hard Git-repository requirement, lazy creation flow, and closed-task pruning policy in repository documentation.
-- [ ] Extend startup validation so `task` mode refuses non-Git `CLAW_CODEX_WORKDIR` values.
-- [ ] Add task worktree metadata to persistence and migrate the SQLite schema safely.
-- [ ] Route task-mode Codex turns through task-specific worktree paths instead of the global workdir.
-- [ ] Implement lazy worktree creation, retry behavior, and closed-task pruning.
-- [ ] Add unit and integration coverage for startup validation, lazy creation, retry, and pruning.
-- [ ] Run `make test` and `make lint` after the implementation lands.
+- [x] (2026-04-05 00:24Z) Extended startup validation so `task` mode now rejects missing, non-directory, and non-Git `CLAW_CODEX_WORKDIR` values before Discord startup.
+- [x] (2026-04-05 00:24Z) Added task worktree metadata to persistence, including additive SQLite migration and branch-name backfill for older rows.
+- [x] (2026-04-05 00:24Z) Routed task-mode Codex turns through task-specific worktree paths while leaving `daily` mode on the configured global workdir.
+- [x] (2026-04-05 00:24Z) Implemented lazy worktree creation, automatic retry after failed preparation, and closed-task worktree pruning with branch retention.
+- [x] (2026-04-05 00:24Z) Added unit and integration coverage for startup validation, lazy creation, retry behavior, pruning, and schema migration.
+- [x] (2026-04-05 00:24Z) Ran `make test` and `make lint` after the implementation landed.
 
 ## Surprises & Discoveries
 
@@ -30,6 +30,12 @@ The user-visible proof is practical. In `task` mode, creating two tasks and send
 
 - Observation: The current architecture and implementation spec still describe one working directory per bot instance, so both documents must be updated before implementation to avoid misleading later contributors.
   Evidence: `ARCHITECTURE.md` and `docs/design-docs/implementation-spec.md`
+
+- Observation: Retrying a failed lazy worktree creation needs to tolerate the case where Git already created the reserved branch during an earlier partial attempt.
+  Evidence: `internal/app/task_workspace.go` now checks for an existing task branch and switches between `git worktree add -b <branch>` and `git worktree add <path> <branch>` on retry.
+
+- Observation: Additive SQLite migration also needs a backfill step because older task rows otherwise keep an empty `branch_name`, which breaks the "reserved branch at task creation" rule for reopened databases.
+  Evidence: `internal/store/sqlite/store.go` runs `UPDATE tasks SET branch_name = 'task/' || task_id WHERE branch_name = ''` after schema migration.
 
 ## Decision Log
 
@@ -55,7 +61,9 @@ The user-visible proof is practical. In `task` mode, creating two tasks and send
 
 ## Outcomes & Retrospective
 
-This plan is not yet implemented. At this stage, the repository has the architectural and product decisions needed to start coding without reopening the core behavior questions. The main remaining risk is keeping schema migration, task orchestration, and Codex workdir selection aligned so task-mode behavior remains understandable and testable.
+This plan is now implemented in the repository. `task` mode startup rejects non-Git source repositories, task creation reserves branch metadata with `worktree_status=pending`, the first normal task message lazily creates a task-specific worktree under `${CLAW_DATADIR}/worktrees/<task_id>`, and later turns reuse that task-specific working directory and Codex thread binding. Closing tasks now keeps task branches but prunes older closed ready worktrees beyond the configured retention window.
+
+The most important lesson was that the feature touches three kinds of state at once: Discord-visible task workflow, Codex thread continuity, and Git workspace lifecycle. Keeping those aligned required a narrow app-layer worktree manager plus additive store migration rather than folding Git operations into the task command flow directly. The remaining follow-up work is operational rather than architectural: if future product needs want manual cleanup commands or richer worktree status output in Discord, those can build on the now-persistent task worktree metadata without changing the core model again.
 
 ## Context and Orientation
 
@@ -167,6 +175,16 @@ Run all commands from `/home/filepang/playground/39claw`.
     make test
     make lint
 
+    Observed result on 2026-04-05:
+
+        ok   github.com/HatsuneMiku3939/39claw/cmd/39claw
+        ok   github.com/HatsuneMiku3939/39claw/internal/app
+        ok   github.com/HatsuneMiku3939/39claw/internal/config
+        ok   github.com/HatsuneMiku3939/39claw/internal/store/sqlite
+        ok   github.com/HatsuneMiku3939/39claw/internal/thread
+        0 issues.
+        Linting passed
+
 7. Record proof artifacts showing:
 
     - `task` mode startup fails when `CLAW_CODEX_WORKDIR` is not a Git repository
@@ -217,6 +235,20 @@ Important expected task-mode lifecycle after this plan:
     -> old closed ready worktrees beyond retention are force-pruned
     -> task branch remains in the source repository
 
+Implemented proof points in automated coverage:
+
+    cmd/39claw/main_test.go
+    -> rejects non-Git task-mode startup workdirs
+
+    internal/app/message_service_test.go
+    -> proves lazy task workdir selection, task switching to distinct worktree paths, and automatic retry after failed workspace setup
+
+    internal/app/task_workspace_test.go
+    -> creates and prunes real Git worktrees in a temporary repository
+
+    internal/store/sqlite/store_test.go
+    -> proves additive migration and closed-ready task ordering for pruning
+
 ## Interfaces and Dependencies
 
 At the end of this plan, the repository should expose a task model shaped like:
@@ -237,6 +269,8 @@ At the end of this plan, the repository should expose a task model shaped like:
         WorktreePrunedAt   *time.Time
         LastUsedAt         *time.Time
     }
+
+Revision note (2026-04-05 00:24Z): Updated the living sections after implementing the full task worktree isolation flow, adding persistence migration, Git worktree orchestration, validation, tests, and final verification results.
 
 The persistence layer should support reading and updating those fields without the app layer needing raw SQL knowledge. The Codex execution path should accept a task-specific working directory override while preserving the existing global configuration path for `daily` mode.
 

--- a/internal/app/message_service.go
+++ b/internal/app/message_service.go
@@ -21,11 +21,18 @@ type ThreadStore interface {
 	UpsertThreadBinding(ctx context.Context, binding ThreadBinding) error
 	CreateTask(ctx context.Context, task Task) error
 	GetTask(ctx context.Context, discordUserID string, taskID string) (Task, bool, error)
+	UpdateTask(ctx context.Context, task Task) error
 	ListOpenTasks(ctx context.Context, discordUserID string) ([]Task, error)
+	ListClosedReadyTasks(ctx context.Context) ([]Task, error)
 	SetActiveTask(ctx context.Context, activeTask ActiveTask) error
 	GetActiveTask(ctx context.Context, discordUserID string) (ActiveTask, bool, error)
 	ClearActiveTask(ctx context.Context, discordUserID string) error
 	CloseTask(ctx context.Context, discordUserID string, taskID string) error
+}
+
+type TaskWorkspaceManager interface {
+	EnsureReady(ctx context.Context, task Task) (Task, error)
+	PruneClosed(ctx context.Context) error
 }
 
 type CodexGateway interface {

--- a/internal/app/message_service_impl.go
+++ b/internal/app/message_service_impl.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"strings"
+	"time"
 
 	"github.com/HatsuneMiku3939/39claw/internal/config"
 )
@@ -15,12 +17,13 @@ const (
 )
 
 type MessageServiceDependencies struct {
-	Mode        config.Mode
-	CommandName string
-	Policy      ThreadPolicy
-	Store       ThreadStore
-	Gateway     CodexGateway
-	Coordinator QueueCoordinator
+	Mode             config.Mode
+	CommandName      string
+	Policy           ThreadPolicy
+	Store            ThreadStore
+	WorkspaceManager TaskWorkspaceManager
+	Gateway          CodexGateway
+	Coordinator      QueueCoordinator
 }
 
 type DefaultMessageService struct {
@@ -28,6 +31,7 @@ type DefaultMessageService struct {
 	commands    commandSurface
 	policy      ThreadPolicy
 	store       ThreadStore
+	worktrees   TaskWorkspaceManager
 	gateway     CodexGateway
 	coordinator QueueCoordinator
 }
@@ -50,6 +54,10 @@ func NewMessageService(deps MessageServiceDependencies) (*DefaultMessageService,
 		return nil, errors.New("thread store must not be nil")
 	}
 
+	if deps.Mode == config.ModeTask && deps.WorkspaceManager == nil {
+		return nil, errors.New("task workspace manager must not be nil in task mode")
+	}
+
 	if deps.Gateway == nil {
 		return nil, errors.New("codex gateway must not be nil")
 	}
@@ -63,6 +71,7 @@ func NewMessageService(deps MessageServiceDependencies) (*DefaultMessageService,
 		commands:    newCommandSurface(commandName),
 		policy:      deps.Policy,
 		store:       deps.Store,
+		worktrees:   deps.WorkspaceManager,
 		gateway:     deps.Gateway,
 		coordinator: deps.Coordinator,
 	}, nil
@@ -120,6 +129,7 @@ func (s *DefaultMessageService) HandleMessage(ctx context.Context, request Messa
 
 type preparedMessage struct {
 	logicalKey string
+	userID     string
 	taskID     string
 	replyToID  string
 	input      CodexTurnInput
@@ -147,6 +157,7 @@ func (s *DefaultMessageService) prepareMessage(
 
 	prepared := preparedMessage{
 		logicalKey: logicalKey,
+		userID:     request.UserID,
 		replyToID:  request.MessageID,
 		input: CodexTurnInput{
 			Prompt:     request.Content,
@@ -180,6 +191,19 @@ func (s *DefaultMessageService) noActiveTaskMessage() string {
 func (s *DefaultMessageService) executePreparedMessage(ctx context.Context, prepared preparedMessage) (MessageResponse, error) {
 	defer runCleanup(prepared.cleanup)
 
+	if s.mode == config.ModeTask {
+		task, response, handled, err := s.ensureTaskReady(ctx, prepared)
+		if err != nil {
+			return MessageResponse{}, err
+		}
+
+		if handled {
+			return response, nil
+		}
+
+		prepared.input.WorkingDirectory = task.WorktreePath
+	}
+
 	binding, ok, err := s.store.GetThreadBinding(ctx, string(s.mode), prepared.logicalKey)
 	if err != nil {
 		return MessageResponse{}, fmt.Errorf("load thread binding: %w", err)
@@ -211,6 +235,12 @@ func (s *DefaultMessageService) executePreparedMessage(ctx context.Context, prep
 	binding.CodexThreadID = result.ThreadID
 	if err := s.store.UpsertThreadBinding(ctx, binding); err != nil {
 		return MessageResponse{}, fmt.Errorf("persist thread binding: %w", err)
+	}
+
+	if s.mode == config.ModeTask {
+		if err := s.touchTaskLastUsed(ctx, prepared.userID, prepared.taskID); err != nil {
+			slog.Error("update task last used timestamp", "task_id", prepared.taskID, "error", err)
+		}
 	}
 
 	return MessageResponse{
@@ -281,4 +311,52 @@ func taskIDFromLogicalKey(userID string, logicalKey string) (string, error) {
 	}
 
 	return strings.TrimPrefix(logicalKey, prefix), nil
+}
+
+func (s *DefaultMessageService) ensureTaskReady(
+	ctx context.Context,
+	prepared preparedMessage,
+) (Task, MessageResponse, bool, error) {
+	task, ok, err := s.store.GetTask(ctx, prepared.userID, prepared.taskID)
+	if err != nil {
+		return Task{}, MessageResponse{}, false, fmt.Errorf("load task for execution: %w", err)
+	}
+
+	if !ok || task.Status != TaskStatusOpen {
+		return Task{}, MessageResponse{
+			Text:      s.noActiveTaskMessage(),
+			ReplyToID: prepared.replyToID,
+		}, true, nil
+	}
+
+	task, err = s.worktrees.EnsureReady(ctx, task)
+	if err != nil {
+		slog.Error("prepare task worktree", "task_id", prepared.taskID, "error", err)
+		return Task{}, MessageResponse{
+			Text:      "Task workspace setup failed. Please retry after checking the configured repository.",
+			ReplyToID: prepared.replyToID,
+		}, true, nil
+	}
+
+	return task, MessageResponse{}, false, nil
+}
+
+func (s *DefaultMessageService) touchTaskLastUsed(ctx context.Context, userID string, taskID string) error {
+	task, ok, err := s.store.GetTask(ctx, userID, taskID)
+	if err != nil {
+		return fmt.Errorf("load task before last-used update: %w", err)
+	}
+
+	if !ok {
+		return nil
+	}
+
+	now := time.Now().UTC()
+	task.LastUsedAt = &now
+	task.UpdatedAt = now
+	if err := s.store.UpdateTask(ctx, task); err != nil {
+		return fmt.Errorf("persist task last-used update: %w", err)
+	}
+
+	return nil
 }

--- a/internal/app/message_service_test.go
+++ b/internal/app/message_service_test.go
@@ -3,6 +3,7 @@ package app_test
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"sort"
 	"sync"
 	"testing"
@@ -184,9 +185,10 @@ func TestMessageServiceHandleMessageReturnsTaskGuidance(t *testing.T) {
 		Policy: stubThreadPolicy{
 			err: app.ErrNoActiveTask,
 		},
-		Store:       &memoryThreadStore{},
-		Gateway:     &fakeCodexGateway{},
-		Coordinator: thread.NewQueueCoordinator(),
+		Store:            &memoryThreadStore{},
+		WorkspaceManager: &fakeTaskWorkspaceManager{},
+		Gateway:          &fakeCodexGateway{},
+		Coordinator:      thread.NewQueueCoordinator(),
 	})
 	if err != nil {
 		t.Fatalf("NewMessageService() error = %v", err)
@@ -266,6 +268,14 @@ func TestMessageServiceHandleMessageTaskReusesTaskBindingAcrossDays(t *testing.T
 
 	if calls[1].threadID != "thread-task-1" {
 		t.Fatalf("second thread id = %q, want %q", calls[1].threadID, "thread-task-1")
+	}
+
+	if calls[0].workingDirectory != "/tmp/worktrees/task-1" {
+		t.Fatalf("first working directory = %q, want %q", calls[0].workingDirectory, "/tmp/worktrees/task-1")
+	}
+
+	if calls[1].workingDirectory != "/tmp/worktrees/task-1" {
+		t.Fatalf("second working directory = %q, want %q", calls[1].workingDirectory, "/tmp/worktrees/task-1")
 	}
 
 	binding, ok, err := store.GetThreadBinding(context.Background(), "task", "user-1:task-1")
@@ -353,10 +363,110 @@ func TestMessageServiceHandleMessageTaskSwitchesThreadsByActiveTask(t *testing.T
 		t.Fatalf("second thread id = %q, want empty", calls[1].threadID)
 	}
 
+	if calls[0].workingDirectory != "/tmp/worktrees/task-1" {
+		t.Fatalf("first working directory = %q, want %q", calls[0].workingDirectory, "/tmp/worktrees/task-1")
+	}
+
+	if calls[1].workingDirectory != "/tmp/worktrees/task-2" {
+		t.Fatalf("second working directory = %q, want %q", calls[1].workingDirectory, "/tmp/worktrees/task-2")
+	}
+
 	for _, key := range []string{"user-1:task-1", "user-1:task-2"} {
 		if _, ok, err := store.GetThreadBinding(context.Background(), "task", key); err != nil || !ok {
 			t.Fatalf("GetThreadBinding(%s) = ok:%v err:%v, want ok:true err:nil", key, ok, err)
 		}
+	}
+}
+
+func TestMessageServiceHandleMessageTaskRetriesFailedWorkspaceSetup(t *testing.T) {
+	t.Parallel()
+
+	store := &memoryThreadStore{
+		tasks: map[string]app.Task{
+			"user-1:task-1": {
+				TaskID:        "task-1",
+				DiscordUserID: "user-1",
+				TaskName:      "Release work",
+				Status:        app.TaskStatusOpen,
+				CreatedAt:     time.Date(2026, time.April, 5, 0, 0, 0, 0, time.UTC),
+			},
+		},
+		activeTasks: map[string]app.ActiveTask{
+			"user-1": {
+				DiscordUserID: "user-1",
+				TaskID:        "task-1",
+			},
+		},
+	}
+	gateway := &fakeCodexGateway{
+		results: []app.RunTurnResult{
+			{ThreadID: "thread-task-1", ResponseText: "Recovered response"},
+		},
+	}
+	worktrees := &fakeTaskWorkspaceManager{
+		store:     store,
+		failCount: 1,
+	}
+	service := newTaskMessageServiceWithWorktrees(t, store, gateway, nil, worktrees)
+
+	firstResponse, err := service.HandleMessage(context.Background(), app.MessageRequest{
+		UserID:     "user-1",
+		MessageID:  "message-1",
+		Content:    "start release",
+		Mentioned:  true,
+		ReceivedAt: time.Date(2026, time.April, 5, 0, 0, 0, 0, time.UTC),
+	}, nil)
+	if err != nil {
+		t.Fatalf("HandleMessage() first error = %v", err)
+	}
+
+	if firstResponse.Text != "Task workspace setup failed. Please retry after checking the configured repository." {
+		t.Fatalf("first response text = %q", firstResponse.Text)
+	}
+
+	if calls := gateway.Calls(); len(calls) != 0 {
+		t.Fatalf("RunTurn() call count after failed setup = %d, want %d", len(calls), 0)
+	}
+
+	task, ok, err := store.GetTask(context.Background(), "user-1", "task-1")
+	if err != nil {
+		t.Fatalf("GetTask() after failed setup error = %v", err)
+	}
+
+	if !ok {
+		t.Fatal("GetTask() after failed setup ok = false, want true")
+	}
+
+	if task.WorktreeStatus != app.TaskWorktreeStatusFailed {
+		t.Fatalf("WorktreeStatus after failed setup = %q, want %q", task.WorktreeStatus, app.TaskWorktreeStatusFailed)
+	}
+
+	secondResponse, err := service.HandleMessage(context.Background(), app.MessageRequest{
+		UserID:     "user-1",
+		MessageID:  "message-2",
+		Content:    "retry release",
+		Mentioned:  true,
+		ReceivedAt: time.Date(2026, time.April, 5, 0, 1, 0, 0, time.UTC),
+	}, nil)
+	if err != nil {
+		t.Fatalf("HandleMessage() second error = %v", err)
+	}
+
+	if secondResponse.Text != "Recovered response" {
+		t.Fatalf("second response text = %q, want %q", secondResponse.Text, "Recovered response")
+	}
+
+	calls := gateway.Calls()
+	if len(calls) != 1 {
+		t.Fatalf("RunTurn() call count after retry = %d, want %d", len(calls), 1)
+	}
+
+	if calls[0].workingDirectory != "/tmp/worktrees/task-1" {
+		t.Fatalf("working directory after retry = %q, want %q", calls[0].workingDirectory, "/tmp/worktrees/task-1")
+	}
+
+	if worktrees.ensureCount != 2 {
+		t.Fatalf("EnsureReady() count = %d, want %d", worktrees.ensureCount, 2)
 	}
 }
 
@@ -671,6 +781,23 @@ func newTaskMessageService(
 ) *app.DefaultMessageService {
 	t.Helper()
 
+	worktrees := &fakeTaskWorkspaceManager{}
+	if memoryStore, ok := store.(*memoryThreadStore); ok {
+		worktrees.store = memoryStore
+	}
+
+	return newTaskMessageServiceWithWorktrees(t, store, gateway, coordinator, worktrees)
+}
+
+func newTaskMessageServiceWithWorktrees(
+	t *testing.T,
+	store app.ThreadStore,
+	gateway app.CodexGateway,
+	coordinator app.QueueCoordinator,
+	worktrees app.TaskWorkspaceManager,
+) *app.DefaultMessageService {
+	t.Helper()
+
 	tokyo, err := time.LoadLocation("Asia/Tokyo")
 	if err != nil {
 		t.Fatalf("time.LoadLocation() error = %v", err)
@@ -686,12 +813,13 @@ func newTaskMessageService(
 	}
 
 	service, err := app.NewMessageService(app.MessageServiceDependencies{
-		Mode:        config.ModeTask,
-		CommandName: "release",
-		Policy:      policy,
-		Store:       store,
-		Gateway:     gateway,
-		Coordinator: coordinator,
+		Mode:             config.ModeTask,
+		CommandName:      "release",
+		Policy:           policy,
+		Store:            store,
+		WorkspaceManager: worktrees,
+		Gateway:          gateway,
+		Coordinator:      coordinator,
 	})
 	if err != nil {
 		t.Fatalf("NewMessageService() error = %v", err)
@@ -748,8 +876,9 @@ type fakeCodexGateway struct {
 }
 
 type runTurnCall struct {
-	threadID string
-	input    app.CodexTurnInput
+	threadID         string
+	workingDirectory string
+	input            app.CodexTurnInput
 }
 
 func (g *fakeCodexGateway) RunTurn(_ context.Context, threadID string, input app.CodexTurnInput) (app.RunTurnResult, error) {
@@ -757,10 +886,12 @@ func (g *fakeCodexGateway) RunTurn(_ context.Context, threadID string, input app
 	defer g.mu.Unlock()
 
 	g.calls = append(g.calls, runTurnCall{
-		threadID: threadID,
+		threadID:         threadID,
+		workingDirectory: input.WorkingDirectory,
 		input: app.CodexTurnInput{
-			Prompt:     input.Prompt,
-			ImagePaths: append([]string(nil), input.ImagePaths...),
+			Prompt:           input.Prompt,
+			ImagePaths:       append([]string(nil), input.ImagePaths...),
+			WorkingDirectory: input.WorkingDirectory,
 		},
 	})
 
@@ -807,10 +938,12 @@ func newBlockingCodexGateway(results ...app.RunTurnResult) *blockingCodexGateway
 func (g *blockingCodexGateway) RunTurn(_ context.Context, threadID string, input app.CodexTurnInput) (app.RunTurnResult, error) {
 	g.mu.Lock()
 	g.calls = append(g.calls, runTurnCall{
-		threadID: threadID,
+		threadID:         threadID,
+		workingDirectory: input.WorkingDirectory,
 		input: app.CodexTurnInput{
-			Prompt:     input.Prompt,
-			ImagePaths: append([]string(nil), input.ImagePaths...),
+			Prompt:           input.Prompt,
+			ImagePaths:       append([]string(nil), input.ImagePaths...),
+			WorkingDirectory: input.WorkingDirectory,
 		},
 	})
 
@@ -888,6 +1021,14 @@ func (s *memoryThreadStore) CreateTask(_ context.Context, task app.Task) error {
 		task.Status = app.TaskStatusOpen
 	}
 
+	if task.BranchName == "" {
+		task.BranchName = app.DefaultTaskBranchName(task.TaskID)
+	}
+
+	if task.WorktreeStatus == "" {
+		task.WorktreeStatus = app.TaskWorktreeStatusPending
+	}
+
 	if task.CreatedAt.IsZero() {
 		task.CreatedAt = time.Date(2026, time.April, 5, 0, 0, 0, 0, time.UTC)
 	}
@@ -907,6 +1048,23 @@ func (s *memoryThreadStore) GetTask(_ context.Context, userID string, taskID str
 
 	task, ok := s.tasks[userID+":"+taskID]
 	return task, ok, nil
+}
+
+func (s *memoryThreadStore) UpdateTask(_ context.Context, task app.Task) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.tasks == nil {
+		return sql.ErrNoRows
+	}
+
+	key := task.DiscordUserID + ":" + task.TaskID
+	if _, ok := s.tasks[key]; !ok {
+		return sql.ErrNoRows
+	}
+
+	s.tasks[key] = task
+	return nil
 }
 
 func (s *memoryThreadStore) ListOpenTasks(_ context.Context, userID string) ([]app.Task, error) {
@@ -934,6 +1092,27 @@ func (s *memoryThreadStore) ListOpenTasks(_ context.Context, userID string) ([]a
 	return tasks, nil
 }
 
+func (s *memoryThreadStore) ListClosedReadyTasks(_ context.Context) ([]app.Task, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	tasks := make([]app.Task, 0)
+	for _, task := range s.tasks {
+		if task.Status == app.TaskStatusClosed && task.WorktreeStatus == app.TaskWorktreeStatusReady && task.ClosedAt != nil {
+			tasks = append(tasks, task)
+		}
+	}
+
+	sort.Slice(tasks, func(i, j int) bool {
+		if tasks[i].ClosedAt.Equal(*tasks[j].ClosedAt) {
+			return tasks[i].TaskID < tasks[j].TaskID
+		}
+		return tasks[i].ClosedAt.After(*tasks[j].ClosedAt)
+	})
+
+	return tasks, nil
+}
+
 func (s *memoryThreadStore) SetActiveTask(_ context.Context, activeTask app.ActiveTask) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -943,6 +1122,47 @@ func (s *memoryThreadStore) SetActiveTask(_ context.Context, activeTask app.Acti
 	}
 
 	s.activeTasks[activeTask.DiscordUserID] = activeTask
+	return nil
+}
+
+type fakeTaskWorkspaceManager struct {
+	store       *memoryThreadStore
+	ensureCount int
+	failCount   int
+}
+
+func (m *fakeTaskWorkspaceManager) EnsureReady(_ context.Context, task app.Task) (app.Task, error) {
+	m.ensureCount++
+	if m.failCount > 0 {
+		m.failCount--
+		task.WorktreeStatus = app.TaskWorktreeStatusFailed
+		if m.store != nil {
+			_ = m.store.UpdateTask(context.Background(), task)
+		}
+		return app.Task{}, errors.New("workspace setup failed")
+	}
+
+	if task.BranchName == "" {
+		task.BranchName = app.DefaultTaskBranchName(task.TaskID)
+	}
+	task.BaseRef = "main"
+	task.WorktreePath = "/tmp/worktrees/" + task.TaskID
+	task.WorktreeStatus = app.TaskWorktreeStatusReady
+	now := time.Date(2026, time.April, 5, 0, 0, 0, 0, time.UTC)
+	if task.WorktreeCreatedAt == nil {
+		task.WorktreeCreatedAt = &now
+	}
+
+	if m.store != nil {
+		if err := m.store.UpdateTask(context.Background(), task); err != nil {
+			return app.Task{}, err
+		}
+	}
+
+	return task, nil
+}
+
+func (*fakeTaskWorkspaceManager) PruneClosed(context.Context) error {
 	return nil
 }
 

--- a/internal/app/task_service.go
+++ b/internal/app/task_service.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"log/slog"
 	"strings"
 
 	"github.com/oklog/ulid/v2"
@@ -19,14 +20,16 @@ type TaskCommandService interface {
 }
 
 type TaskCommandServiceDependencies struct {
-	CommandName string
-	Store       ThreadStore
-	NewTaskID   func() string
+	CommandName      string
+	Store            ThreadStore
+	WorkspaceManager TaskWorkspaceManager
+	NewTaskID        func() string
 }
 
 type DefaultTaskCommandService struct {
 	commands  commandSurface
 	store     ThreadStore
+	worktrees TaskWorkspaceManager
 	newTaskID func() string
 }
 
@@ -50,6 +53,7 @@ func NewTaskCommandService(deps TaskCommandServiceDependencies) (*DefaultTaskCom
 	return &DefaultTaskCommandService{
 		commands:  newCommandSurface(commandName),
 		store:     deps.Store,
+		worktrees: deps.WorkspaceManager,
 		newTaskID: newTaskID,
 	}, nil
 }
@@ -126,11 +130,14 @@ func (s *DefaultTaskCommandService) CreateTask(ctx context.Context, userID strin
 	}
 
 	task := Task{
-		TaskID:        s.newTaskID(),
-		DiscordUserID: userID,
-		TaskName:      taskName,
-		Status:        TaskStatusOpen,
+		TaskID:         s.newTaskID(),
+		DiscordUserID:  userID,
+		TaskName:       taskName,
+		Status:         TaskStatusOpen,
+		WorktreeStatus: TaskWorktreeStatusPending,
 	}
+
+	task.BranchName = DefaultTaskBranchName(task.TaskID)
 
 	if err := s.store.CreateTask(ctx, task); err != nil {
 		return MessageResponse{}, fmt.Errorf("create task: %w", err)
@@ -235,10 +242,13 @@ func (s *DefaultTaskCommandService) CloseTask(ctx context.Context, userID string
 	}
 
 	if hasActiveTask && activeTask.TaskID == task.TaskID {
+		s.pruneClosedTaskWorktrees(ctx)
 		return taskCommandResponse(
 			fmt.Sprintf("Closed task %s. No active task is selected now.", renderTask(task)),
 		), nil
 	}
+
+	s.pruneClosedTaskWorktrees(ctx)
 
 	nextActiveTaskLine, err := s.renderActiveTaskSuffix(ctx, userID)
 	if err != nil {
@@ -301,5 +311,15 @@ func taskCommandResponse(text string) MessageResponse {
 	return MessageResponse{
 		Text:      text,
 		Ephemeral: true,
+	}
+}
+
+func (s *DefaultTaskCommandService) pruneClosedTaskWorktrees(ctx context.Context) {
+	if s.worktrees == nil {
+		return
+	}
+
+	if err := s.worktrees.PruneClosed(ctx); err != nil {
+		slog.Error("prune closed task worktrees", "error", err)
 	}
 }

--- a/internal/app/task_service_test.go
+++ b/internal/app/task_service_test.go
@@ -91,6 +91,14 @@ func TestTaskCommandServiceCreateTaskMakesTaskActive(t *testing.T) {
 		t.Fatalf("TaskName = %q, want %q", task.TaskName, "Release work")
 	}
 
+	if task.BranchName != "task/01JABCDEF0123456789TASK000" {
+		t.Fatalf("BranchName = %q, want %q", task.BranchName, "task/01JABCDEF0123456789TASK000")
+	}
+
+	if task.WorktreeStatus != app.TaskWorktreeStatusPending {
+		t.Fatalf("WorktreeStatus = %q, want %q", task.WorktreeStatus, app.TaskWorktreeStatusPending)
+	}
+
 	activeTask, ok, err := store.GetActiveTask(context.Background(), "user-1")
 	if err != nil {
 		t.Fatalf("GetActiveTask() error = %v", err)
@@ -254,9 +262,37 @@ func TestTaskCommandServiceCloseTaskKeepsDifferentActiveTask(t *testing.T) {
 	}
 }
 
+func TestTaskCommandServiceCloseTaskTriggersPruning(t *testing.T) {
+	t.Parallel()
+
+	store := &memoryThreadStore{
+		tasks: map[string]app.Task{
+			"user-1:task-1": {
+				TaskID:         "task-1",
+				DiscordUserID:  "user-1",
+				TaskName:       "Release work",
+				Status:         app.TaskStatusOpen,
+				CreatedAt:      time.Date(2026, time.April, 5, 0, 0, 0, 0, time.UTC),
+				WorktreeStatus: app.TaskWorktreeStatusReady,
+			},
+		},
+	}
+
+	worktrees := &countingTaskWorkspaceManager{}
+	service := newTaskCommandServiceWithWorkspace(t, store, nil, worktrees)
+
+	if _, err := service.CloseTask(context.Background(), "user-1", "task-1"); err != nil {
+		t.Fatalf("CloseTask() error = %v", err)
+	}
+
+	if worktrees.pruneCalls != 1 {
+		t.Fatalf("PruneClosed() call count = %d, want %d", worktrees.pruneCalls, 1)
+	}
+}
+
 func newTaskCommandService(t *testing.T, store app.ThreadStore) *app.DefaultTaskCommandService {
 	t.Helper()
-	return newTaskCommandServiceWithID(t, store, nil)
+	return newTaskCommandServiceWithWorkspace(t, store, nil, nil)
 }
 
 func newTaskCommandServiceWithID(
@@ -265,15 +301,39 @@ func newTaskCommandServiceWithID(
 	newTaskID func() string,
 ) *app.DefaultTaskCommandService {
 	t.Helper()
+	return newTaskCommandServiceWithWorkspace(t, store, newTaskID, nil)
+}
+
+func newTaskCommandServiceWithWorkspace(
+	t *testing.T,
+	store app.ThreadStore,
+	newTaskID func() string,
+	worktrees app.TaskWorkspaceManager,
+) *app.DefaultTaskCommandService {
+	t.Helper()
 
 	service, err := app.NewTaskCommandService(app.TaskCommandServiceDependencies{
-		CommandName: "release",
-		Store:       store,
-		NewTaskID:   newTaskID,
+		CommandName:      "release",
+		Store:            store,
+		WorkspaceManager: worktrees,
+		NewTaskID:        newTaskID,
 	})
 	if err != nil {
 		t.Fatalf("NewTaskCommandService() error = %v", err)
 	}
 
 	return service
+}
+
+type countingTaskWorkspaceManager struct {
+	pruneCalls int
+}
+
+func (*countingTaskWorkspaceManager) EnsureReady(context.Context, app.Task) (app.Task, error) {
+	return app.Task{}, nil
+}
+
+func (m *countingTaskWorkspaceManager) PruneClosed(context.Context) error {
+	m.pruneCalls++
+	return nil
 }

--- a/internal/app/task_workspace.go
+++ b/internal/app/task_workspace.go
@@ -1,0 +1,300 @@
+package app
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const (
+	defaultGitExecutablePath   = "git"
+	defaultClosedTaskRetention = 15
+	worktreesDirectoryName     = "worktrees"
+	worktreeDirectoryPerms     = 0o755
+)
+
+type TaskWorkspaceManagerDependencies struct {
+	Store            ThreadStore
+	SourceRepository string
+	DataDir          string
+	GitExecutable    string
+	ClosedRetention  int
+	Logger           *slog.Logger
+	Clock            func() time.Time
+}
+
+type GitTaskWorkspaceManager struct {
+	store            ThreadStore
+	sourceRepository string
+	dataDir          string
+	gitExecutable    string
+	closedRetention  int
+	logger           *slog.Logger
+	clock            func() time.Time
+}
+
+func NewTaskWorkspaceManager(deps TaskWorkspaceManagerDependencies) (*GitTaskWorkspaceManager, error) {
+	if deps.Store == nil {
+		return nil, errors.New("thread store must not be nil")
+	}
+
+	sourceRepository := strings.TrimSpace(deps.SourceRepository)
+	if sourceRepository == "" {
+		return nil, errors.New("source repository must not be empty")
+	}
+
+	dataDir := strings.TrimSpace(deps.DataDir)
+	if dataDir == "" {
+		return nil, errors.New("data dir must not be empty")
+	}
+
+	gitExecutable := strings.TrimSpace(deps.GitExecutable)
+	if gitExecutable == "" {
+		gitExecutable = defaultGitExecutablePath
+	}
+
+	closedRetention := deps.ClosedRetention
+	if closedRetention <= 0 {
+		closedRetention = defaultClosedTaskRetention
+	}
+
+	logger := deps.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+
+	clock := deps.Clock
+	if clock == nil {
+		clock = time.Now().UTC
+	}
+
+	return &GitTaskWorkspaceManager{
+		store:            deps.Store,
+		sourceRepository: sourceRepository,
+		dataDir:          dataDir,
+		gitExecutable:    gitExecutable,
+		closedRetention:  closedRetention,
+		logger:           logger,
+		clock:            clock,
+	}, nil
+}
+
+func DefaultTaskBranchName(taskID string) string {
+	return "task/" + strings.TrimSpace(taskID)
+}
+
+func (m *GitTaskWorkspaceManager) EnsureReady(ctx context.Context, task Task) (Task, error) {
+	if strings.TrimSpace(task.TaskID) == "" {
+		return Task{}, errors.New("task id must not be empty")
+	}
+
+	if task.BranchName == "" {
+		task.BranchName = DefaultTaskBranchName(task.TaskID)
+	}
+
+	if task.WorktreeStatus == "" {
+		task.WorktreeStatus = TaskWorktreeStatusPending
+	}
+
+	if task.WorktreeStatus == TaskWorktreeStatusReady && strings.TrimSpace(task.WorktreePath) != "" {
+		return task, nil
+	}
+
+	baseRef := task.BaseRef
+	if baseRef == "" {
+		detectedBaseRef, err := m.detectBaseRef(ctx)
+		if err != nil {
+			return Task{}, m.markTaskWorktreeFailed(ctx, task, "", err)
+		}
+		baseRef = detectedBaseRef
+	}
+
+	worktreePath := task.WorktreePath
+	if worktreePath == "" {
+		worktreePath = m.worktreePath(task.TaskID)
+	}
+
+	if err := m.prepareWorktreePath(ctx, worktreePath); err != nil {
+		return Task{}, m.markTaskWorktreeFailed(ctx, task, worktreePath, err)
+	}
+
+	branchExists, err := m.branchExists(ctx, task.BranchName)
+	if err != nil {
+		return Task{}, m.markTaskWorktreeFailed(ctx, task, worktreePath, err)
+	}
+
+	args := []string{"worktree", "add"}
+	if !branchExists {
+		args = append(args, "-b", task.BranchName)
+	}
+	args = append(args, worktreePath)
+	if branchExists {
+		args = append(args, task.BranchName)
+	} else {
+		args = append(args, baseRef)
+	}
+
+	if _, err := m.runGit(ctx, args...); err != nil {
+		return Task{}, m.markTaskWorktreeFailed(ctx, task, worktreePath, err)
+	}
+
+	now := m.clock()
+	task.BaseRef = baseRef
+	task.WorktreePath = worktreePath
+	task.WorktreeStatus = TaskWorktreeStatusReady
+	task.WorktreePrunedAt = nil
+	task.UpdatedAt = now
+	if task.WorktreeCreatedAt == nil {
+		task.WorktreeCreatedAt = &now
+	}
+
+	if err := m.store.UpdateTask(ctx, task); err != nil {
+		return Task{}, fmt.Errorf("persist ready task worktree: %w", err)
+	}
+
+	return task, nil
+}
+
+func (m *GitTaskWorkspaceManager) PruneClosed(ctx context.Context) error {
+	tasks, err := m.store.ListClosedReadyTasks(ctx)
+	if err != nil {
+		return fmt.Errorf("list closed ready tasks: %w", err)
+	}
+
+	if len(tasks) <= m.closedRetention {
+		return nil
+	}
+
+	var errs []error
+	for _, task := range tasks[m.closedRetention:] {
+		if strings.TrimSpace(task.WorktreePath) == "" {
+			continue
+		}
+
+		if _, err := m.runGit(ctx, "worktree", "remove", "--force", task.WorktreePath); err != nil {
+			m.logger.Error(
+				"prune closed task worktree",
+				"task_id", task.TaskID,
+				"worktree_path", task.WorktreePath,
+				"error", err,
+			)
+			errs = append(errs, fmt.Errorf("prune task %s: %w", task.TaskID, err))
+			continue
+		}
+
+		now := m.clock()
+		task.WorktreeStatus = TaskWorktreeStatusPruned
+		task.WorktreePrunedAt = &now
+		task.UpdatedAt = now
+		if err := m.store.UpdateTask(ctx, task); err != nil {
+			m.logger.Error(
+				"persist pruned task worktree",
+				"task_id", task.TaskID,
+				"worktree_path", task.WorktreePath,
+				"error", err,
+			)
+			errs = append(errs, fmt.Errorf("persist pruned task %s: %w", task.TaskID, err))
+		}
+	}
+
+	return errors.Join(errs...)
+}
+
+func (m *GitTaskWorkspaceManager) detectBaseRef(ctx context.Context) (string, error) {
+	for _, ref := range []string{"main", "master"} {
+		if _, err := m.runGit(ctx, "rev-parse", "--verify", "--quiet", ref+"^{commit}"); err == nil {
+			return ref, nil
+		}
+	}
+
+	return "", errors.New("detect task worktree base ref: expected local branch main or master")
+}
+
+func (m *GitTaskWorkspaceManager) branchExists(ctx context.Context, branchName string) (bool, error) {
+	_, err := m.runGit(ctx, "show-ref", "--verify", "--quiet", "refs/heads/"+branchName)
+	if err == nil {
+		return true, nil
+	}
+
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
+		return false, nil
+	}
+
+	return false, fmt.Errorf("check branch existence: %w", err)
+}
+
+func (m *GitTaskWorkspaceManager) prepareWorktreePath(ctx context.Context, worktreePath string) error {
+	if err := os.MkdirAll(filepath.Dir(worktreePath), worktreeDirectoryPerms); err != nil {
+		return fmt.Errorf("create worktree parent directory: %w", err)
+	}
+
+	if _, statErr := os.Stat(worktreePath); statErr == nil {
+		if _, err := m.runGit(ctx, "worktree", "remove", "--force", worktreePath); err != nil {
+			m.logger.Debug("ignore stale worktree removal failure before retry", "worktree_path", worktreePath, "error", err)
+		}
+	} else if !errors.Is(statErr, os.ErrNotExist) {
+		return fmt.Errorf("stat existing worktree path: %w", statErr)
+	}
+
+	if err := os.RemoveAll(worktreePath); err != nil {
+		return fmt.Errorf("clear worktree path: %w", err)
+	}
+
+	return nil
+}
+
+func (m *GitTaskWorkspaceManager) markTaskWorktreeFailed(
+	ctx context.Context,
+	task Task,
+	worktreePath string,
+	cause error,
+) error {
+	now := m.clock()
+	task.WorktreeStatus = TaskWorktreeStatusFailed
+	task.UpdatedAt = now
+	if task.WorktreePath == "" {
+		task.WorktreePath = worktreePath
+	}
+
+	if err := m.store.UpdateTask(ctx, task); err != nil {
+		return fmt.Errorf("mark task worktree failed: %w: %v", err, cause)
+	}
+
+	return cause
+}
+
+func (m *GitTaskWorkspaceManager) worktreePath(taskID string) string {
+	return filepath.Join(m.dataDir, worktreesDirectoryName, taskID)
+}
+
+func (m *GitTaskWorkspaceManager) runGit(ctx context.Context, args ...string) (string, error) {
+	commandArgs := append([]string{"-C", m.sourceRepository}, args...)
+
+	//nolint:gosec // The git executable path is intentionally configurable for tests.
+	cmd := exec.CommandContext(ctx, m.gitExecutable, commandArgs...)
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		message := strings.TrimSpace(stderr.String())
+		if message == "" {
+			message = strings.TrimSpace(stdout.String())
+		}
+		if message == "" {
+			return "", fmt.Errorf("run git %s: %w", strings.Join(args, " "), err)
+		}
+		return "", fmt.Errorf("run git %s: %w: %s", strings.Join(args, " "), err, message)
+	}
+
+	return strings.TrimSpace(stdout.String()), nil
+}

--- a/internal/app/task_workspace_test.go
+++ b/internal/app/task_workspace_test.go
@@ -1,0 +1,200 @@
+package app_test
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/HatsuneMiku3939/39claw/internal/app"
+)
+
+func TestGitTaskWorkspaceManagerEnsureReadyCreatesWorktree(t *testing.T) {
+	t.Parallel()
+
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git is required for worktree integration tests")
+	}
+
+	sourceRepo := createGitRepository(t, "main")
+	dataDir := t.TempDir()
+	store := &memoryThreadStore{
+		tasks: map[string]app.Task{
+			"user-1:task-1": {
+				TaskID:         "task-1",
+				DiscordUserID:  "user-1",
+				TaskName:       "Release work",
+				Status:         app.TaskStatusOpen,
+				BranchName:     app.DefaultTaskBranchName("task-1"),
+				WorktreeStatus: app.TaskWorktreeStatusPending,
+				CreatedAt:      time.Date(2026, time.April, 5, 0, 0, 0, 0, time.UTC),
+			},
+		},
+	}
+
+	manager, err := app.NewTaskWorkspaceManager(app.TaskWorkspaceManagerDependencies{
+		Store:            store,
+		SourceRepository: sourceRepo,
+		DataDir:          dataDir,
+		GitExecutable:    "git",
+		Clock: func() time.Time {
+			return time.Date(2026, time.April, 5, 15, 4, 0, 0, time.UTC)
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewTaskWorkspaceManager() error = %v", err)
+	}
+
+	task, ok, err := store.GetTask(context.Background(), "user-1", "task-1")
+	if err != nil {
+		t.Fatalf("GetTask() error = %v", err)
+	}
+	if !ok {
+		t.Fatal("GetTask() ok = false, want true")
+	}
+
+	readyTask, err := manager.EnsureReady(context.Background(), task)
+	if err != nil {
+		t.Fatalf("EnsureReady() error = %v", err)
+	}
+
+	wantPath := filepath.Join(dataDir, "worktrees", "task-1")
+	if readyTask.WorktreePath != wantPath {
+		t.Fatalf("WorktreePath = %q, want %q", readyTask.WorktreePath, wantPath)
+	}
+
+	if readyTask.WorktreeStatus != app.TaskWorktreeStatusReady {
+		t.Fatalf("WorktreeStatus = %q, want %q", readyTask.WorktreeStatus, app.TaskWorktreeStatusReady)
+	}
+
+	if readyTask.BaseRef != "main" {
+		t.Fatalf("BaseRef = %q, want %q", readyTask.BaseRef, "main")
+	}
+
+	if _, err := os.Stat(filepath.Join(wantPath, ".git")); err != nil {
+		t.Fatalf("worktree .git stat error = %v", err)
+	}
+}
+
+func TestGitTaskWorkspaceManagerPruneClosedRemovesOldReadyWorktrees(t *testing.T) {
+	t.Parallel()
+
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git is required for worktree integration tests")
+	}
+
+	sourceRepo := createGitRepository(t, "main")
+	dataDir := t.TempDir()
+	store := &memoryThreadStore{}
+	clock := time.Date(2026, time.April, 5, 15, 4, 0, 0, time.UTC)
+
+	manager, err := app.NewTaskWorkspaceManager(app.TaskWorkspaceManagerDependencies{
+		Store:            store,
+		SourceRepository: sourceRepo,
+		DataDir:          dataDir,
+		GitExecutable:    "git",
+		ClosedRetention:  2,
+		Clock: func() time.Time {
+			return clock
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewTaskWorkspaceManager() error = %v", err)
+	}
+
+	for index := 1; index <= 3; index++ {
+		taskID := "task-" + string(rune('0'+index))
+		task := app.Task{
+			TaskID:         taskID,
+			DiscordUserID:  "user-1",
+			TaskName:       taskID,
+			Status:         app.TaskStatusOpen,
+			BranchName:     app.DefaultTaskBranchName(taskID),
+			WorktreeStatus: app.TaskWorktreeStatusPending,
+			CreatedAt:      clock.Add(-time.Duration(index) * time.Hour),
+		}
+		if err := store.CreateTask(context.Background(), task); err != nil {
+			t.Fatalf("CreateTask(%s) error = %v", taskID, err)
+		}
+
+		readyTask, err := manager.EnsureReady(context.Background(), task)
+		if err != nil {
+			t.Fatalf("EnsureReady(%s) error = %v", taskID, err)
+		}
+
+		closedAt := clock.Add(-time.Duration(index) * time.Hour)
+		readyTask.Status = app.TaskStatusClosed
+		readyTask.ClosedAt = &closedAt
+		if err := store.UpdateTask(context.Background(), readyTask); err != nil {
+			t.Fatalf("UpdateTask(%s) error = %v", taskID, err)
+		}
+	}
+
+	if err := manager.PruneClosed(context.Background()); err != nil {
+		t.Fatalf("PruneClosed() error = %v", err)
+	}
+
+	oldestTask, ok, err := store.GetTask(context.Background(), "user-1", "task-3")
+	if err != nil {
+		t.Fatalf("GetTask(task-3) error = %v", err)
+	}
+	if !ok {
+		t.Fatal("GetTask(task-3) ok = false, want true")
+	}
+
+	if oldestTask.WorktreeStatus != app.TaskWorktreeStatusPruned {
+		t.Fatalf("oldest task WorktreeStatus = %q, want %q", oldestTask.WorktreeStatus, app.TaskWorktreeStatusPruned)
+	}
+
+	if oldestTask.WorktreePrunedAt == nil {
+		t.Fatal("oldest task WorktreePrunedAt = nil, want non-nil")
+	}
+
+	if _, err := os.Stat(filepath.Join(dataDir, "worktrees", "task-3")); !os.IsNotExist(err) {
+		t.Fatalf("oldest worktree path stat error = %v, want not-exist", err)
+	}
+
+	newestTask, ok, err := store.GetTask(context.Background(), "user-1", "task-1")
+	if err != nil {
+		t.Fatalf("GetTask(task-1) error = %v", err)
+	}
+	if !ok {
+		t.Fatal("GetTask(task-1) ok = false, want true")
+	}
+
+	if newestTask.WorktreeStatus != app.TaskWorktreeStatusReady {
+		t.Fatalf("newest task WorktreeStatus = %q, want %q", newestTask.WorktreeStatus, app.TaskWorktreeStatusReady)
+	}
+}
+
+func createGitRepository(t *testing.T, branch string) string {
+	t.Helper()
+
+	repo := t.TempDir()
+
+	runGit(t, repo, "init", "-b", branch)
+	runGit(t, repo, "config", "user.email", "codex@example.com")
+	runGit(t, repo, "config", "user.name", "Codex")
+
+	filePath := filepath.Join(repo, "README.md")
+	if err := os.WriteFile(filePath, []byte("hello\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(README.md) error = %v", err)
+	}
+
+	runGit(t, repo, "add", "README.md")
+	runGit(t, repo, "commit", "-m", "initial commit")
+
+	return repo
+}
+
+func runGit(t *testing.T, workdir string, args ...string) {
+	t.Helper()
+
+	cmd := exec.Command("git", args...)
+	cmd.Dir = workdir
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v error = %v\n%s", args, err, output)
+	}
+}

--- a/internal/app/types.go
+++ b/internal/app/types.go
@@ -38,14 +38,30 @@ const (
 	TaskStatusClosed TaskStatus = "closed"
 )
 
+type TaskWorktreeStatus string
+
+const (
+	TaskWorktreeStatusPending TaskWorktreeStatus = "pending"
+	TaskWorktreeStatusReady   TaskWorktreeStatus = "ready"
+	TaskWorktreeStatusFailed  TaskWorktreeStatus = "failed"
+	TaskWorktreeStatusPruned  TaskWorktreeStatus = "pruned"
+)
+
 type Task struct {
-	TaskID        string
-	DiscordUserID string
-	TaskName      string
-	Status        TaskStatus
-	CreatedAt     time.Time
-	UpdatedAt     time.Time
-	ClosedAt      *time.Time
+	TaskID            string
+	DiscordUserID     string
+	TaskName          string
+	Status            TaskStatus
+	BranchName        string
+	BaseRef           string
+	WorktreePath      string
+	WorktreeStatus    TaskWorktreeStatus
+	CreatedAt         time.Time
+	UpdatedAt         time.Time
+	ClosedAt          *time.Time
+	WorktreeCreatedAt *time.Time
+	WorktreePrunedAt  *time.Time
+	LastUsedAt        *time.Time
 }
 
 type ActiveTask struct {
@@ -67,8 +83,9 @@ type RunTurnResult struct {
 }
 
 type CodexTurnInput struct {
-	Prompt     string
-	ImagePaths []string
+	Prompt           string
+	ImagePaths       []string
+	WorkingDirectory string
 }
 
 type QueueAdmission struct {

--- a/internal/codex/gateway.go
+++ b/internal/codex/gateway.go
@@ -34,9 +34,14 @@ func (g *Gateway) RunTurn(ctx context.Context, threadID string, input app.CodexT
 		return app.RunTurnResult{}, err
 	}
 
-	thread := g.client.StartThread(g.threadOptions)
+	threadOptions := g.threadOptions
+	if strings.TrimSpace(input.WorkingDirectory) != "" {
+		threadOptions.WorkingDirectory = input.WorkingDirectory
+	}
+
+	thread := g.client.StartThread(threadOptions)
 	if threadID != "" {
-		thread = g.client.ResumeThread(threadID, g.threadOptions)
+		thread = g.client.ResumeThread(threadID, threadOptions)
 	}
 
 	turn, err := thread.Run(ctx, codexInput)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -143,6 +144,33 @@ func LoadFromLookup(lookup func(string) (string, bool)) (Config, error) {
 		CodexNetworkAccess:         networkAccess,
 		LogLevel:                   logLevel,
 	}, nil
+}
+
+func ValidateRuntimePaths(cfg Config) error {
+	if cfg.Mode != ModeTask {
+		return nil
+	}
+
+	info, err := os.Stat(cfg.CodexWorkdir)
+	if err != nil {
+		return fmt.Errorf("task mode requires CLAW_CODEX_WORKDIR to exist: %w", err)
+	}
+
+	if !info.IsDir() {
+		return fmt.Errorf("task mode requires CLAW_CODEX_WORKDIR to be a directory: %s", cfg.CodexWorkdir)
+	}
+
+	gitEntryPath := filepath.Join(cfg.CodexWorkdir, ".git")
+	_, err = os.Stat(gitEntryPath)
+	if err == nil {
+		return nil
+	}
+
+	if errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("task mode requires CLAW_CODEX_WORKDIR to be a Git repository root: %s", cfg.CodexWorkdir)
+	}
+
+	return fmt.Errorf("inspect CLAW_CODEX_WORKDIR git metadata: %w", err)
 }
 
 func sqlitePath(dataDir string) string {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -280,6 +281,91 @@ func TestLoadFromLookup(t *testing.T) {
 
 			if got.LogLevel != tt.want.LogLevel {
 				t.Fatalf("LogLevel = %q, want %q", got.LogLevel, tt.want.LogLevel)
+			}
+		})
+	}
+}
+
+func TestValidateRuntimePaths(t *testing.T) {
+	t.Parallel()
+
+	taskRepo := t.TempDir()
+	if err := os.Mkdir(filepath.Join(taskRepo, ".git"), 0o755); err != nil {
+		t.Fatalf("Mkdir(.git) error = %v", err)
+	}
+
+	nonRepo := t.TempDir()
+	filePath := filepath.Join(t.TempDir(), "not-a-dir")
+	if err := os.WriteFile(filePath, []byte("hello"), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	tests := []struct {
+		name    string
+		config  Config
+		wantErr string
+	}{
+		{
+			name: "allows daily mode non-git workdir",
+			config: Config{
+				Mode:         ModeDaily,
+				CodexWorkdir: nonRepo,
+			},
+		},
+		{
+			name: "allows task mode git repository root",
+			config: Config{
+				Mode:         ModeTask,
+				CodexWorkdir: taskRepo,
+			},
+		},
+		{
+			name: "rejects missing task mode workdir",
+			config: Config{
+				Mode:         ModeTask,
+				CodexWorkdir: filepath.Join(t.TempDir(), "missing"),
+			},
+			wantErr: "task mode requires CLAW_CODEX_WORKDIR to exist",
+		},
+		{
+			name: "rejects task mode file path",
+			config: Config{
+				Mode:         ModeTask,
+				CodexWorkdir: filePath,
+			},
+			wantErr: "task mode requires CLAW_CODEX_WORKDIR to be a directory",
+		},
+		{
+			name: "rejects task mode non-git directory",
+			config: Config{
+				Mode:         ModeTask,
+				CodexWorkdir: nonRepo,
+			},
+			wantErr: "task mode requires CLAW_CODEX_WORKDIR to be a Git repository root",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := ValidateRuntimePaths(tt.config)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("ValidateRuntimePaths() error = %v", err)
+				}
+
+				return
+			}
+
+			if err == nil {
+				t.Fatalf("ValidateRuntimePaths() error = nil, want substring %q", tt.wantErr)
+			}
+
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("ValidateRuntimePaths() error = %q, want substring %q", err.Error(), tt.wantErr)
 			}
 		})
 	}

--- a/internal/store/sqlite/store.go
+++ b/internal/store/sqlite/store.go
@@ -20,6 +20,19 @@ const (
 	sqliteDirectoryPermsMode = 0o755
 )
 
+var taskColumnDefinitions = []struct {
+	name       string
+	definition string
+}{
+	{name: "branch_name", definition: `TEXT NOT NULL DEFAULT ''`},
+	{name: "base_ref", definition: `TEXT NULL`},
+	{name: "worktree_path", definition: `TEXT NULL`},
+	{name: "worktree_status", definition: `TEXT NOT NULL DEFAULT 'pending'`},
+	{name: "worktree_created_at", definition: `TEXT NULL`},
+	{name: "worktree_pruned_at", definition: `TEXT NULL`},
+	{name: "last_used_at", definition: `TEXT NULL`},
+}
+
 type Store struct {
 	db    *sql.DB
 	clock func() time.Time
@@ -78,9 +91,16 @@ func (s *Store) InitSchema(ctx context.Context) error {
 			discord_user_id TEXT NOT NULL,
 			task_name TEXT NOT NULL,
 			status TEXT NOT NULL,
+			branch_name TEXT NOT NULL DEFAULT '',
+			base_ref TEXT NULL,
+			worktree_path TEXT NULL,
+			worktree_status TEXT NOT NULL DEFAULT 'pending',
 			created_at TEXT NOT NULL,
 			updated_at TEXT NOT NULL,
-			closed_at TEXT NULL
+			closed_at TEXT NULL,
+			worktree_created_at TEXT NULL,
+			worktree_pruned_at TEXT NULL,
+			last_used_at TEXT NULL
 		);`,
 		`CREATE TABLE IF NOT EXISTS active_tasks (
 			discord_user_id TEXT PRIMARY KEY,
@@ -93,6 +113,17 @@ func (s *Store) InitSchema(ctx context.Context) error {
 		if _, err := s.db.ExecContext(ctx, statement); err != nil {
 			return fmt.Errorf("exec schema statement: %w", err)
 		}
+	}
+
+	if err := s.ensureTaskColumns(ctx); err != nil {
+		return err
+	}
+
+	if _, err := s.db.ExecContext(
+		ctx,
+		`UPDATE tasks SET branch_name = 'task/' || task_id WHERE branch_name = ''`,
+	); err != nil {
+		return fmt.Errorf("backfill task branch names: %w", err)
 	}
 
 	return nil
@@ -182,18 +213,34 @@ func (s *Store) CreateTask(ctx context.Context, task app.Task) error {
 		task.Status = app.TaskStatusOpen
 	}
 
+	if task.BranchName == "" {
+		task.BranchName = app.DefaultTaskBranchName(task.TaskID)
+	}
+
+	if task.WorktreeStatus == "" {
+		task.WorktreeStatus = app.TaskWorktreeStatusPending
+	}
+
 	_, err := s.db.ExecContext(
 		ctx,
 		`INSERT INTO tasks (
-			task_id, discord_user_id, task_name, status, created_at, updated_at, closed_at
-		) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+			task_id, discord_user_id, task_name, status, branch_name, base_ref, worktree_path,
+			worktree_status, created_at, updated_at, closed_at, worktree_created_at, worktree_pruned_at, last_used_at
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		task.TaskID,
 		task.DiscordUserID,
 		task.TaskName,
 		string(task.Status),
+		task.BranchName,
+		nullableString(task.BaseRef),
+		nullableString(task.WorktreePath),
+		string(task.WorktreeStatus),
 		task.CreatedAt.Format(time.RFC3339Nano),
 		task.UpdatedAt.Format(time.RFC3339Nano),
 		nullableTime(task.ClosedAt),
+		nullableTime(task.WorktreeCreatedAt),
+		nullableTime(task.WorktreePrunedAt),
+		nullableTime(task.LastUsedAt),
 	)
 	if err != nil {
 		return fmt.Errorf("create task: %w", err)
@@ -205,7 +252,8 @@ func (s *Store) CreateTask(ctx context.Context, task app.Task) error {
 func (s *Store) GetTask(ctx context.Context, discordUserID string, taskID string) (app.Task, bool, error) {
 	row := s.db.QueryRowContext(
 		ctx,
-		`SELECT task_id, discord_user_id, task_name, status, created_at, updated_at, closed_at
+		`SELECT task_id, discord_user_id, task_name, status, branch_name, base_ref, worktree_path, worktree_status,
+			created_at, updated_at, closed_at, worktree_created_at, worktree_pruned_at, last_used_at
 		FROM tasks WHERE discord_user_id = ? AND task_id = ?`,
 		discordUserID,
 		taskID,
@@ -217,7 +265,8 @@ func (s *Store) GetTask(ctx context.Context, discordUserID string, taskID string
 func (s *Store) ListOpenTasks(ctx context.Context, discordUserID string) ([]app.Task, error) {
 	rows, err := s.db.QueryContext(
 		ctx,
-		`SELECT task_id, discord_user_id, task_name, status, created_at, updated_at, closed_at
+		`SELECT task_id, discord_user_id, task_name, status, branch_name, base_ref, worktree_path, worktree_status,
+			created_at, updated_at, closed_at, worktree_created_at, worktree_pruned_at, last_used_at
 		FROM tasks WHERE discord_user_id = ? AND status = ? ORDER BY created_at ASC`,
 		discordUserID,
 		string(app.TaskStatusOpen),
@@ -238,6 +287,92 @@ func (s *Store) ListOpenTasks(ctx context.Context, discordUserID string) ([]app.
 
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("iterate open tasks: %w", err)
+	}
+
+	return tasks, nil
+}
+
+func (s *Store) UpdateTask(ctx context.Context, task app.Task) error {
+	now := s.clock()
+	if task.UpdatedAt.IsZero() {
+		task.UpdatedAt = now
+	}
+
+	if task.Status == "" {
+		task.Status = app.TaskStatusOpen
+	}
+
+	if task.BranchName == "" {
+		task.BranchName = app.DefaultTaskBranchName(task.TaskID)
+	}
+
+	if task.WorktreeStatus == "" {
+		task.WorktreeStatus = app.TaskWorktreeStatusPending
+	}
+
+	result, err := s.db.ExecContext(
+		ctx,
+		`UPDATE tasks
+		SET task_name = ?, status = ?, branch_name = ?, base_ref = ?, worktree_path = ?, worktree_status = ?,
+			updated_at = ?, closed_at = ?, worktree_created_at = ?, worktree_pruned_at = ?, last_used_at = ?
+		WHERE discord_user_id = ? AND task_id = ?`,
+		task.TaskName,
+		string(task.Status),
+		task.BranchName,
+		nullableString(task.BaseRef),
+		nullableString(task.WorktreePath),
+		string(task.WorktreeStatus),
+		task.UpdatedAt.Format(time.RFC3339Nano),
+		nullableTime(task.ClosedAt),
+		nullableTime(task.WorktreeCreatedAt),
+		nullableTime(task.WorktreePrunedAt),
+		nullableTime(task.LastUsedAt),
+		task.DiscordUserID,
+		task.TaskID,
+	)
+	if err != nil {
+		return fmt.Errorf("update task: %w", err)
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("update task rows affected: %w", err)
+	}
+
+	if rowsAffected == 0 {
+		return sql.ErrNoRows
+	}
+
+	return nil
+}
+
+func (s *Store) ListClosedReadyTasks(ctx context.Context) ([]app.Task, error) {
+	rows, err := s.db.QueryContext(
+		ctx,
+		`SELECT task_id, discord_user_id, task_name, status, branch_name, base_ref, worktree_path, worktree_status,
+			created_at, updated_at, closed_at, worktree_created_at, worktree_pruned_at, last_used_at
+		FROM tasks
+		WHERE status = ? AND worktree_status = ? AND closed_at IS NOT NULL
+		ORDER BY closed_at DESC, task_id ASC`,
+		string(app.TaskStatusClosed),
+		string(app.TaskWorktreeStatusReady),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("query closed ready tasks: %w", err)
+	}
+	defer rows.Close()
+
+	tasks := make([]app.Task, 0)
+	for rows.Next() {
+		task, _, err := scanTask(rows)
+		if err != nil {
+			return nil, err
+		}
+		tasks = append(tasks, task)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate closed ready tasks: %w", err)
 	}
 
 	return tasks, nil
@@ -364,18 +499,32 @@ func (s *Store) CloseTask(ctx context.Context, discordUserID string, taskID stri
 func scanTask(scanner interface{ Scan(dest ...any) error }) (app.Task, bool, error) {
 	var task app.Task
 	var status string
+	var worktreeStatus string
+	var branchName string
+	var baseRef sql.NullString
+	var worktreePath sql.NullString
 	var createdAt string
 	var updatedAt string
 	var closedAt sql.NullString
+	var worktreeCreatedAt sql.NullString
+	var worktreePrunedAt sql.NullString
+	var lastUsedAt sql.NullString
 
 	err := scanner.Scan(
 		&task.TaskID,
 		&task.DiscordUserID,
 		&task.TaskName,
 		&status,
+		&branchName,
+		&baseRef,
+		&worktreePath,
+		&worktreeStatus,
 		&createdAt,
 		&updatedAt,
 		&closedAt,
+		&worktreeCreatedAt,
+		&worktreePrunedAt,
+		&lastUsedAt,
 	)
 	if errors.Is(err, sql.ErrNoRows) {
 		return app.Task{}, false, nil
@@ -386,6 +535,16 @@ func scanTask(scanner interface{ Scan(dest ...any) error }) (app.Task, bool, err
 	}
 
 	task.Status = app.TaskStatus(status)
+	task.BranchName = branchName
+	if task.BranchName == "" {
+		task.BranchName = app.DefaultTaskBranchName(task.TaskID)
+	}
+	task.BaseRef = nullableStringValue(baseRef)
+	task.WorktreePath = nullableStringValue(worktreePath)
+	task.WorktreeStatus = app.TaskWorktreeStatus(worktreeStatus)
+	if task.WorktreeStatus == "" {
+		task.WorktreeStatus = app.TaskWorktreeStatusPending
+	}
 
 	task.CreatedAt, err = time.Parse(time.RFC3339Nano, createdAt)
 	if err != nil {
@@ -405,7 +564,58 @@ func scanTask(scanner interface{ Scan(dest ...any) error }) (app.Task, bool, err
 		task.ClosedAt = &parsedClosedAt
 	}
 
+	if task.WorktreeCreatedAt, err = parseNullableTime(worktreeCreatedAt); err != nil {
+		return app.Task{}, false, fmt.Errorf("parse task worktree_created_at: %w", err)
+	}
+
+	if task.WorktreePrunedAt, err = parseNullableTime(worktreePrunedAt); err != nil {
+		return app.Task{}, false, fmt.Errorf("parse task worktree_pruned_at: %w", err)
+	}
+
+	if task.LastUsedAt, err = parseNullableTime(lastUsedAt); err != nil {
+		return app.Task{}, false, fmt.Errorf("parse task last_used_at: %w", err)
+	}
+
 	return task, true, nil
+}
+
+func (s *Store) ensureTaskColumns(ctx context.Context) error {
+	rows, err := s.db.QueryContext(ctx, `PRAGMA table_info(tasks)`)
+	if err != nil {
+		return fmt.Errorf("query task table info: %w", err)
+	}
+	defer rows.Close()
+
+	existingColumns := make(map[string]struct{})
+	for rows.Next() {
+		var cid int
+		var name string
+		var columnType string
+		var notNull int
+		var defaultValue sql.NullString
+		var primaryKey int
+		if err := rows.Scan(&cid, &name, &columnType, &notNull, &defaultValue, &primaryKey); err != nil {
+			return fmt.Errorf("scan task table info: %w", err)
+		}
+		existingColumns[name] = struct{}{}
+	}
+
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("iterate task table info: %w", err)
+	}
+
+	for _, column := range taskColumnDefinitions {
+		if _, ok := existingColumns[column.name]; ok {
+			continue
+		}
+
+		statement := fmt.Sprintf(`ALTER TABLE tasks ADD COLUMN %s %s`, column.name, column.definition)
+		if _, err := s.db.ExecContext(ctx, statement); err != nil {
+			return fmt.Errorf("add tasks.%s column: %w", column.name, err)
+		}
+	}
+
+	return nil
 }
 
 func nullableString(value string) any {
@@ -422,4 +632,25 @@ func nullableTime(value *time.Time) any {
 	}
 
 	return value.Format(time.RFC3339Nano)
+}
+
+func nullableStringValue(value sql.NullString) string {
+	if !value.Valid {
+		return ""
+	}
+
+	return value.String
+}
+
+func parseNullableTime(value sql.NullString) (*time.Time, error) {
+	if !value.Valid {
+		return nil, nil
+	}
+
+	parsed, err := time.Parse(time.RFC3339Nano, value.String)
+	if err != nil {
+		return nil, err
+	}
+
+	return &parsed, nil
 }

--- a/internal/store/sqlite/store_test.go
+++ b/internal/store/sqlite/store_test.go
@@ -198,6 +198,14 @@ func TestStoreTaskStatePersistsAcrossReopen(t *testing.T) {
 		t.Fatalf("TaskName = %q, want %q", task.TaskName, "Release work")
 	}
 
+	if task.BranchName != "task/task-1" {
+		t.Fatalf("BranchName = %q, want %q", task.BranchName, "task/task-1")
+	}
+
+	if task.WorktreeStatus != app.TaskWorktreeStatusPending {
+		t.Fatalf("WorktreeStatus = %q, want %q", task.WorktreeStatus, app.TaskWorktreeStatusPending)
+	}
+
 	activeTask, ok, err := reopened.GetActiveTask(ctx, "user-1")
 	if err != nil {
 		t.Fatalf("GetActiveTask() reopen error = %v", err)
@@ -244,6 +252,14 @@ func TestStoreTaskLifecycle(t *testing.T) {
 
 	if task.Status != app.TaskStatusOpen {
 		t.Fatalf("Status = %q, want %q", task.Status, app.TaskStatusOpen)
+	}
+
+	if task.BranchName != "task/task-1" {
+		t.Fatalf("BranchName = %q, want %q", task.BranchName, "task/task-1")
+	}
+
+	if task.WorktreeStatus != app.TaskWorktreeStatusPending {
+		t.Fatalf("WorktreeStatus = %q, want %q", task.WorktreeStatus, app.TaskWorktreeStatusPending)
 	}
 
 	tasks, err := store.ListOpenTasks(ctx, "user-1")
@@ -358,6 +374,135 @@ func TestStoreCloseTaskKeepsDifferentActiveTask(t *testing.T) {
 	}
 }
 
+func TestStoreInitSchemaMigratesExistingTaskTable(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "39claw.db")
+
+	db, err := sql.Open(driverName, path)
+	if err != nil {
+		t.Fatalf("sql.Open() error = %v", err)
+	}
+
+	if _, err := db.ExecContext(context.Background(), `CREATE TABLE tasks (
+		task_id TEXT PRIMARY KEY,
+		discord_user_id TEXT NOT NULL,
+		task_name TEXT NOT NULL,
+		status TEXT NOT NULL,
+		created_at TEXT NOT NULL,
+		updated_at TEXT NOT NULL,
+		closed_at TEXT NULL
+	);`); err != nil {
+		t.Fatalf("create legacy tasks table error = %v", err)
+	}
+
+	createdAt := time.Date(2026, time.April, 5, 15, 4, 0, 0, time.UTC).Format(time.RFC3339Nano)
+	if _, err := db.ExecContext(
+		context.Background(),
+		`INSERT INTO tasks (task_id, discord_user_id, task_name, status, created_at, updated_at, closed_at)
+		VALUES (?, ?, ?, ?, ?, ?, NULL)`,
+		"task-1",
+		"user-1",
+		"Legacy task",
+		string(app.TaskStatusOpen),
+		createdAt,
+		createdAt,
+	); err != nil {
+		t.Fatalf("insert legacy task error = %v", err)
+	}
+
+	if err := db.Close(); err != nil {
+		t.Fatalf("db.Close() error = %v", err)
+	}
+
+	store, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	defer func() {
+		if closeErr := store.Close(); closeErr != nil {
+			t.Fatalf("Close() error = %v", closeErr)
+		}
+	}()
+
+	if err := store.InitSchema(context.Background()); err != nil {
+		t.Fatalf("InitSchema() error = %v", err)
+	}
+
+	task, ok, err := store.GetTask(context.Background(), "user-1", "task-1")
+	if err != nil {
+		t.Fatalf("GetTask() error = %v", err)
+	}
+
+	if !ok {
+		t.Fatal("GetTask() ok = false, want true")
+	}
+
+	if task.BranchName != "task/task-1" {
+		t.Fatalf("BranchName = %q, want %q", task.BranchName, "task/task-1")
+	}
+
+	if task.WorktreeStatus != app.TaskWorktreeStatusPending {
+		t.Fatalf("WorktreeStatus = %q, want %q", task.WorktreeStatus, app.TaskWorktreeStatusPending)
+	}
+}
+
+func TestStoreUpdateTaskAndListClosedReadyTasks(t *testing.T) {
+	t.Parallel()
+
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	tasks := []app.Task{
+		{
+			TaskID:         "task-1",
+			DiscordUserID:  "user-1",
+			TaskName:       "Older closed task",
+			Status:         app.TaskStatusClosed,
+			BranchName:     "task/task-1",
+			WorktreePath:   "/tmp/worktrees/task-1",
+			WorktreeStatus: app.TaskWorktreeStatusReady,
+			ClosedAt:       timePtr(time.Date(2026, time.April, 5, 10, 0, 0, 0, time.UTC)),
+		},
+		{
+			TaskID:         "task-2",
+			DiscordUserID:  "user-1",
+			TaskName:       "Newest closed task",
+			Status:         app.TaskStatusClosed,
+			BranchName:     "task/task-2",
+			WorktreePath:   "/tmp/worktrees/task-2",
+			WorktreeStatus: app.TaskWorktreeStatusReady,
+			ClosedAt:       timePtr(time.Date(2026, time.April, 5, 12, 0, 0, 0, time.UTC)),
+		},
+	}
+
+	for _, task := range tasks {
+		if err := store.CreateTask(ctx, task); err != nil {
+			t.Fatalf("CreateTask(%s) error = %v", task.TaskID, err)
+		}
+		if err := store.UpdateTask(ctx, task); err != nil {
+			t.Fatalf("UpdateTask(%s) error = %v", task.TaskID, err)
+		}
+	}
+
+	closedReady, err := store.ListClosedReadyTasks(ctx)
+	if err != nil {
+		t.Fatalf("ListClosedReadyTasks() error = %v", err)
+	}
+
+	if len(closedReady) != 2 {
+		t.Fatalf("ListClosedReadyTasks() len = %d, want %d", len(closedReady), 2)
+	}
+
+	if closedReady[0].TaskID != "task-2" {
+		t.Fatalf("first closed ready task = %q, want %q", closedReady[0].TaskID, "task-2")
+	}
+
+	if closedReady[1].TaskID != "task-1" {
+		t.Fatalf("second closed ready task = %q, want %q", closedReady[1].TaskID, "task-1")
+	}
+}
+
 func newTestStore(t *testing.T) *Store {
 	t.Helper()
 
@@ -381,4 +526,8 @@ func newTestStore(t *testing.T) *Store {
 	})
 
 	return store
+}
+
+func timePtr(value time.Time) *time.Time {
+	return &value
 }

--- a/internal/thread/policy_test.go
+++ b/internal/thread/policy_test.go
@@ -207,7 +207,15 @@ func (s stubThreadStore) GetTask(context.Context, string, string) (app.Task, boo
 	return app.Task{}, false, nil
 }
 
+func (s stubThreadStore) UpdateTask(context.Context, app.Task) error {
+	return nil
+}
+
 func (s stubThreadStore) ListOpenTasks(context.Context, string) ([]app.Task, error) {
+	return nil, nil
+}
+
+func (s stubThreadStore) ListClosedReadyTasks(context.Context) ([]app.Task, error) {
 	return nil, nil
 }
 


### PR DESCRIPTION
## Summary

- add task-specific Git worktree orchestration for task mode
- persist worktree metadata with additive SQLite migration and retry/pruning flows
- validate task-mode source repositories at startup and extend coverage for the new lifecycle

## Background

`task` mode already isolated Codex thread bindings by task, but every task still executed inside one shared checkout. This change makes task switching isolate both the Codex thread context and the working directory used for execution.

## Related issue(s)

- None

## Implementation details

- added a task workspace manager that lazily creates task worktrees, detects `main`/`master`, retries failed setup, and prunes older closed ready worktrees while keeping branches
- extended task persistence with branch/worktree metadata, additive migration, and backfill for legacy rows
- routed task-mode Codex turns through per-task worktree paths and updated task close flow to trigger best-effort pruning
- updated README and the active ExecPlan to reflect the implemented behavior and validation results

## Test coverage

- `make test`
- `make lint`
- added coverage for startup validation, lazy worktree creation, retry handling, pruning, and SQLite migration behavior

## Breaking changes

- `task` mode now fails startup unless `CLAW_CODEX_WORKDIR` is a Git repository root

## Notes

- task branches are retained even when older closed-task worktrees are pruned
- the first normal message for a new task may spend time preparing its dedicated worktree before Codex responds

Created by Codex
