### PR TITLE
feat: sanitize Discord workspace paths in replies

### DIFF
--- a/docs/design-docs/implementation-spec.md
+++ b/docs/design-docs/implementation-spec.md
@@ -128,6 +128,7 @@ Closed tasks keep their task branches, but only the fifteen most recently closed
 Unsupported non-mention chatter is ignored.
 Mention-only posts that contain no text and no usable image attachments are also ignored.
 Long responses are chunked into Discord-safe messages while preserving code fences when practical.
+Before a response is sent to Discord, local workspace file references should be rewritten so the absolute `CLAW_CODEX_WORKDIR` path is not exposed, and percent-encoded path segments should be decoded for display.
 Only one Codex turn may run at a time for a given logical thread key.
 If another message arrives for the same logical thread while a turn is running, the bot should accept up to five waiting messages in an in-memory FIFO queue.
 Queued messages should receive an immediate acknowledgment and later receive their final answer as a follow-up reply to the original message.

--- a/docs/product-specs/discord-command-behavior.md
+++ b/docs/product-specs/discord-command-behavior.md
@@ -213,6 +213,9 @@ Examples:
 - short summaries before large technical output
 - avoidance of excessively noisy raw dumps when a summary would be clearer
 
+When responses reference local workspace files, the Discord-facing text should avoid exposing the configured absolute `CLAW_CODEX_WORKDIR`.
+Workspace-local file references should be rewritten into readable workspace-relative paths, and percent-encoded path segments should be decoded before they are shown to users.
+
 ### Error messages
 
 Error responses should be:

--- a/internal/runtime/discord/response_formatter.go
+++ b/internal/runtime/discord/response_formatter.go
@@ -1,0 +1,178 @@
+package discord
+
+import (
+	"net/url"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+var markdownLinkPattern = regexp.MustCompile(`\[(?P<label>[^\]]+)\]\((?P<target>[^)\n]+)\)`)
+
+func formatDiscordResponseText(text string, workdir string) string {
+	text = rewriteMarkdownLinks(text, workdir)
+	text = rewriteWorkspacePaths(text, workdir)
+	return text
+}
+
+func rewriteMarkdownLinks(text string, workdir string) string {
+	matches := markdownLinkPattern.FindAllStringSubmatchIndex(text, -1)
+	if len(matches) == 0 {
+		return text
+	}
+
+	var builder strings.Builder
+	last := 0
+	for _, match := range matches {
+		start := match[0]
+		end := match[1]
+		if start > 0 && text[start-1] == '!' {
+			continue
+		}
+
+		builder.WriteString(text[last:start])
+
+		label := strings.TrimSpace(text[match[2]:match[3]])
+		target := strings.TrimSpace(text[match[4]:match[5]])
+		displayTarget := formatDiscordLinkTarget(target, workdir)
+
+		switch {
+		case label == "" && displayTarget == "":
+		case displayTarget == "":
+			builder.WriteString(label)
+		case label == "" || label == displayTarget:
+			builder.WriteString("`")
+			builder.WriteString(displayTarget)
+			builder.WriteString("`")
+		default:
+			builder.WriteString(label)
+			builder.WriteString(" (`")
+			builder.WriteString(displayTarget)
+			builder.WriteString("`)")
+		}
+
+		last = end
+	}
+
+	builder.WriteString(text[last:])
+	return builder.String()
+}
+
+func formatDiscordLinkTarget(target string, workdir string) string {
+	target = strings.TrimSpace(target)
+	if target == "" {
+		return ""
+	}
+
+	if strings.HasPrefix(target, "http://") || strings.HasPrefix(target, "https://") {
+		return target
+	}
+
+	return sanitizeLocalPathForDiscord(target, workdir)
+}
+
+func sanitizeLocalPathForDiscord(rawPath string, workdir string) string {
+	pathPart, fragment := splitFragment(rawPath)
+	pathPart = decodePercentEscapes(pathPart)
+
+	if workdir != "" {
+		cleanWorkdir := filepath.Clean(workdir)
+		cleanPath := filepath.Clean(pathPart)
+		if relativePath, ok := workspaceRelativePath(cleanWorkdir, cleanPath); ok {
+			pathPart = relativePath
+		} else {
+			pathPart = filepath.ToSlash(cleanPath)
+		}
+	} else {
+		pathPart = filepath.ToSlash(filepath.Clean(pathPart))
+	}
+
+	if fragment == "" {
+		return pathPart
+	}
+
+	return pathPart + "#" + decodePercentEscapes(fragment)
+}
+
+func workspaceRelativePath(workdir string, targetPath string) (string, bool) {
+	relativePath, err := filepath.Rel(workdir, targetPath)
+	if err != nil {
+		return "", false
+	}
+
+	if relativePath == "." {
+		return "workspace", true
+	}
+
+	if relativePath == ".." || strings.HasPrefix(relativePath, ".."+string(filepath.Separator)) {
+		return "", false
+	}
+
+	return filepath.ToSlash(filepath.Join("workspace", relativePath)), true
+}
+
+func rewriteWorkspacePaths(text string, workdir string) string {
+	if strings.TrimSpace(workdir) == "" {
+		return text
+	}
+
+	text = strings.ReplaceAll(text, workdir, "workspace")
+
+	var builder strings.Builder
+	for index := 0; index < len(text); {
+		if !strings.HasPrefix(text[index:], "workspace") {
+			builder.WriteByte(text[index])
+			index++
+			continue
+		}
+
+		end := index + len("workspace")
+		for end < len(text) && isWorkspacePathRune(text[end]) {
+			end++
+		}
+
+		builder.WriteString(decodePercentEscapes(text[index:end]))
+		index = end
+	}
+
+	return builder.String()
+}
+
+func isWorkspacePathRune(value byte) bool {
+	switch value {
+	case '/', '#', '.', '-', '_', '~', '%':
+		return true
+	}
+
+	if value >= '0' && value <= '9' {
+		return true
+	}
+
+	if value >= 'A' && value <= 'Z' {
+		return true
+	}
+
+	if value >= 'a' && value <= 'z' {
+		return true
+	}
+
+	return false
+}
+
+func decodePercentEscapes(value string) string {
+	decoded, err := url.PathUnescape(value)
+	if err != nil {
+		return value
+	}
+
+	return decoded
+}
+
+func splitFragment(value string) (string, string) {
+	pathPart, fragment, found := strings.Cut(value, "#")
+	if !found {
+		return value, ""
+	}
+
+	return pathPart, fragment
+}

--- a/internal/runtime/discord/response_formatter_test.go
+++ b/internal/runtime/discord/response_formatter_test.go
@@ -1,0 +1,31 @@
+package discord
+
+import "testing"
+
+func TestFormatDiscordResponseTextRewritesWorkspaceMarkdownLinks(t *testing.T) {
+	t.Parallel()
+
+	workdir := "/home/filepang/Documents/filepang"
+	text := "그리고 [디펜더봇 평가-머지-릴리즈 자동화](" +
+		"/home/filepang/Documents/filepang/1%20Project/direnv-action/%EB%94%94%ED%8E%9C%EB%8D%94%EB%B4%87%20%ED%8F%89%EA%B0%80-%EB%A8%B8%EC%A7%80-%EB%A6%B4%EB%A6%AC%EC%A6%88%20%EC%9E%90%EB%8F%99%ED%99%94.md" +
+		") 노트도 같이 업데이트했어."
+
+	got := formatDiscordResponseText(text, workdir)
+	want := "그리고 디펜더봇 평가-머지-릴리즈 자동화 (`workspace/1 Project/direnv-action/디펜더봇 평가-머지-릴리즈 자동화.md`) 노트도 같이 업데이트했어."
+	if got != want {
+		t.Fatalf("formatDiscordResponseText() = %q, want %q", got, want)
+	}
+}
+
+func TestFormatDiscordResponseTextRewritesBareWorkspacePaths(t *testing.T) {
+	t.Parallel()
+
+	workdir := "/home/filepang/Documents/filepang"
+	text := "여기 경로를 확인해: /home/filepang/Documents/filepang/1%20Project/%ED%95%9C%EA%B8%80.md"
+
+	got := formatDiscordResponseText(text, workdir)
+	want := "여기 경로를 확인해: workspace/1 Project/한글.md"
+	if got != want {
+		t.Fatalf("formatDiscordResponseText() = %q, want %q", got, want)
+	}
+}

--- a/internal/runtime/discord/runtime.go
+++ b/internal/runtime/discord/runtime.go
@@ -178,7 +178,7 @@ func (r *Runtime) handleMessageCreate(_ *discordgo.Session, event *discordgo.Mes
 		}
 
 		r.logger.Error("prepare image attachments", "error", err, "channel_id", request.ChannelID, "message_id", request.MessageID)
-		if err := presentMessage(discordSession, request.ChannelID, app.MessageResponse{
+		if err := r.presentMessageResponse(discordSession, request.ChannelID, app.MessageResponse{
 			Text:      imageDownloadErrorMessage,
 			ReplyToID: request.MessageID,
 		}); err != nil {
@@ -208,7 +208,7 @@ func (r *Runtime) handleMessageCreate(_ *discordgo.Session, event *discordgo.Mes
 			return err
 		}
 
-		if err := presentMessage(currentSession, request.ChannelID, response); err != nil {
+		if err := r.presentMessageResponse(currentSession, request.ChannelID, response); err != nil {
 			r.logger.Error("present deferred message response", "error", err, "channel_id", request.ChannelID, "message_id", request.MessageID)
 			return err
 		}
@@ -225,7 +225,7 @@ func (r *Runtime) handleMessageCreate(_ *discordgo.Session, event *discordgo.Mes
 		}
 	}
 
-	if err := presentMessage(discordSession, request.ChannelID, response); err != nil {
+	if err := r.presentMessageResponse(discordSession, request.ChannelID, response); err != nil {
 		r.logger.Error("present message response", "error", err, "channel_id", request.ChannelID, "message_id", request.MessageID)
 	}
 }
@@ -253,9 +253,23 @@ func (r *Runtime) handleInteractionCreate(_ *discordgo.Session, event *discordgo
 		}
 	}
 
-	if err := presentInteraction(discordSession, event.Interaction, response); err != nil {
+	if err := r.presentInteractionResponse(discordSession, event.Interaction, response); err != nil {
 		r.logger.Error("present interaction response", "error", err, "command", request.Name, "user_id", request.UserID)
 	}
+}
+
+func (r *Runtime) presentMessageResponse(discordSession session, channelID string, response app.MessageResponse) error {
+	response.Text = formatDiscordResponseText(response.Text, r.config.CodexWorkdir)
+	return presentMessage(discordSession, channelID, response)
+}
+
+func (r *Runtime) presentInteractionResponse(
+	discordSession session,
+	interaction *discordgo.Interaction,
+	response app.MessageResponse,
+) error {
+	response.Text = formatDiscordResponseText(response.Text, r.config.CodexWorkdir)
+	return presentInteraction(discordSession, interaction, response)
 }
 
 func (r *Runtime) routeCommand(ctx context.Context, request commandRequest) (app.MessageResponse, error) {

--- a/internal/runtime/discord/runtime_test.go
+++ b/internal/runtime/discord/runtime_test.go
@@ -153,6 +153,50 @@ func TestRuntimeMentionHandlingRepliesToTriggerMessage(t *testing.T) {
 	}
 }
 
+func TestRuntimeMentionHandlingSanitizesWorkspacePathsForDiscord(t *testing.T) {
+	t.Parallel()
+
+	messageService := &fakeMessageService{
+		response: app.MessageResponse{
+			Text: "[디펜더봇 평가-머지-릴리즈 자동화](" +
+				"/home/filepang/Documents/filepang/1%20Project/direnv-action/%EB%94%94%ED%8E%9C%EB%8D%94%EB%B4%87%20%ED%8F%89%EA%B0%80-%EB%A8%B8%EC%A7%80-%EB%A6%B4%EB%A6%AC%EC%A6%88%20%EC%9E%90%EB%8F%99%ED%99%94.md" +
+				")",
+			ReplyToID: "message-1",
+		},
+	}
+	fakeSession := newFakeSession("bot-user")
+	runtime := newTestRuntimeWithServices(t, config.ModeDaily, fakeSession, messageService, &fakeTaskCommandService{})
+	runtime.config.CodexWorkdir = "/home/filepang/Documents/filepang"
+
+	if err := runtime.Start(context.Background()); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	t.Cleanup(func() {
+		_ = runtime.Close()
+	})
+
+	fakeSession.dispatchMessage(&discordgo.MessageCreate{
+		Message: &discordgo.Message{
+			ID:        "message-1",
+			ChannelID: "channel-1",
+			Content:   "<@bot-user> sanitize this",
+			Author:    &discordgo.User{ID: "user-1"},
+			Mentions: []*discordgo.User{
+				{ID: "bot-user"},
+			},
+		},
+	})
+
+	if len(fakeSession.sentMessages) != 1 {
+		t.Fatalf("sent message count = %d, want %d", len(fakeSession.sentMessages), 1)
+	}
+
+	want := "디펜더봇 평가-머지-릴리즈 자동화 (`workspace/1 Project/direnv-action/디펜더봇 평가-머지-릴리즈 자동화.md`)"
+	if fakeSession.sentMessages[0].Content != want {
+		t.Fatalf("sent content = %q, want %q", fakeSession.sentMessages[0].Content, want)
+	}
+}
+
 func TestRuntimeMentionHandlingPresentsQueuedAcknowledgementAndDeferredReply(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- sanitize Discord-facing local workspace paths so absolute `CLAW_CODEX_WORKDIR` values are not exposed
- decode percent-encoded multibyte path segments before presenting them in Discord
- add regression tests and document the Discord presentation rule

## Background

Discord renders local Markdown file links poorly, which can leak absolute workspace paths and leave percent-encoded multibyte characters hard to read.
This change adds a presentation formatter right before Discord delivery so responses stay readable and avoid exposing local filesystem details.

## Related issue(s)

- None.

## Implementation details

- add a Discord response formatter that rewrites local Markdown links into readable text with workspace-relative paths
- rewrite bare workspace paths to `workspace/...` display paths and decode percent-encoded segments
- apply the formatter to both channel replies and interaction responses
- add unit and runtime tests for the new sanitization behavior
- update the implementation spec and Discord command behavior docs

## Test coverage

- `make test`
- `make lint`

## Breaking changes

- None.

## Notes

- This change only rewrites Discord presentation text and does not alter Codex thread execution or stored workspace paths.

Created by Codex
