### PR TITLE
Archive completed ExecPlans 07 and 08

### DIFF
--- a/docs/exec-plans/completed/07-instance-specific-root-command.md
+++ b/docs/exec-plans/completed/07-instance-specific-root-command.md
@@ -21,6 +21,7 @@ The user-visible proof is simple. If a bot instance starts with `CLAW_DISCORD_CO
 - [x] (2026-04-04 23:07Z) Updated `README.md`, `docs/product-specs/discord-command-behavior.md`, `docs/product-specs/task-mode-user-flow.md`, and `docs/design-docs/implementation-spec.md` to describe the new command surface.
 - [x] (2026-04-04 23:07Z) Ran `make test` and `make lint` successfully after the implementation landed.
 - [x] (2026-04-04 23:28Z) Manually confirmed in Discord that a guild-scoped bot instance contributes one `/claw` root command entry and that the task-mode smoke flow succeeds end to end.
+- [x] (2026-04-05 02:04Z) Re-checked the repository state, confirmed the acceptance criteria remain satisfied, and archived this completed plan because the implementation, automated validation, and Discord smoke proof are all already present in the repository.
 
 ## Surprises & Discoveries
 
@@ -61,9 +62,15 @@ The user-visible proof is simple. If a bot instance starts with `CLAW_DISCORD_CO
   Rationale: Missing-task and task-state responses are produced below the Discord runtime boundary. Keeping those strings aligned at the source avoids a split-brain UX where slash-command help and task guidance disagree.
   Date/Author: 2026-04-04 / Codex
 
+- Decision: Archive this ExecPlan without additional follow-up tracking.
+  Rationale: The implementation, repository docs, automated validation, and manual Discord smoke proof are complete, and no intentional non-blocking gap remains from this scope.
+  Date/Author: 2026-04-05 / Codex
+
 ## Outcomes & Retrospective
 
 Implementation is complete in code, tests, repository docs, and manual Discord smoke validation. The resulting command surface now scales with the number of installed bot instances instead of scaling with instances multiplied by slash-command variants, and help/task guidance consistently identifies the configured root command for the current deployment. Manual validation in a guild confirmed that one instance contributes one `/claw` root command entry and that the task-mode smoke flow works end to end when guild-scoped registration is used for immediate propagation.
+
+This plan now leaves `active/` because its acceptance criteria are still satisfied in the current repository state and there is no remaining implementation work hidden behind the document. The repository has already absorbed the command-surface migration fully enough that keeping this file active would misrepresent what contributors should pick up next.
 
 ## Context and Orientation
 
@@ -302,3 +309,4 @@ No change in this plan should bypass that app-layer contract or route task contr
 
 Revision Note: 2026-04-04 / Codex - Created this ExecPlan after deciding to replace the shared `/help` and `/task ...` command family with one instance-specific root command in order to avoid Discord command-search explosion in multi-instance deployments.
 Revision Note: 2026-04-05 / Codex - Simplified the plan to use only `CLAW_DISCORD_COMMAND_NAME` after deciding a second display-label setting added complexity without meaningful UX value.
+Revision Note: 2026-04-05 / Codex - Archived this completed ExecPlan after reconciling the living-document sections with the already-landed implementation and validation evidence.

--- a/docs/exec-plans/completed/08-task-mode-worktree-isolation.md
+++ b/docs/exec-plans/completed/08-task-mode-worktree-isolation.md
@@ -19,6 +19,7 @@ The user-visible proof is practical. In `task` mode, creating two tasks and send
 - [x] (2026-04-05 00:24Z) Implemented lazy worktree creation, automatic retry after failed preparation, and closed-task worktree pruning with branch retention.
 - [x] (2026-04-05 00:24Z) Added unit and integration coverage for startup validation, lazy creation, retry behavior, pruning, and schema migration.
 - [x] (2026-04-05 00:24Z) Ran `make test` and `make lint` after the implementation landed.
+- [x] (2026-04-05 02:04Z) Re-checked the repository state, confirmed the acceptance criteria remain satisfied, and archived this completed plan while recording the remaining operator-facing follow-up in `docs/exec-plans/tech-debt-tracker.md`.
 
 ## Surprises & Discoveries
 
@@ -59,11 +60,17 @@ The user-visible proof is practical. In `task` mode, creating two tasks and send
   Rationale: Many failure causes are transient or operator-fixable, so the product should recover without introducing extra task-repair commands in v1.
   Date/Author: 2026-04-04 / Codex
 
+- Decision: Archive this ExecPlan and track later operator-facing improvements as explicit tech debt instead of keeping the implementation plan active.
+  Rationale: The shipped worktree isolation behavior is complete and validated, while the remaining ideas are optional usability enhancements rather than unfinished core scope.
+  Date/Author: 2026-04-05 / Codex
+
 ## Outcomes & Retrospective
 
 This plan is now implemented in the repository. `task` mode startup rejects non-Git source repositories, task creation reserves branch metadata with `worktree_status=pending`, the first normal task message lazily creates a task-specific worktree under `${CLAW_DATADIR}/worktrees/<task_id>`, and later turns reuse that task-specific working directory and Codex thread binding. Closing tasks now keeps task branches but prunes older closed ready worktrees beyond the configured retention window.
 
 The most important lesson was that the feature touches three kinds of state at once: Discord-visible task workflow, Codex thread continuity, and Git workspace lifecycle. Keeping those aligned required a narrow app-layer worktree manager plus additive store migration rather than folding Git operations into the task command flow directly. The remaining follow-up work is operational rather than architectural: if future product needs want manual cleanup commands or richer worktree status output in Discord, those can build on the now-persistent task worktree metadata without changing the core model again.
+
+This plan now leaves `active/` because the core worktree-isolation behavior, persistence migration, retry path, pruning policy, and repository validation are all already implemented and covered. The document would otherwise imply that contributors still need to land core functionality when the only remaining work is optional product hardening captured as explicit follow-up debt.
 
 ## Context and Orientation
 
@@ -275,3 +282,4 @@ Revision note (2026-04-05 00:24Z): Updated the living sections after implementin
 The persistence layer should support reading and updating those fields without the app layer needing raw SQL knowledge. The Codex execution path should accept a task-specific working directory override while preserving the existing global configuration path for `daily` mode.
 
 Revision Note: 2026-04-04 / Codex - Created this active ExecPlan after the task worktree isolation design was agreed and documented.
+Revision Note: 2026-04-05 / Codex - Archived this completed ExecPlan after reconciling the living-document sections and moving the remaining operator-facing ideas into the tech-debt tracker.

--- a/docs/exec-plans/index.md
+++ b/docs/exec-plans/index.md
@@ -25,8 +25,6 @@ Plans in this directory should be written and maintained in line with `.agents/P
 
 These plans are intended to be executed in numeric order. Each plan is self-contained, but later plans name the repository state they expect to find and explain how to recover if that state is missing.
 
-- [Replace shared `/help` and `/task` slash commands with one instance-specific root command](./active/07-instance-specific-root-command.md)
-- [Add task-isolated Git worktrees to `task` mode](./active/08-task-mode-worktree-isolation.md)
 - [Add a durable memory bridge to `daily` mode](./active/09-daily-memory-bridge.md)
 
 ## Recently Completed Plans
@@ -37,3 +35,5 @@ These plans are intended to be executed in numeric order. Each plan is self-cont
 - [Implement the Discord runtime, commands, and response presentation](./completed/04-discord-runtime-and-presentation.md)
 - [Implement capped per-thread message queueing for busy Codex turns](./completed/05-queued-message-handling.md)
 - [Implement Discord image attachment intake for Codex turns](./completed/06-discord-image-input.md)
+- [Replace shared `/help` and `/task` slash commands with one instance-specific root command](./completed/07-instance-specific-root-command.md)
+- [Add task-isolated Git worktrees to `task` mode](./completed/08-task-mode-worktree-isolation.md)

--- a/docs/exec-plans/tech-debt-tracker.md
+++ b/docs/exec-plans/tech-debt-tracker.md
@@ -61,3 +61,24 @@ Keep this entry open until one of the following becomes true:
 - a production or staging issue suggests the live Discord path needs explicit end-to-end confirmation
 
 Until then, treat this as explicit technical debt rather than an implicit missing task. When one of the triggers above is met, run the documented smoke test from `README.md` with a disposable Discord bot token and guild ID, including both normal reply and image-attachment scenarios, then either mark this entry resolved or record any runtime-specific fixes in a follow-up ExecPlan.
+
+### Task worktree operator ergonomics follow-up
+
+- Status: open
+- Date: 2026-04-05
+- Related plan: `docs/exec-plans/completed/08-task-mode-worktree-isolation.md`
+- Owner: Unassigned
+
+### Context
+
+Task-isolated worktrees now exist and the repository validates the core lifecycle correctly, but the shipped v1 surface still keeps worktree lifecycle mostly implicit. Contributors and operators can recover from failed creation through automatic retry, yet there is no dedicated Discord-visible diagnostic or repair affordance for inspecting worktree state, forcing them to rely on logs or the SQLite store when they want to understand why a task workspace is pending, failed, ready, or pruned.
+
+This gap is intentionally deferred because the core scope was isolated task execution, not workspace administration UX. Keeping the follow-up explicit here avoids leaving the completed ExecPlan in `active/` just to remember an optional hardening idea.
+
+### Risk
+
+When task worktree preparation fails or old worktrees are pruned, users may have limited self-service visibility into what happened. That can increase operator support burden and make it slower to distinguish transient setup failures from expected closed-task cleanup behavior.
+
+### Next step
+
+Add the smallest useful operator-facing surface for task worktree state before expanding the workflow further. A safe first increment is to expose each task's current worktree lifecycle state in existing task command responses such as `task-current` and `task-list`, then decide later whether a dedicated repair or cleanup command is still necessary.


### PR DESCRIPTION
## Summary

- archive ExecPlans 07 and 08 under `docs/exec-plans/completed`
- update the ExecPlan index so only plan 09 remains active
- record deferred task-worktree operator ergonomics follow-up as explicit tech debt

## Background

Plans 07 and 08 were still listed under `docs/exec-plans/active` even though their implementation, repository updates, and validation evidence were already present.

## Related issue(s)

- None.

## Implementation details

- finalized the living-document sections for both plans with archival progress, rationale, and revision notes
- moved both plans from `docs/exec-plans/active` to `docs/exec-plans/completed`
- updated `docs/exec-plans/index.md` to reflect the new active/completed split
- added a tech-debt entry for future task worktree operator-facing ergonomics

## Test coverage

- `make test`
- `make lint`

## Breaking changes

- None.

## Notes

- plan 09 remains active and unchanged
- the new tech-debt entry keeps non-blocking follow-up work explicit without leaving completed scope in `active/`

Created by Codex
