### PR TITLE
Archive execplan 09 daily memory bridge

### DIFF
--- a/docs/exec-plans/completed/09-daily-memory-bridge.md
+++ b/docs/exec-plans/completed/09-daily-memory-bridge.md
@@ -23,6 +23,7 @@ The user-visible proof should be practical. A user should be able to tell the bo
 - [x] (2026-04-05 02:42Z) Added unit coverage for bootstrap idempotence, startup validation, preflight invocation, timeout/error handling, and daily message-service fallback sequencing.
 - [x] (2026-04-05 02:49Z) Ran `make test` and `make lint` after the implementation landed; both passed.
 - [x] (2026-04-05 03:02Z) Removed runtime-managed `AGENTS.md` edits after clarifying that `AGENTS.md` is user-owned and any memory-consumption guidance must be authored by the user, not by 39claw.
+- [x] (2026-04-05 03:20Z) Verified that the shipped code, tests, and repository docs satisfy the plan's acceptance criteria, then archived the plan because no blocking implementation work remains in `active/`.
 
 ## Surprises & Discoveries
 
@@ -79,11 +80,17 @@ The user-visible proof should be practical. A user should be able to tell the bo
   Rationale: This keeps the per-turn prompt short while still letting the runtime fully control which exact skill instructions are used.
   Date/Author: 2026-04-05 / Codex
 
+- Decision: Archive this ExecPlan and move it to `docs/exec-plans/completed/09-daily-memory-bridge.md`.
+  Rationale: Repository evidence now shows the daily memory bridge code, tests, and product/design documentation are all landed, the plan's required validation has already passed, and no unresolved blocking scope remains to justify keeping the plan under `active/`.
+  Date/Author: 2026-04-05 / Codex
+
 ## Outcomes & Retrospective
 
 The durable daily memory bridge is now implemented. `daily` mode startup creates and refreshes the runtime-managed memory artifacts inside `CLAW_CODEX_WORKDIR`, the first visible turn of a new local day can refresh durable memory from the previous day's thread, and visible replies still proceed when that hidden refresh fails.
 
 Repository-wide validation is complete: `make test` and `make lint` both pass. The main lesson from implementation was that keeping the feature behind the existing application and gateway boundaries made the change much smaller than introducing any new persistence table or Codex-specific orchestration layer, and that user-owned instruction files such as `AGENTS.md` must remain outside runtime-managed writes.
+
+No new blocking work remains for this scope, so the plan no longer belongs in `active/`. The repository already contains the required code paths, tests, and updated architecture/product documents described above. No additional tech-debt entry was needed during archival because the remaining open items in `docs/exec-plans/tech-debt-tracker.md` belong to other completed plans, not to this daily-memory bridge delivery.
 
 ## Context and Orientation
 
@@ -407,3 +414,4 @@ Revision Note: 2026-04-05 / Codex - Expanded the plan with the exact runtime-man
 Revision Note: 2026-04-05 / Codex - Reworked the plan to use `CLAW_CODEX_WORKDIR/AGENT_MEMORY` instead of an external facts directory and to treat write-capable sandboxing as an explicit feature requirement.
 Revision Note: 2026-04-05 / Codex - Updated the living sections after implementation landed, including the final bootstrap, preflight, fallback, and documentation results.
 Revision Note: 2026-04-05 / Codex - Corrected the ownership boundary so `AGENTS.md` remains fully user-authored; runtime-managed work now stops at `AGENT_MEMORY/` and the managed refresh skill.
+Revision Note: 2026-04-05 / Codex - Archived the completed plan after re-verifying the shipped code, tests, and documentation against the acceptance criteria and confirming that no blocking follow-up remained.

--- a/docs/exec-plans/index.md
+++ b/docs/exec-plans/index.md
@@ -25,8 +25,6 @@ Plans in this directory should be written and maintained in line with `.agents/P
 
 These plans are intended to be executed in numeric order. Each plan is self-contained, but later plans name the repository state they expect to find and explain how to recover if that state is missing.
 
-- [Add a durable memory bridge to `daily` mode](./active/09-daily-memory-bridge.md)
-
 ## Recently Completed Plans
 
 - [Build the foundation, contracts, and bootstrap path](./completed/01-foundation-and-contracts.md)
@@ -37,3 +35,4 @@ These plans are intended to be executed in numeric order. Each plan is self-cont
 - [Implement Discord image attachment intake for Codex turns](./completed/06-discord-image-input.md)
 - [Replace shared `/help` and `/task` slash commands with one instance-specific root command](./completed/07-instance-specific-root-command.md)
 - [Add task-isolated Git worktrees to `task` mode](./completed/08-task-mode-worktree-isolation.md)
+- [Add a durable memory bridge to `daily` mode](./completed/09-daily-memory-bridge.md)


### PR DESCRIPTION
## Summary

- Archive the completed `09-daily-memory-bridge` ExecPlan under `docs/exec-plans/completed/`.
- Update the plan body and index so the repository records the plan as finished instead of still active.

## Background

The daily memory bridge work is already implemented, documented, and validated in the repository, so keeping its ExecPlan under `docs/exec-plans/active/` no longer reflects the real project state.

## Related issue(s)

- N/A

## Implementation details

- Add a final archival progress entry, archival rationale, and revision note to the ExecPlan.
- Move `docs/exec-plans/active/09-daily-memory-bridge.md` to `docs/exec-plans/completed/09-daily-memory-bridge.md`.
- Update `docs/exec-plans/index.md` to remove the plan from active plans and list it under recently completed plans.

## Test coverage

- `make lint`
- `make test`

## Breaking changes

- None.

## Notes

- No new tech-debt entry was needed because the remaining open tracker items belong to other completed plans.

Created by Codex
