### PR TITLE
docs: define runtime validation strategy and plan fake runtime harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -474,7 +474,8 @@ Most message-path events also carry routing context such as `component`, `mode`,
 
 ## Smoke Test Checklist
 
-After startup, confirm the basics:
+Use this checklist when you want optional live Discord hardening beyond the normal automated suites.
+It is most useful for real-platform behaviors such as hosted attachments, command registration, permissions, and final reply delivery:
 
 - mention the bot and confirm the reply targets the original message
 - mention the bot with text plus an image and confirm the request is handled

--- a/docs/design-docs/architecture-overview.md
+++ b/docs/design-docs/architecture-overview.md
@@ -98,6 +98,17 @@ Whether Codex consults those files during normal visible turns is controlled by 
 - The waiting queue is intentionally in memory only, so queued turns are lost if the process exits before they run.
 - The short overview here stays subordinate to `ARCHITECTURE.md`, which remains the authoritative source for the full request flow and shutdown behavior.
 
+## Validation View
+
+The shipping runtime is currently Discord, but the validation strategy should already separate reusable product behavior from Discord-specific external-platform hardening.
+
+- automated coverage should be the primary source of confidence
+  - cover message qualification, ignored-message rules, logical-thread resolution handoff, queue admission, queued acknowledgments, deferred reply handoff, command normalization, and normalized response expectations at the app/runtime boundary
+- adapter-level fake runtime tests should drive representative runtime events and capture the visible outputs without requiring a live Discord deployment
+- live Discord smoke remains a narrow optional hardening layer for command-registration propagation, hosted attachment fetches, permission quirks, and final delivery edge cases
+
+This keeps the current Discord implementation practical while making the validation shape easier to reuse if future runtimes such as Slack or Telegram are introduced later.
+
 ## Read Next
 
 - root `ARCHITECTURE.md`

--- a/docs/design-docs/first-stage-release-automation.md
+++ b/docs/design-docs/first-stage-release-automation.md
@@ -63,7 +63,7 @@ It is also shipping a behavior contract defined across:
 - `docs/design-docs`
 - `docs/product-specs`
 
-For that reason, the repository adds `docs/operations/RELEASE_RUNBOOK.md` and documents manual smoke expectations alongside automated checks.
+For that reason, the repository adds `docs/operations/RELEASE_RUNBOOK.md` and documents targeted Discord hardening expectations alongside automated checks. Automated coverage remains the primary gate, while live Discord confirmation stays a narrower optional layer for external-platform behavior.
 
 ## Release Scope
 

--- a/docs/design-docs/implementation-spec.md
+++ b/docs/design-docs/implementation-spec.md
@@ -185,9 +185,27 @@ When `CLAW_DISCORD_GUILD_ID` is set, slash commands are overwritten in that guil
 For local development, the safe-default workflow is an ignored `.env.local` file loaded through an ignored `.envrc`.
 Checked-in examples such as `.env.example` and `.envrc.example` must use placeholders only and must not contain live credentials.
 
+## Validation Strategy Defaults
+
+The primary validation story should be reusable automated coverage rather than broad Discord-only live smoke testing.
+Even though v1 ships only a Discord runtime, validation should already be organized so future runtimes such as Slack or Telegram can reuse the same categories.
+
+The repository should treat validation as three layers:
+
+- runtime-agnostic behavior contracts
+  - cover the application and runtime boundary behaviors that should remain stable regardless of the current chat platform
+  - include qualifying message intake, ignored-message conditions, logical-thread handoff, queue admission outcomes, queued acknowledgment behavior, deferred reply delivery handoff, command-intent normalization, and normalized response expectations at the app/runtime boundary
+- adapter-level fake runtime coverage
+  - simulate platform inputs and capture runtime-visible outputs without depending on a live Discord deployment
+  - cover representative normal-message events, command-style intents, attachment metadata inputs, reply targets, payload text, visibility hints, and deferred-delivery timing semantics
+- live-platform hardening
+  - stay narrow and optional instead of acting as the primary quality gate
+  - focus on external-platform behaviors such as real command-registration propagation, hosted attachment fetches, permission or intent quirks, and final delivery edge cases
+
 ## Validation Targets
 
-The initial implementation should demonstrate the following observable behavior:
+The initial implementation should demonstrate the following observable behavior.
+Most of these outcomes should be proven through automated contract coverage plus fake runtime tests, while the narrow live-platform remainder should be handled as optional hardening:
 
 - In `daily` mode, the first qualifying mention creates a thread binding, a second same-day mention reuses it, and the first mention on the next local date creates a new binding after the durable-memory preflight refreshes `AGENT_MEMORY` from the previous day's thread when that previous binding exists.
 - In `daily` mode, startup does not create or rewrite `AGENTS.md`.
@@ -204,3 +222,10 @@ The initial implementation should demonstrate the following observable behavior:
 - Non-mention chatter is ignored, unsupported non-image-only mention posts stay silent, supported slash commands respond correctly, and long replies are chunked cleanly.
 - Simultaneous requests for the same logical thread do not execute overlapping Codex turns.
 - Simultaneous requests for the same logical thread receive queued acknowledgments and later deferred replies until the waiting queue reaches five items.
+
+Live Discord hardening remains useful only for the smaller set of behaviors that require the real platform, such as:
+
+- command-registration propagation in Discord
+- hosted attachment fetch behavior with real Discord-hosted files
+- permission or intent configuration quirks in a deployed bot
+- final message delivery edge cases that a fake runtime cannot reproduce faithfully

--- a/docs/exec-plans/active/11-fake-runtime-validation.md
+++ b/docs/exec-plans/active/11-fake-runtime-validation.md
@@ -1,0 +1,322 @@
+# Build fake runtime validation infrastructure for adapter-level tests
+
+This ExecPlan is a living document. The sections `Progress`, `Surprises & Discoveries`, `Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work proceeds.
+
+This document must be maintained in accordance with `.agents/PLANS.md`.
+
+## Purpose / Big Picture
+
+After this plan, a contributor should be able to prove the most important runtime-facing behavior without a live Discord server. They should be able to run a focused automated suite that drives fake runtime inputs, observes adapter-visible outputs, and confirms that 39claw still replies to qualifying mentions, acknowledges queued work, delivers deferred replies later, and handles command-style inputs at the application boundary.
+
+This change matters because the repository's main confidence story should no longer depend on broad live Discord smoke checks. The result should be a reusable fake-runtime testing shape that stays useful if a future Slack or Telegram runtime is added, while keeping the current production architecture thin and Discord-specific details out of the application layer.
+
+## Progress
+
+- [x] (2026-04-05 19:15Z) Reviewed `.agents/PLANS.md`, the current runtime and application tests, and the validation-strategy docs updated for issue `#57`.
+- [x] (2026-04-05 19:15Z) Confirmed the current repository state: Discord runtime tests already use package-local fake sessions, and application tests already use in-memory stores and fake gateways, but there is no reusable fake-runtime harness or shared contract-style suite.
+- [x] (2026-04-05 19:15Z) Created this ExecPlan under `docs/exec-plans/active/` and restored the missing `active/` directory so issue `#58` has a tracked execution plan.
+- [ ] Introduce a reusable test-support package for runtime-facing fake inputs and observed deliveries.
+- [ ] Refactor or replace the current Discord package-local fake session helpers so the new contract-style tests can drive runtime events and capture outputs through one consistent harness.
+- [ ] Add at least one end-to-end-style Discord adapter suite that uses the fake runtime boundary to prove observable behavior for normal messages, queued acknowledgments, deferred replies, and one command-style interaction.
+- [ ] Update repository documentation so contributors know the fake-runtime suite is the preferred validation layer before optional live Discord hardening.
+- [ ] Run `make test` and `make lint`, then record proof and any follow-up gaps in this plan.
+
+## Surprises & Discoveries
+
+- Observation: The repository already has most of the raw pieces needed for fake-runtime coverage, but they are split across package-local test doubles instead of a reusable harness.
+  Evidence: `internal/runtime/discord/runtime_test.go`, `internal/app/message_service_test.go`
+
+- Observation: The current `internal/app.MessageService` contract already defines the correct app/runtime boundary for reusable validation: normalized `MessageRequest`, immediate `MessageResponse`, and optional `DeferredReplySink`.
+  Evidence: `internal/app/message_service.go`, `internal/app/types.go`
+
+- Observation: The Discord runtime already exposes realistic end-to-end seams for adapter-level tests because `Runtime.Start` registers handlers on an abstract `session` interface and `runtime_test.go` can dispatch fake `discordgo` events through that interface.
+  Evidence: `internal/runtime/discord/runtime.go`, `internal/runtime/discord/session.go`, `internal/runtime/discord/runtime_test.go`
+
+- Observation: The current validation gap is not "no tests exist." The real gap is that the existing tests are difficult to reuse as a runtime-neutral pattern because the doubles and assertions are tightly coupled to one package's private test helpers.
+  Evidence: `internal/runtime/discord/runtime_test.go`
+
+## Decision Log
+
+- Decision: Keep the new fake-runtime infrastructure in a test-support package such as `internal/testutil/runtimeharness` instead of introducing a new production runtime abstraction.
+  Rationale: Issue `#58` is about validation shape, not a new architecture layer. Putting the harness in test support avoids leaking speculative runtime-generic interfaces into production code.
+  Date/Author: 2026-04-05 / Codex
+
+- Decision: Define the reusable contract at the app/runtime boundary, not at the Discord SDK boundary and not at the Codex gateway boundary.
+  Rationale: The validation strategy agreed in issue `#57` explicitly limits runtime-agnostic contracts to message qualification, ignored-message rules, queue admission, deferred delivery handoff, command normalization, and normalized response expectations at the app/runtime boundary.
+  Date/Author: 2026-04-05 / Codex
+
+- Decision: Start with one real adapter implementation of the harness, the Discord runtime, and require one vertical-slice automated suite before expanding to more helper abstractions.
+  Rationale: The repository only ships Discord today. Proving the harness on the real runtime prevents over-design and keeps future-runtime reuse grounded in an existing working example.
+  Date/Author: 2026-04-05 / Codex
+
+- Decision: Prefer reusing and relocating existing fake helpers over rewriting all runtime tests at once.
+  Rationale: `runtime_test.go` and `message_service_test.go` already encode valuable behavior. The safest path is to extract stable helpers, convert the key adapter-level cases to the new harness, and leave narrowly unit-scoped tests in place when they still add value.
+  Date/Author: 2026-04-05 / Codex
+
+## Outcomes & Retrospective
+
+Implementation has not started yet. The intended outcome is a repository where contributors can validate key runtime behavior through a fake runtime harness first, then use optional live Discord hardening only for the narrow external-platform remainder documented in `docs/exec-plans/tech-debt-tracker.md`.
+
+The plan will be complete when the repository contains a reusable fake-runtime test-support package, at least one Discord contract-style suite built on that package, updated documentation, and passing repository checks.
+
+## Context and Orientation
+
+39claw is a thin gateway between Discord and Codex. The production message path starts in `internal/runtime/discord/runtime.go`, where the runtime receives Discord events, maps them into normalized application requests, calls the application layer, and presents the returned response back to Discord. The application boundary is defined in `internal/app/message_service.go` and `internal/app/types.go`. A normal message becomes an `app.MessageRequest`; the application returns an immediate `app.MessageResponse`; and queued work can later use `app.DeferredReplySink` to publish a follow-up reply.
+
+In this repository, a "fake runtime" means a test harness that simulates platform-facing events and captures the runtime-visible outputs without connecting to a real Discord deployment. It is not a second production runtime and it is not a broad interface that every future runtime must implement in production code. It is a test-support shape that lets tests express scenarios such as "a qualifying mention arrives," "a command interaction arrives," and "a deferred reply is delivered later," then assert what the adapter presented externally.
+
+The key current files are:
+
+- `internal/runtime/discord/runtime.go`
+  - owns Discord session startup, event handlers, response presentation, and shutdown draining
+- `internal/runtime/discord/session.go`
+  - defines the narrow `session` interface that production and test sessions both satisfy
+- `internal/runtime/discord/runtime_test.go`
+  - already contains a package-local fake session plus adapter-level tests, but the helpers are not reusable outside this file
+- `internal/runtime/discord/message_mapper.go` and `internal/runtime/discord/interaction_mapper.go`
+  - normalize Discord events into `app.MessageRequest` and task-command requests
+- `internal/app/message_service.go`
+  - defines `MessageService`, `DeferredReplySink`, and the queue-related boundary
+- `internal/app/message_service_impl.go`
+  - implements logical-key resolution, queue admission, deferred delivery handoff, and Codex turn orchestration
+- `internal/app/task_service.go`
+  - implements command-style task control and help behavior behind the runtime
+- `internal/thread/queue.go`
+  - owns capped in-memory queue admission for same-key work
+
+The repository already has focused automated tests for the application layer and Discord runtime. What it does not have is a single reusable harness that can express runtime-facing contract scenarios and make those scenarios easy to repeat for future runtimes.
+
+## Starting State
+
+Start this plan only after confirming the repository still matches these assumptions:
+
+- the production runtime is still `internal/runtime/discord`
+- the app/runtime boundary still flows through `app.MessageRequest`, `app.MessageResponse`, and `app.DeferredReplySink`
+- `internal/runtime/discord/runtime_test.go` still contains working fake-session-based adapter tests
+- `internal/app/message_service_test.go` still provides in-memory store and gateway doubles that can support end-to-end-style tests without a real Codex backend
+- `make test` and `make lint` pass before the new harness work begins
+
+Verify that state with:
+
+    cd /home/filepang/playground/39claw
+    make test
+    make lint
+
+If the repository has drifted away from that shape, update this plan before implementing so it remains truthful and self-contained.
+
+## Preconditions
+
+This plan assumes and fixes the following boundaries:
+
+- runtime-agnostic validation stops at the app/runtime boundary
+- production code must stay thin and should not gain a speculative cross-platform runtime interface
+- adapter-level fake tests may use Discord-specific event values internally, but the reusable test-support package should describe observed behavior in transport-neutral terms
+- optional live Discord hardening remains a separate concern and is not part of this implementation plan
+
+## Milestone 1: Create a reusable runtime-harness vocabulary
+
+At the end of this milestone, the repository should have one test-support package that defines the language of runtime-facing validation: fake incoming events, observed deliveries, and reusable assertions. This package should be small enough that a future runtime can adopt it with limited glue code.
+
+Create a new package under `internal/testutil/runtimeharness`. Keep it test-support-only in purpose even if the Go files are normal source files. Define transport-neutral types that describe what the tests care about, not what Discord SDK types happen to look like. The package should include a small set of event and observation types such as:
+
+- a normal-message fixture that carries user ID, channel ID, message ID, mention state, text payload, and optional attachment metadata
+- a command-intent fixture that carries user ID, channel ID, command name, action name, and any task-related arguments
+- an observed-delivery record that captures the visible outcome: channel ID, reply target, text payload, whether the delivery was immediate or deferred, and whether the response was ephemeral
+
+Keep these types plain and boring. They exist so tests can describe scenarios consistently. Do not add a production dependency from `internal/app` or `internal/runtime/discord` to this package.
+
+Add reusable assertion helpers here as well. For example, provide helpers that verify "one immediate reply rooted to message X," "one queued acknowledgment followed by one deferred reply," or "one ephemeral interaction response." The helpers should compare only runtime-visible behavior and avoid asserting implementation trivia such as specific helper function names or internal log wording.
+
+## Milestone 2: Adapt the Discord tests to the reusable harness
+
+At the end of this milestone, the Discord runtime should have a contract-style suite that is driven through fake runtime inputs and verified through normalized observed deliveries. The suite must use the real `discord.Runtime` startup path, not a hand-wired imitation of the runtime logic.
+
+First, extract or rewrite the current package-local fake session helpers in `internal/runtime/discord/runtime_test.go` so they can be reused by multiple test files. It is acceptable to keep the fake session implementation inside the `internal/runtime/discord` test package as long as the observed outputs can be converted into the shared `runtimeharness` vocabulary. Preserve the current ability to:
+
+- dispatch fake `discordgo.MessageCreate` events
+- dispatch fake `discordgo.InteractionCreate` events
+- record sent channel messages
+- record interaction responses and follow-up edits or messages
+- inspect registration state when needed
+
+Next, add a new contract-style test file in `internal/runtime/discord`, for example `runtime_contract_test.go`. This file should build one or more real `Runtime` values with realistic dependencies and then exercise scenarios through the harness. Use the real application service where doing so gives meaningful cross-layer coverage, and use focused fakes only where the runtime boundary itself is the subject under test.
+
+The minimum scenarios to cover are:
+
+1. A qualifying normal mention produces one reply to the triggering message.
+2. A queued normal mention produces one immediate queued acknowledgment and later one deferred reply to the original message.
+3. A command-style interaction produces the correct visible presentation, including the ephemeral flag where applicable.
+4. One representative attachment-aware message flow proves that attachment metadata and reply semantics can be driven through the fake runtime path without a live Discord server.
+
+For the queueing scenario, prefer wiring the real `app.DefaultMessageService`, the real `thread.QueueCoordinator`, an in-memory thread store double, and a fake Codex gateway that can block and release on command. That gives one real vertical slice that covers runtime event handling, app-level queue admission, and deferred delivery without a live Discord deployment.
+
+For the command scenario, use the real task-command service when practical so the suite validates the actual runtime mapping and presentation path, not a bespoke fake response path.
+
+## Milestone 3: Tighten helper ownership and keep focused unit tests
+
+At the end of this milestone, the repository should have a clear split between narrow unit tests and the new runtime contract tests. Existing unit tests that still provide low-level value should remain, but duplicated scenario setup should move into shared helpers or the new contract suite.
+
+As part of this cleanup, remove or simplify any now-redundant helper code in `internal/runtime/discord/runtime_test.go` that was only needed because there was no shared harness vocabulary. Keep focused mapper, formatter, and presenter unit tests in place when they assert small transformation rules that the broader contract suite would not explain clearly.
+
+Do not try to convert every existing runtime test into the new harness in one pass. The goal is to establish a reusable path and prove it on the most important adapter-level behaviors first.
+
+## Milestone 4: Document the fake-runtime validation path
+
+At the end of this milestone, contributors should know where the fake-runtime suite lives, when to run it, and how it fits into the repository's broader validation strategy.
+
+Update the most relevant documents:
+
+- `README.md`
+  - mention the focused fake-runtime suite as the first choice for runtime behavior validation before optional live Discord hardening
+- `docs/design-docs/implementation-spec.md`
+  - add the concrete package path or test command if the final harness layout should be discoverable there
+- `docs/exec-plans/tech-debt-tracker.md`
+  - if implementation of this plan materially narrows the remaining live Discord gap, update the wording so the debt entry reflects the new fake-runtime coverage
+
+Do not create a brand-new design note unless implementation discovers something that cannot be explained clearly in the existing docs.
+
+## Plan of Work
+
+Begin by creating `internal/testutil/runtimeharness` with a small transport-neutral vocabulary for runtime events and deliveries. Keep the package purpose narrow: it should only help tests describe and assert behavior at the app/runtime boundary.
+
+Next, inspect the current fake helpers in `internal/runtime/discord/runtime_test.go` and decide which ones should become stable shared test utilities. A likely shape is to keep the low-level fake Discord session in the Discord test package, but add conversion helpers that transform recorded Discord-specific outputs into `runtimeharness` observations.
+
+Then add one new contract-style test file in `internal/runtime/discord` that uses the shared harness vocabulary. For at least one queueing scenario, wire the real application service and queue coordinator so the test proves observable queue behavior through the runtime boundary. For the other required scenarios, choose the thinnest dependencies that still make the visible behavior meaningful.
+
+After the new suite is stable, trim duplicated setup from existing runtime tests where it improves readability. Leave small unit tests in place when they still explain isolated rules better than a vertical slice would.
+
+Finally, update the docs named above so the repository's written guidance matches the new test infrastructure and the validation strategy already agreed in issue `#57`.
+
+## Concrete Steps
+
+Run all commands from `/home/filepang/playground/39claw`.
+
+1. Confirm the starting state and capture a clean baseline.
+
+    make test
+    make lint
+
+2. Add the new test-support package and its self-tests, if needed.
+
+    go test ./internal/testutil/runtimeharness -v
+
+3. Build or refactor the Discord fake-session helpers until they support the new contract suite cleanly.
+
+    go test ./internal/runtime/discord -run 'TestRuntimeStart|TestRuntimeMention|TestRuntimeDeferred' -v
+
+4. Add the new contract-style suite and run only the new scenarios while iterating.
+
+    go test ./internal/runtime/discord -run 'TestRuntimeContract' -v
+
+5. Run the application-layer tests if the contract suite uses real message-service or task-service wiring and the supporting doubles changed.
+
+    go test ./internal/app -run 'TestMessageService|TestTaskService' -v
+
+6. Run the full repository checks after the new harness and docs land.
+
+    make test
+    make lint
+
+7. Record concise proof artifacts and any discovered follow-up work in this plan before closing or archiving it.
+
+## Validation and Acceptance
+
+This plan is complete when all of the following are true:
+
+- the repository contains a reusable fake-runtime test-support package under a stable path such as `internal/testutil/runtimeharness`
+- the new package defines transport-neutral inputs or observations for runtime-facing behavior instead of exposing Discord SDK types directly
+- at least one Discord adapter suite drives fake runtime events through the real `Runtime` startup path and verifies observable outputs through the shared harness vocabulary
+- the suite proves a normal mention reply flow, a queued-acknowledgment-plus-deferred-reply flow, and one command-style interaction flow
+- at least one queueing test uses the real app-layer queue admission path rather than a runtime-only stub so the suite behaves like an end-to-end slice
+- existing focused runtime unit tests still pass, with duplicated setup reduced where practical
+- repository docs mention the fake-runtime validation path as the preferred automated layer before optional live Discord hardening
+- `make test` passes
+- `make lint` passes
+
+The most important human-readable proof is this automated scenario:
+
+1. Start the real Discord runtime in a test with a fake session.
+2. Dispatch one qualifying message that stays busy long enough to admit a second message into the queue.
+3. Observe one immediate queued acknowledgment reply to the second message.
+4. Release the first turn.
+5. Observe one later deferred reply to that same second message.
+
+That proof must happen entirely inside automated tests without a live Discord deployment.
+
+## Idempotence and Recovery
+
+This plan is safe to iterate on because the new harness is additive. If the first version of the shared vocabulary proves awkward, adjust the helper package before migrating more tests. Do not add production runtime abstraction layers just to make the tests look more generic.
+
+If a partial refactor breaks the current Discord runtime tests, the safe recovery path is to keep the old package-local helpers working while the new harness is introduced beside them. Only remove duplicated helpers after the new contract suite is green and understandable.
+
+If the first attempt at a transport-neutral vocabulary becomes too Discord-shaped, stop and simplify it. The right boundary is "what the app/runtime contract makes visible," not "everything Discord can do."
+
+## Artifacts and Notes
+
+Current code facts that motivate this plan:
+
+    internal/app/message_service.go:
+      type DeferredReplySink interface {
+          Deliver(ctx context.Context, response MessageResponse) error
+      }
+
+    internal/runtime/discord/session.go:
+      Runtime startup and event handling already depend on a narrow session interface.
+
+    internal/runtime/discord/runtime_test.go:
+      already contains fake-session-driven scenarios for mentions, queued replies, shutdown drain, and attachment downloads.
+
+Helpful target test names:
+
+    TestRuntimeContractNormalMentionReply
+    TestRuntimeContractQueuedAcknowledgementAndDeferredReply
+    TestRuntimeContractHelpCommandUsesEphemeralPresentation
+    TestRuntimeContractAttachmentAwareMessageFlow
+
+Helpful dependency shape for the vertical queueing slice:
+
+    real runtime
+    real app.DefaultMessageService
+    real thread.QueueCoordinator
+    in-memory thread store test double
+    fake Codex gateway with controllable blocking
+    fake Discord session that records deliveries
+
+## Interfaces and Dependencies
+
+At the end of this plan, the new test-support package should expose stable names equivalent to these examples:
+
+    package runtimeharness
+
+    type MessageEvent struct {
+        UserID      string
+        ChannelID   string
+        MessageID   string
+        Mentioned   bool
+        Content     string
+        Attachments []Attachment
+    }
+
+    type CommandEvent struct {
+        UserID      string
+        ChannelID   string
+        CommandName string
+        Action      string
+        TaskName    string
+        TaskID      string
+    }
+
+    type Delivery struct {
+        ChannelID string
+        ReplyToID string
+        Text      string
+        Ephemeral bool
+        Deferred  bool
+    }
+
+    func RequireReplyTo(t *testing.T, deliveries []Delivery, replyToID string)
+    func RequireQueuedFlow(t *testing.T, deliveries []Delivery, replyToID string, ackText string, finalText string)
+
+These names are examples, not mandatory exact spelling, but the final package must provide the same capabilities. The production runtime must continue to depend only on `internal/app`, `internal/config`, `discordgo`, and its existing collaborators. The new harness must not become a production dependency.
+
+Revision Note: 2026-04-05 / Codex - Created this ExecPlan for issue `#58` after documenting the validation strategy in issue `#57`, creating the missing `docs/exec-plans/active/` directory, and confirming that the repository already has package-local fake runtime helpers that can be promoted into a reusable harness.

--- a/docs/exec-plans/active/README.md
+++ b/docs/exec-plans/active/README.md
@@ -1,0 +1,5 @@
+# Active ExecPlans
+
+This directory stores living execution plans that are currently being implemented or are ready to be picked up next.
+
+Keep every plan self-contained and maintain it in accordance with `.agents/PLANS.md`.

--- a/docs/exec-plans/index.md
+++ b/docs/exec-plans/index.md
@@ -25,6 +25,8 @@ Plans in this directory should be written and maintained in line with `.agents/P
 
 These plans are intended to be executed in numeric order. Each plan is self-contained, but later plans name the repository state they expect to find and explain how to recover if that state is missing.
 
+- [Build fake runtime validation infrastructure for adapter-level tests](./active/11-fake-runtime-validation.md)
+
 ## Recently Completed Plans
 
 - [Add first-stage tag-driven release automation](./completed/10-first-stage-release-automation.md)

--- a/docs/exec-plans/tech-debt-tracker.md
+++ b/docs/exec-plans/tech-debt-tracker.md
@@ -52,7 +52,7 @@ Until one maintainer performs the first live tagged release, the project still l
 
 Follow `docs/operations/RELEASE_RUNBOOK.md` from a clean, up-to-date `master` checkout and perform the first live tagged release, starting with a small version such as `v0.1.0`. After the draft GitHub Release is created successfully and the attached archives are verified, mark this entry resolved or replace it with any concrete follow-up discovered during the first live run.
 
-### Discord runtime smoke test follow-up
+### Runtime validation strategy and narrow live Discord hardening follow-up
 
 - Status: open
 - Date: 2026-04-05
@@ -61,27 +61,34 @@ Follow `docs/operations/RELEASE_RUNBOOK.md` from a clean, up-to-date `master` ch
 
 ### Context
 
-The Discord runtime implementation has landed and the delivery plans have been archived, but the final manual smoke test against a disposable Discord server was not run before archival because disposable bot credentials were not available in the implementation environment.
+The Discord runtime implementation has landed and the delivery plans have been archived, but the remaining validation debt should no longer be described as broad missing live Discord smoke coverage.
 
-This gap now covers both the general runtime flow and the live validation of Discord-hosted image attachments. Automated tests prove the image download, cleanup, multipart-input forwarding, and deferred reply behavior, but they do not prove the final live Discord path with real attachment hosting and reply delivery.
+The repository already has meaningful automated validation for message mapping, command routing, chunking, image download handling, multipart-input forwarding, queueing, and deferred reply behavior. The stronger long-term direction is to keep expanding that confidence through runtime-agnostic behavioral contracts plus adapter-level fake runtime coverage that can later be reused by future runtimes such as Slack or Telegram.
 
-This follow-up remains intentionally open. For now, the repository accepts a documented gap instead of trying to automate disposable Discord bot provisioning or full live-server validation inside the normal development workflow.
+The live Discord gap should therefore be treated as narrow hardening work around behaviors that automated tests and fake runtimes cannot fully prove, such as real command-registration propagation, hosted attachment fetches, permission or intent quirks, and final reply delivery behavior in a real Discord deployment.
+
+This follow-up remains intentionally open. For now, the repository accepts a documented gap instead of trying to automate disposable Discord bot provisioning or broad live-server validation inside the normal development workflow.
 
 ### Risk
 
-Automated tests prove message mapping, command routing, chunking, presentation behavior, image download handling, and multipart-input forwarding, but they cannot prove that live Discord registration, hosted attachment fetches, and reply flow behave exactly as expected in a real server.
+If this debt keeps a Discord-smoke-centric framing, contributors may over-invest in platform-specific manual checks while under-investing in reusable automated coverage at the application and runtime-adapter boundaries.
 
-Because the gap is documented rather than closed, contributors may incorrectly assume that the live Discord path has already been validated end to end. Any real-server integration regression would therefore be discovered later than a fully automated or regularly executed smoke test would allow.
+Automated tests still cannot prove that real Discord registration, hosted attachment fetches, permission settings, and final reply delivery behave exactly as expected in a live deployment. If those narrow external-platform risks are left implicit, contributors may either assume too much confidence or run ad hoc live checks without a clear trigger.
 
 ### Next step
 
-Keep this entry open until one of the following becomes true:
+Treat this entry as a two-part follow-up:
 
-- a sustainable disposable-bot workflow is available for repeatable live smoke testing
-- a release-hardening pass decides that manual real-server validation is now worth the setup cost
-- a production or staging issue suggests the live Discord path needs explicit end-to-end confirmation
+- continue documenting runtime-agnostic validation boundaries so contributors invest in automated contract and fake-runtime coverage first
+- add adapter-level fake runtime tests for key orchestration flows so most confidence no longer depends on live Discord confirmation
 
-Until then, treat this as explicit technical debt rather than an implicit missing task. When one of the triggers above is met, run the documented smoke test from `README.md` with a disposable Discord bot token and guild ID, including both normal reply and image-attachment scenarios, then either mark this entry resolved or record any runtime-specific fixes in a follow-up ExecPlan.
+Keep the live Discord check as optional hardening until one of the following becomes true:
+
+- a release-hardening pass decides that Discord-specific external behavior now warrants manual confirmation
+- a sustainable disposable-bot workflow is available for repeatable targeted live checks
+- a production or staging issue suggests the real Discord path needs explicit end-to-end confirmation
+
+When one of those triggers is met, run the documented Discord checklist from `README.md` with a disposable bot token and guild ID, focusing on the narrow live-platform remainder such as reply delivery, hosted attachments, and command-registration behavior. Then either mark this entry resolved or record any runtime-specific fixes in a follow-up ExecPlan.
 
 ### Task worktree operator ergonomics follow-up
 

--- a/docs/operations/RELEASE_RUNBOOK.md
+++ b/docs/operations/RELEASE_RUNBOOK.md
@@ -7,7 +7,7 @@ This is intentionally a conservative first stage:
 
 - releases are created from explicit Git tags
 - GitHub Actions creates a draft release instead of auto-publishing it
-- the release candidate gate mixes automated checks with explicit maintainer judgment
+- the release candidate gate mixes automated checks with explicit maintainer judgment plus targeted live-platform hardening when risk warrants it
 - automatic version calculation is intentionally out of scope
 
 ## Release Candidate Gate
@@ -26,14 +26,17 @@ Do not create or push a release tag until all of the following are true:
    - `ARCHITECTURE.md`
    - relevant files under `docs/design-docs`
    - relevant files under `docs/product-specs`
-4. Core runtime smoke paths have been exercised manually against a real or test Discord bot deployment:
-   - mention-driven reply flow works
-   - slash command help still works
-   - `task` mode can create and switch tasks when enabled
-   - image attachment handling still works when applicable
-5. `go run ./cmd/39claw version` returns a sensible value locally and the release config still injects `version.Version`.
-6. The `HOMEBREW_TAP_GITHUB_TOKEN` GitHub Actions secret is configured with write access to `HatsuneMiku3939/homebrew-tap`.
-7. No ad hoc release-only edits are waiting outside version control.
+4. Automated validation remains the primary quality gate for runtime behavior:
+   - rely on the repository's automated suites for queueing, routing, normalization, and deferred-delivery behavior
+   - do not use broad manual Discord smoke as a substitute for missing automated coverage
+5. When the release touches Discord-specific external-platform risk, targeted Discord hardening paths have been exercised manually against a real or test deployment:
+   - mention-driven reply flow after message-routing or presenter changes
+   - slash-command help or task controls after command-surface changes
+   - image attachment handling after attachment-mapping or download changes
+   - any other Discord-specific behavior implicated by a recent incident or release risk
+6. `go run ./cmd/39claw version` returns a sensible value locally and the release config still injects `version.Version`.
+7. The `HOMEBREW_TAP_GITHUB_TOKEN` GitHub Actions secret is configured with write access to `HatsuneMiku3939/homebrew-tap`.
+8. No ad hoc release-only edits are waiting outside version control.
 
 If any gate fails, fix the repository state first and rerun the failed checks before tagging.
 
@@ -58,6 +61,18 @@ What these commands prove:
 - `make release-snapshot` verifies that GoReleaser can build release artifacts locally without a real tag
 
 `make release-snapshot` leaves local artifacts under `dist/`. That is expected for validation.
+
+## Discord Hardening Triggers
+
+Manual Discord validation is optional hardening, not the primary release gate.
+Run it when one or more of the following is true:
+
+- the release changes slash-command registration, command parsing, or interaction presentation
+- the release changes mention intake, reply targeting, chunking, or other Discord-presenter behavior
+- the release changes attachment download behavior or other Discord-hosted asset handling
+- a staging or production issue suggests real Discord behavior needs confirmation before tagging
+
+When none of those triggers apply, rely on the automated validation layers instead of forcing a broad live Discord pass.
 
 ## Tagging a Release
 


### PR DESCRIPTION
## Summary

- redefine the repository validation story around automated runtime-agnostic coverage plus narrow live Discord hardening
- update release and architecture docs to treat live Discord checks as optional platform-specific hardening
- add an active ExecPlan for issue #58 to build reusable fake runtime validation infrastructure

## Background

Issue #50 proposes shifting the repository away from a Discord-smoke-centric quality story toward runtime-agnostic validation contracts and adapter-level fake runtime coverage.

Issue #57 captures the documentation-first part of that work, and issue #58 captures the implementation work for the fake runtime harness.

## Related issue(s)

- #50
- #57
- #58
- #42

## Implementation details

- rewrote the existing tech-debt entry so the remaining Discord gap is described as narrow optional hardening instead of the primary missing validation strategy
- added validation-strategy defaults to the implementation and architecture docs
- updated the release runbook and release automation note to keep automated coverage as the main gate and targeted Discord hardening as a conditional step
- added `docs/exec-plans/active/11-fake-runtime-validation.md` plus an active-plan directory README and index entry for issue #58

## Test coverage

- `make test`
- `make lint`

## Breaking changes

- None

## Notes

- This PR is documentation and planning only; it does not change production behavior yet.
- The new ExecPlan is intended to be the implementation guide for issue #58.

Created by Codex
