### PR TITLE
Improve Discord reply latency with streamed Codex updates

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -129,6 +129,7 @@ Responsibilities:
 - determine whether the bot should respond
 - normalize input into application requests
 - send formatted responses back to Discord
+- surface best-effort streamed progress by editing the in-flight Discord reply while a non-queued Codex turn is still running
 - own the runtime lifecycle for in-flight and queued background work during shutdown
 
 The runtime must not directly talk to storage or Codex implementation details.
@@ -147,7 +148,8 @@ Responsibilities:
 5. load any existing binding from the thread store
 6. call the Codex gateway with or without an existing thread ID
 7. persist the returned thread ID when a new binding is created or updated
-8. return an immediate response and, when needed, deliver a deferred follow-up reply
+8. stream best-effort progress updates for immediate turns when the runtime requests them
+9. return an immediate response and, when needed, deliver a deferred follow-up reply
 
 ### 6.3 Thread Policy
 
@@ -299,8 +301,9 @@ Tradeoffs:
 5. If the turn starts immediately, the thread store looks up any existing Codex thread ID
 6. If missing, Codex creates a new thread
 7. The binding is persisted
-8. Discord runtime posts either the final response immediately or a queued acknowledgment
-9. If the turn was queued, the application service later executes it and the runtime posts the deferred reply
+8. Discord runtime posts either a queued acknowledgment or, for immediate turns, an editable placeholder reply
+9. While a non-queued Codex turn is running, streamed Codex events may update that placeholder with progress or partial assistant text
+10. If the turn was queued, the application service later executes it and the runtime posts the deferred reply
 ```
 
 ## 8.1 Concurrency Model

--- a/README.md
+++ b/README.md
@@ -530,6 +530,7 @@ For the complete release candidate checklist, tagging steps, and post-release ve
 - one instance-specific root slash command
 - `action:help`, `action:task-current`, `action:task-list`, `action:task-new`, `action:task-switch`, and `action:task-close`
 - SQLite-backed persistence for thread bindings and task state
+- streamed in-place progress updates for immediate Discord turns
 - queued acknowledgments with deferred follow-up replies
 
 ## Learn More

--- a/docs/design-docs/architecture-overview.md
+++ b/docs/design-docs/architecture-overview.md
@@ -44,7 +44,7 @@ Discord Runtime
 
 ### Discord Runtime
 
-Receives Discord inputs and delivers formatted responses.
+Receives Discord inputs, delivers formatted responses, and edits in-flight non-queued replies when streamed Codex progress is available.
 
 ### Message Application Service
 
@@ -65,7 +65,7 @@ The first turn for an idle key runs immediately, up to five additional waiting t
 
 ### Codex Gateway
 
-Owns the direct integration with the Codex SDK or Codex API layer, including the effective working directory for each turn.
+Owns the direct integration with the Codex SDK or Codex API layer, including the effective working directory for each turn and the translation of streamed Codex events into app-facing progress updates.
 
 ### Response Presenter
 
@@ -84,8 +84,9 @@ Adapts normalized application output into Discord-safe responses.
 8. Application service sends the turn through the Codex gateway with the saved thread ID when one exists
 9. If no saved thread exists yet, the first turn creates one and returns its thread ID
 10. Application service persists the returned binding
-11. Response presenter formats the result
-12. Discord runtime posts the final response immediately for non-queued work or later as a deferred reply for queued work
+11. For non-queued work, the runtime may post and edit a placeholder reply while the turn is still running
+12. Response presenter formats the result
+13. Discord runtime posts the final response immediately for non-queued work or later as a deferred reply for queued work
 
 The runtime-owned part stops at creating and refreshing the memory files themselves.
 Whether Codex consults those files during normal visible turns is controlled by the user-owned instructions already present in the workdir, such as `AGENTS.md`.

--- a/docs/exec-plans/active/11-fake-runtime-validation.md
+++ b/docs/exec-plans/active/11-fake-runtime-validation.md
@@ -6,7 +6,7 @@ This document must be maintained in accordance with `.agents/PLANS.md`.
 
 ## Purpose / Big Picture
 
-After this plan, a contributor should be able to prove the most important runtime-facing behavior without a live Discord server. They should be able to run a focused automated suite that drives fake runtime inputs, observes adapter-visible outputs, and confirms that 39claw still replies to qualifying mentions, acknowledges queued work, delivers deferred replies later, and handles command-style inputs at the application boundary.
+After this plan, a contributor should be able to prove the most important runtime-facing behavior without a live Discord server. They should be able to run a focused automated suite that drives fake runtime inputs, observes adapter-visible outputs, and confirms that 39claw still replies to qualifying mentions, streams in-place progress edits for immediate turns, acknowledges queued work, delivers deferred replies later, and handles command-style inputs at the application boundary.
 
 This change matters because the repository's main confidence story should no longer depend on broad live Discord smoke checks. The result should be a reusable fake-runtime testing shape that stays useful if a future Slack or Telegram runtime is added, while keeping the current production architecture thin and Discord-specific details out of the application layer.
 
@@ -15,9 +15,10 @@ This change matters because the repository's main confidence story should no lon
 - [x] (2026-04-05 19:15Z) Reviewed `.agents/PLANS.md`, the current runtime and application tests, and the validation-strategy docs updated for issue `#57`.
 - [x] (2026-04-05 19:15Z) Confirmed the current repository state: Discord runtime tests already use package-local fake sessions, and application tests already use in-memory stores and fake gateways, but there is no reusable fake-runtime harness or shared contract-style suite.
 - [x] (2026-04-05 19:15Z) Created this ExecPlan under `docs/exec-plans/active/` and restored the missing `active/` directory so issue `#58` has a tracked execution plan.
+- [x] (2026-04-05 19:40Z) Re-read the current runtime and app contracts after the streamed immediate-reply change and updated this ExecPlan so the fake-runtime scope explicitly covers best-effort progress delivery through `MessageProgressSink` and Discord message edits.
 - [ ] Introduce a reusable test-support package for runtime-facing fake inputs and observed deliveries.
 - [ ] Refactor or replace the current Discord package-local fake session helpers so the new contract-style tests can drive runtime events and capture outputs through one consistent harness.
-- [ ] Add at least one end-to-end-style Discord adapter suite that uses the fake runtime boundary to prove observable behavior for normal messages, queued acknowledgments, deferred replies, and one command-style interaction.
+- [ ] Add at least one end-to-end-style Discord adapter suite that uses the fake runtime boundary to prove observable behavior for normal messages, streamed immediate-reply edits, queued acknowledgments, deferred replies, and one command-style interaction.
 - [ ] Update repository documentation so contributors know the fake-runtime suite is the preferred validation layer before optional live Discord hardening.
 - [ ] Run `make test` and `make lint`, then record proof and any follow-up gaps in this plan.
 
@@ -34,6 +35,9 @@ This change matters because the repository's main confidence story should no lon
 
 - Observation: The current validation gap is not "no tests exist." The real gap is that the existing tests are difficult to reuse as a runtime-neutral pattern because the doubles and assertions are tightly coupled to one package's private test helpers.
   Evidence: `internal/runtime/discord/runtime_test.go`
+
+- Observation: A neighboring runtime change widened the app/runtime boundary by adding `app.MessageProgressSink` for best-effort streamed updates on immediate turns, and the Discord session seam now includes message-edit and message-delete operations.
+  Evidence: `internal/app/types.go`, `internal/app/message_service_impl.go`, `internal/runtime/discord/runtime.go`, `internal/runtime/discord/session.go`, `internal/runtime/discord/live_message.go`
 
 ## Decision Log
 
@@ -53,46 +57,53 @@ This change matters because the repository's main confidence story should no lon
   Rationale: `runtime_test.go` and `message_service_test.go` already encode valuable behavior. The safest path is to extract stable helpers, convert the key adapter-level cases to the new harness, and leave narrowly unit-scoped tests in place when they still add value.
   Date/Author: 2026-04-05 / Codex
 
+- Decision: Treat streamed immediate-reply edits as part of the runtime-visible contract that the fake-runtime suite must cover, but keep those edits best-effort and separate from queued deferred-delivery guarantees.
+  Rationale: The production runtime now edits an in-flight Discord reply when `Codex` emits progress or partial assistant text on immediate turns. That behavior is user-visible and should be validated, but it is intentionally weaker than the queued-message contract because progress delivery failures do not fail the Codex turn.
+  Date/Author: 2026-04-05 / Codex
+
 ## Outcomes & Retrospective
 
-Implementation has not started yet. The intended outcome is a repository where contributors can validate key runtime behavior through a fake runtime harness first, then use optional live Discord hardening only for the narrow external-platform remainder documented in `docs/exec-plans/tech-debt-tracker.md`.
+Implementation of this ExecPlan has not started yet. The intended outcome is a repository where contributors can validate key runtime behavior through a fake runtime harness first, then use optional live Discord hardening only for the narrow external-platform remainder documented in `docs/exec-plans/tech-debt-tracker.md`.
 
-The plan will be complete when the repository contains a reusable fake-runtime test-support package, at least one Discord contract-style suite built on that package, updated documentation, and passing repository checks.
+The plan will be complete when the repository contains a reusable fake-runtime test-support package, at least one Discord contract-style suite built on that package, explicit coverage for streamed immediate-reply edits as well as queued deferred replies, updated documentation, and passing repository checks.
 
 ## Context and Orientation
 
-39claw is a thin gateway between Discord and Codex. The production message path starts in `internal/runtime/discord/runtime.go`, where the runtime receives Discord events, maps them into normalized application requests, calls the application layer, and presents the returned response back to Discord. The application boundary is defined in `internal/app/message_service.go` and `internal/app/types.go`. A normal message becomes an `app.MessageRequest`; the application returns an immediate `app.MessageResponse`; and queued work can later use `app.DeferredReplySink` to publish a follow-up reply.
+39claw is a thin gateway between Discord and Codex. The production message path starts in `internal/runtime/discord/runtime.go`, where the runtime receives Discord events, maps them into normalized application requests, calls the application layer, and presents the returned response back to Discord. The application boundary is defined in `internal/app/message_service.go` and `internal/app/types.go`. A normal message becomes an `app.MessageRequest`; the application returns an immediate `app.MessageResponse`; queued work can later use `app.DeferredReplySink` to publish a follow-up reply; and immediate turns may now use `app.MessageProgressSink` to push best-effort streamed progress into the runtime before the final response is ready.
 
 In this repository, a "fake runtime" means a test harness that simulates platform-facing events and captures the runtime-visible outputs without connecting to a real Discord deployment. It is not a second production runtime and it is not a broad interface that every future runtime must implement in production code. It is a test-support shape that lets tests express scenarios such as "a qualifying mention arrives," "a command interaction arrives," and "a deferred reply is delivered later," then assert what the adapter presented externally.
 
 The key current files are:
 
 - `internal/runtime/discord/runtime.go`
-  - owns Discord session startup, event handlers, response presentation, and shutdown draining
+  - owns Discord session startup, event handlers, response presentation, streamed immediate-reply edits, and shutdown draining
 - `internal/runtime/discord/session.go`
-  - defines the narrow `session` interface that production and test sessions both satisfy
+  - defines the narrow `session` interface that production and test sessions both satisfy, including message send, edit, and delete operations
+- `internal/runtime/discord/live_message.go`
+  - keeps one in-flight Discord reply synchronized with streamed progress text by sending, editing, and trimming message chunks
 - `internal/runtime/discord/runtime_test.go`
-  - already contains a package-local fake session plus adapter-level tests, but the helpers are not reusable outside this file
+  - already contains a package-local fake session plus adapter-level tests, including streamed-reply edit assertions, but the helpers are not reusable outside this file
 - `internal/runtime/discord/message_mapper.go` and `internal/runtime/discord/interaction_mapper.go`
   - normalize Discord events into `app.MessageRequest` and task-command requests
 - `internal/app/message_service.go`
-  - defines `MessageService`, `DeferredReplySink`, and the queue-related boundary
+  - defines `MessageService`, `DeferredReplySink`, `MessageProgressSink`, and the queue-related boundary
 - `internal/app/message_service_impl.go`
-  - implements logical-key resolution, queue admission, deferred delivery handoff, and Codex turn orchestration
+  - implements logical-key resolution, queue admission, best-effort progress delivery for immediate turns, deferred delivery handoff, and Codex turn orchestration
 - `internal/app/task_service.go`
   - implements command-style task control and help behavior behind the runtime
 - `internal/thread/queue.go`
   - owns capped in-memory queue admission for same-key work
 
-The repository already has focused automated tests for the application layer and Discord runtime. What it does not have is a single reusable harness that can express runtime-facing contract scenarios and make those scenarios easy to repeat for future runtimes.
+The repository already has focused automated tests for the application layer and Discord runtime. What it does not have is a single reusable harness that can express runtime-facing contract scenarios, including streamed immediate-reply edits, and make those scenarios easy to repeat for future runtimes.
 
 ## Starting State
 
 Start this plan only after confirming the repository still matches these assumptions:
 
 - the production runtime is still `internal/runtime/discord`
-- the app/runtime boundary still flows through `app.MessageRequest`, `app.MessageResponse`, and `app.DeferredReplySink`
+- the app/runtime boundary still flows through `app.MessageRequest`, `app.MessageResponse`, `app.DeferredReplySink`, and `app.MessageProgressSink`
 - `internal/runtime/discord/runtime_test.go` still contains working fake-session-based adapter tests
+- the Discord runtime still publishes immediate-turn progress by editing one in-flight reply through the `session` interface
 - `internal/app/message_service_test.go` still provides in-memory store and gateway doubles that can support end-to-end-style tests without a real Codex backend
 - `make test` and `make lint` pass before the new harness work begins
 
@@ -111,6 +122,7 @@ This plan assumes and fixes the following boundaries:
 - runtime-agnostic validation stops at the app/runtime boundary
 - production code must stay thin and should not gain a speculative cross-platform runtime interface
 - adapter-level fake tests may use Discord-specific event values internally, but the reusable test-support package should describe observed behavior in transport-neutral terms
+- streamed immediate-turn progress is part of the visible runtime contract, but its delivery remains best-effort rather than a hard application guarantee
 - optional live Discord hardening remains a separate concern and is not part of this implementation plan
 
 ## Milestone 1: Create a reusable runtime-harness vocabulary
@@ -121,11 +133,11 @@ Create a new package under `internal/testutil/runtimeharness`. Keep it test-supp
 
 - a normal-message fixture that carries user ID, channel ID, message ID, mention state, text payload, and optional attachment metadata
 - a command-intent fixture that carries user ID, channel ID, command name, action name, and any task-related arguments
-- an observed-delivery record that captures the visible outcome: channel ID, reply target, text payload, whether the delivery was immediate or deferred, and whether the response was ephemeral
+- an observed-delivery record that captures the visible outcome: channel ID, reply target, text payload, whether the delivery was immediate, streamed-edit, or deferred, and whether the response was ephemeral
 
 Keep these types plain and boring. They exist so tests can describe scenarios consistently. Do not add a production dependency from `internal/app` or `internal/runtime/discord` to this package.
 
-Add reusable assertion helpers here as well. For example, provide helpers that verify "one immediate reply rooted to message X," "one queued acknowledgment followed by one deferred reply," or "one ephemeral interaction response." The helpers should compare only runtime-visible behavior and avoid asserting implementation trivia such as specific helper function names or internal log wording.
+Add reusable assertion helpers here as well. For example, provide helpers that verify "one immediate reply rooted to message X," "one streamed immediate reply that evolves through edits," "one queued acknowledgment followed by one deferred reply," or "one ephemeral interaction response." The helpers should compare only runtime-visible behavior and avoid asserting implementation trivia such as specific helper function names or internal log wording.
 
 ## Milestone 2: Adapt the Discord tests to the reusable harness
 
@@ -144,9 +156,10 @@ Next, add a new contract-style test file in `internal/runtime/discord`, for exam
 The minimum scenarios to cover are:
 
 1. A qualifying normal mention produces one reply to the triggering message.
-2. A queued normal mention produces one immediate queued acknowledgment and later one deferred reply to the original message.
-3. A command-style interaction produces the correct visible presentation, including the ephemeral flag where applicable.
-4. One representative attachment-aware message flow proves that attachment metadata and reply semantics can be driven through the fake runtime path without a live Discord server.
+2. A qualifying immediate turn that emits progress produces one reply that is updated in place as progress or partial assistant text arrives.
+3. A queued normal mention produces one immediate queued acknowledgment and later one deferred reply to the original message.
+4. A command-style interaction produces the correct visible presentation, including the ephemeral flag where applicable.
+5. One representative attachment-aware message flow proves that attachment metadata and reply semantics can be driven through the fake runtime path without a live Discord server.
 
 For the queueing scenario, prefer wiring the real `app.DefaultMessageService`, the real `thread.QueueCoordinator`, an in-memory thread store double, and a fake Codex gateway that can block and release on command. That gives one real vertical slice that covers runtime event handling, app-level queue admission, and deferred delivery without a live Discord deployment.
 
@@ -177,11 +190,11 @@ Do not create a brand-new design note unless implementation discovers something 
 
 ## Plan of Work
 
-Begin by creating `internal/testutil/runtimeharness` with a small transport-neutral vocabulary for runtime events and deliveries. Keep the package purpose narrow: it should only help tests describe and assert behavior at the app/runtime boundary.
+Begin by creating `internal/testutil/runtimeharness` with a small transport-neutral vocabulary for runtime events and deliveries. Keep the package purpose narrow: it should only help tests describe and assert behavior at the app/runtime boundary, including immediate reply edits and deferred follow-up replies.
 
 Next, inspect the current fake helpers in `internal/runtime/discord/runtime_test.go` and decide which ones should become stable shared test utilities. A likely shape is to keep the low-level fake Discord session in the Discord test package, but add conversion helpers that transform recorded Discord-specific outputs into `runtimeharness` observations.
 
-Then add one new contract-style test file in `internal/runtime/discord` that uses the shared harness vocabulary. For at least one queueing scenario, wire the real application service and queue coordinator so the test proves observable queue behavior through the runtime boundary. For the other required scenarios, choose the thinnest dependencies that still make the visible behavior meaningful.
+Then add one new contract-style test file in `internal/runtime/discord` that uses the shared harness vocabulary. For at least one queueing scenario, wire the real application service and queue coordinator so the test proves observable queue behavior through the runtime boundary. For at least one immediate-turn scenario, wire a fake Codex gateway or scripted message service that emits progress updates so the harness proves the reply-edit behavior through the same runtime boundary. For the other required scenarios, choose the thinnest dependencies that still make the visible behavior meaningful.
 
 After the new suite is stable, trim duplicated setup from existing runtime tests where it improves readability. Leave small unit tests in place when they still explain isolated rules better than a vertical slice would.
 
@@ -200,9 +213,9 @@ Run all commands from `/home/filepang/playground/39claw`.
 
     go test ./internal/testutil/runtimeharness -v
 
-3. Build or refactor the Discord fake-session helpers until they support the new contract suite cleanly.
+3. Build or refactor the Discord fake-session helpers until they support the new contract suite cleanly, including reply edits and any chunk-trimming deletes.
 
-    go test ./internal/runtime/discord -run 'TestRuntimeStart|TestRuntimeMention|TestRuntimeDeferred' -v
+    go test ./internal/runtime/discord -run 'TestRuntimeStart|TestRuntimeMention|TestRuntimeDeferred|TestRuntime.*Stream' -v
 
 4. Add the new contract-style suite and run only the new scenarios while iterating.
 
@@ -226,7 +239,7 @@ This plan is complete when all of the following are true:
 - the repository contains a reusable fake-runtime test-support package under a stable path such as `internal/testutil/runtimeharness`
 - the new package defines transport-neutral inputs or observations for runtime-facing behavior instead of exposing Discord SDK types directly
 - at least one Discord adapter suite drives fake runtime events through the real `Runtime` startup path and verifies observable outputs through the shared harness vocabulary
-- the suite proves a normal mention reply flow, a queued-acknowledgment-plus-deferred-reply flow, and one command-style interaction flow
+- the suite proves a normal mention reply flow, a streamed immediate-reply edit flow, a queued-acknowledgment-plus-deferred-reply flow, and one command-style interaction flow
 - at least one queueing test uses the real app-layer queue admission path rather than a runtime-only stub so the suite behaves like an end-to-end slice
 - existing focused runtime unit tests still pass, with duplicated setup reduced where practical
 - repository docs mention the fake-runtime validation path as the preferred automated layer before optional live Discord hardening
@@ -242,6 +255,14 @@ The most important human-readable proof is this automated scenario:
 5. Observe one later deferred reply to that same second message.
 
 That proof must happen entirely inside automated tests without a live Discord deployment.
+
+An additional human-readable proof should cover the new immediate-turn streaming contract:
+
+1. Start the real Discord runtime in a test with a fake session.
+2. Dispatch one qualifying message whose dependency emits progress and then a final response.
+3. Observe one initial reply message.
+4. Observe that same reply being edited in place as progress or partial assistant text arrives.
+5. Observe the final edit settle on the completed assistant response.
 
 ## Idempotence and Recovery
 
@@ -260,15 +281,21 @@ Current code facts that motivate this plan:
           Deliver(ctx context.Context, response MessageResponse) error
       }
 
+    internal/app/types.go:
+      type MessageProgressSink interface {
+          Deliver(ctx context.Context, progress MessageProgress) error
+      }
+
     internal/runtime/discord/session.go:
-      Runtime startup and event handling already depend on a narrow session interface.
+      Runtime startup and event handling already depend on a narrow session interface with send, edit, and delete operations.
 
     internal/runtime/discord/runtime_test.go:
-      already contains fake-session-driven scenarios for mentions, queued replies, shutdown drain, and attachment downloads.
+      already contains fake-session-driven scenarios for mentions, streamed reply edits, queued replies, shutdown drain, and attachment downloads.
 
 Helpful target test names:
 
     TestRuntimeContractNormalMentionReply
+    TestRuntimeContractStreamedImmediateReplyEdits
     TestRuntimeContractQueuedAcknowledgementAndDeferredReply
     TestRuntimeContractHelpCommandUsesEphemeralPresentation
     TestRuntimeContractAttachmentAwareMessageFlow
@@ -312,11 +339,14 @@ At the end of this plan, the new test-support package should expose stable names
         Text      string
         Ephemeral bool
         Deferred  bool
+        Edited    bool
     }
 
     func RequireReplyTo(t *testing.T, deliveries []Delivery, replyToID string)
+    func RequireStreamedEditFlow(t *testing.T, deliveries []Delivery, replyToID string)
     func RequireQueuedFlow(t *testing.T, deliveries []Delivery, replyToID string, ackText string, finalText string)
 
 These names are examples, not mandatory exact spelling, but the final package must provide the same capabilities. The production runtime must continue to depend only on `internal/app`, `internal/config`, `discordgo`, and its existing collaborators. The new harness must not become a production dependency.
 
 Revision Note: 2026-04-05 / Codex - Created this ExecPlan for issue `#58` after documenting the validation strategy in issue `#57`, creating the missing `docs/exec-plans/active/` directory, and confirming that the repository already has package-local fake runtime helpers that can be promoted into a reusable harness.
+Revision Note: 2026-04-05 19:40Z / Codex - Updated this ExecPlan after the streamed immediate Discord reply change landed on the working branch. The plan now treats `MessageProgressSink` and in-place reply edits as part of the runtime-visible behavior that the future fake-runtime harness must validate.

--- a/docs/product-specs/discord-command-behavior.md
+++ b/docs/product-specs/discord-command-behavior.md
@@ -83,6 +83,7 @@ Examples:
 v1 should use mention-only triggering for normal-message interaction.
 When the bot is mentioned, a normal message may contain typed text, one or more image attachments, or both.
 If the mention is present but the message contains neither text nor a usable image attachment, the bot should stay silent.
+If the turn starts immediately, the bot may first post a short placeholder reply and then edit that same reply as Codex streams progress or partial assistant output.
 If another turn for the same logical conversation is already running, the bot should acknowledge queued acceptance immediately and post the real answer later as a reply to the original triggering message.
 If five waiting messages are already queued for that logical conversation, the bot should return a clear retry-later response instead of queueing more work.
 
@@ -226,6 +227,7 @@ Error responses should be:
 
 Queued acknowledgments should also stay short and explicit.
 They should make it clear that the message was accepted and that the final answer will arrive later.
+For immediate non-queued turns, streamed progress updates should feel like one continuously improving reply rather than a burst of separate bot messages.
 
 ## Help and Discoverability
 

--- a/internal/app/message_service_impl.go
+++ b/internal/app/message_service_impl.go
@@ -117,8 +117,10 @@ func (s *DefaultMessageService) HandleMessage(ctx context.Context, request Messa
 
 	executionKey := buildExecutionKey(s.mode, prepared.logicalKey)
 	logger := s.messageLogger(prepared)
+	queuedPrepared := prepared
+	queuedPrepared.input.ProgressSink = nil
 	admission, err := s.coordinator.Admit(executionKey, func() {
-		s.processQueuedMessage(ctx, prepared)
+		s.processQueuedMessage(ctx, queuedPrepared)
 	})
 	if err != nil {
 		if errors.Is(err, ErrExecutionQueueFull) {
@@ -214,8 +216,9 @@ func (s *DefaultMessageService) prepareMessage(
 		replyToID:  request.MessageID,
 		receivedAt: request.ReceivedAt,
 		input: CodexTurnInput{
-			Prompt:     request.Content,
-			ImagePaths: append([]string(nil), request.ImagePaths...),
+			Prompt:       request.Content,
+			ImagePaths:   append([]string(nil), request.ImagePaths...),
+			ProgressSink: request.ProgressSink,
 		},
 		sink:    sink,
 		cleanup: cleanup,
@@ -286,6 +289,14 @@ func (s *DefaultMessageService) executePreparedMessage(ctx context.Context, prep
 	logger := s.messageLogger(prepared)
 	turnStartedAt := time.Now()
 	threadResumed := strings.TrimSpace(threadID) != ""
+	if prepared.input.ProgressSink != nil {
+		if err := prepared.input.ProgressSink.Deliver(ctx, MessageProgress{
+			Text: "Thinking...",
+		}); err != nil {
+			ignoreProgressDeliveryError(err)
+		}
+	}
+
 	logger.Info(
 		"codex turn started",
 		"event",
@@ -516,6 +527,10 @@ func runCleanup(cleanup func()) {
 	if cleanup != nil {
 		cleanup()
 	}
+}
+
+func ignoreProgressDeliveryError(err error) {
+	_ = err
 }
 
 func taskIDFromLogicalKey(userID string, logicalKey string) (string, error) {

--- a/internal/app/message_service_test.go
+++ b/internal/app/message_service_test.go
@@ -116,6 +116,45 @@ func TestMessageServiceHandleMessageDailyReusesSameDayBinding(t *testing.T) {
 	}
 }
 
+func TestMessageServiceHandleMessageStreamsImmediateProgress(t *testing.T) {
+	t.Parallel()
+
+	store := &memoryThreadStore{}
+	gateway := &fakeCodexGateway{
+		results: []app.RunTurnResult{
+			{ThreadID: "thread-1", ResponseText: "Final response"},
+		},
+	}
+	service := newDailyMessageService(t, store, gateway, nil)
+
+	var progress []string
+	response, err := service.HandleMessage(context.Background(), app.MessageRequest{
+		MessageID: "message-1",
+		Content:   "stream me",
+		Mentioned: true,
+		ProgressSink: app.MessageProgressSinkFunc(func(_ context.Context, update app.MessageProgress) error {
+			progress = append(progress, update.Text)
+			return nil
+		}),
+		ReceivedAt: time.Date(2026, time.April, 5, 0, 0, 0, 0, time.UTC),
+	}, nil)
+	if err != nil {
+		t.Fatalf("HandleMessage() error = %v", err)
+	}
+
+	if response.Text != "Final response" {
+		t.Fatalf("response text = %q, want %q", response.Text, "Final response")
+	}
+
+	if len(progress) != 1 {
+		t.Fatalf("progress count = %d, want %d", len(progress), 1)
+	}
+
+	if progress[0] != "Thinking..." {
+		t.Fatalf("progress = %q, want %q", progress[0], "Thinking...")
+	}
+}
+
 func TestMessageServiceHandleMessageDailyRollsOverOnNextDay(t *testing.T) {
 	t.Parallel()
 
@@ -623,10 +662,15 @@ func TestMessageServiceHandleMessageQueuesBusyTurnAndDeliversDeferredReply(t *te
 	waitForSignal(t, gateway.started, "first codex turn start")
 
 	delivered := make(chan app.MessageResponse, 1)
+	var progress []string
 	secondResponse, err := service.HandleMessage(context.Background(), app.MessageRequest{
-		MessageID:  "message-2",
-		Content:    "follow up later",
-		Mentioned:  true,
+		MessageID: "message-2",
+		Content:   "follow up later",
+		Mentioned: true,
+		ProgressSink: app.MessageProgressSinkFunc(func(_ context.Context, update app.MessageProgress) error {
+			progress = append(progress, update.Text)
+			return nil
+		}),
 		ReceivedAt: time.Date(2026, time.April, 5, 0, 1, 0, 0, time.UTC),
 	}, app.DeferredReplySinkFunc(func(ctx context.Context, response app.MessageResponse) error {
 		delivered <- response
@@ -642,6 +686,10 @@ func TestMessageServiceHandleMessageQueuesBusyTurnAndDeliversDeferredReply(t *te
 
 	if secondResponse.ReplyToID != "message-2" {
 		t.Fatalf("queued ReplyToID = %q, want %q", secondResponse.ReplyToID, "message-2")
+	}
+
+	if len(progress) != 0 {
+		t.Fatalf("queued progress = %v, want empty", progress)
 	}
 
 	close(gateway.release)

--- a/internal/app/types.go
+++ b/internal/app/types.go
@@ -1,18 +1,22 @@
 package app
 
-import "time"
+import (
+	"context"
+	"time"
+)
 
 type MessageRequest struct {
-	UserID      string
-	ChannelID   string
-	MessageID   string
-	Content     string
-	ImagePaths  []string
-	Cleanup     func()
-	Mentioned   bool
-	CommandName string
-	CommandArgs []string
-	ReceivedAt  time.Time
+	UserID       string
+	ChannelID    string
+	MessageID    string
+	Content      string
+	ImagePaths   []string
+	Cleanup      func()
+	ProgressSink MessageProgressSink
+	Mentioned    bool
+	CommandName  string
+	CommandArgs  []string
+	ReceivedAt   time.Time
 }
 
 type MessageResponse struct {
@@ -82,10 +86,25 @@ type RunTurnResult struct {
 	Usage        *TokenUsage
 }
 
+type MessageProgress struct {
+	Text string
+}
+
+type MessageProgressSink interface {
+	Deliver(ctx context.Context, progress MessageProgress) error
+}
+
+type MessageProgressSinkFunc func(ctx context.Context, progress MessageProgress) error
+
+func (f MessageProgressSinkFunc) Deliver(ctx context.Context, progress MessageProgress) error {
+	return f(ctx, progress)
+}
+
 type CodexTurnInput struct {
 	Prompt           string
 	ImagePaths       []string
 	WorkingDirectory string
+	ProgressSink     MessageProgressSink
 }
 
 type QueueAdmission struct {

--- a/internal/codex/codex_test.go
+++ b/internal/codex/codex_test.go
@@ -409,6 +409,43 @@ func runHelperProcess() error {
 	case "process-failed":
 		_, _ = fmt.Fprintln(os.Stderr, "helper process failed")
 		return errors.New("helper process failed")
+	case "stream-progress":
+		writeHelperEvent(map[string]any{"type": "thread.started", "thread_id": "thread_stream"})
+		writeHelperEvent(map[string]any{"type": "turn.started"})
+		writeHelperEvent(map[string]any{
+			"type": "item.started",
+			"item": map[string]any{
+				"id":      "item_cmd",
+				"type":    "command_execution",
+				"command": "go test ./...",
+				"status":  "in_progress",
+			},
+		})
+		writeHelperEvent(map[string]any{
+			"type": "item.updated",
+			"item": map[string]any{
+				"id":   "item_msg",
+				"type": "agent_message",
+				"text": "Partial helper response",
+			},
+		})
+		writeHelperEvent(map[string]any{
+			"type": "item.completed",
+			"item": map[string]any{
+				"id":   "item_msg",
+				"type": "agent_message",
+				"text": "Final helper response",
+			},
+		})
+		writeHelperEvent(map[string]any{
+			"type": "turn.completed",
+			"usage": map[string]any{
+				"input_tokens":        8,
+				"cached_input_tokens": 0,
+				"output_tokens":       4,
+			},
+		})
+		return nil
 	default:
 		return fmt.Errorf("unknown helper scenario %q", os.Getenv("CODEX_TEST_SCENARIO"))
 	}

--- a/internal/codex/gateway.go
+++ b/internal/codex/gateway.go
@@ -3,6 +3,7 @@ package codex
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 
 	"github.com/HatsuneMiku3939/39claw/internal/app"
@@ -16,6 +17,8 @@ type Gateway struct {
 	client        *Client
 	threadOptions ThreadOptions
 }
+
+const agentMessageItemType = "agent_message"
 
 func NewGateway(client *Client, options GatewayOptions) *Gateway {
 	return &Gateway{
@@ -44,25 +47,117 @@ func (g *Gateway) RunTurn(ctx context.Context, threadID string, input app.CodexT
 		thread = g.client.ResumeThread(threadID, threadOptions)
 	}
 
-	turn, err := thread.Run(ctx, codexInput)
+	stream, err := thread.RunStreamed(ctx, codexInput)
 	if err != nil {
 		return app.RunTurnResult{}, err
 	}
 
-	result := app.RunTurnResult{
-		ThreadID:     thread.ID(),
-		ResponseText: turn.FinalResponse,
-	}
+	result := app.RunTurnResult{}
+	var turnFailure *ThreadError
+	var streamFailure string
+	responseStarted := false
+	lastProgressText := ""
 
-	if turn.Usage != nil {
-		result.Usage = &app.TokenUsage{
-			InputTokens:       turn.Usage.InputTokens,
-			CachedInputTokens: turn.Usage.CachedInputTokens,
-			OutputTokens:      turn.Usage.OutputTokens,
+	for event := range stream.Events() {
+		switch event.Type {
+		case "item.started", "item.updated", "item.completed":
+			if event.Item == nil {
+				continue
+			}
+
+			if event.Item.Type == agentMessageItemType {
+				result.ResponseText = event.Item.Text
+				if strings.TrimSpace(event.Item.Text) != "" {
+					responseStarted = true
+				}
+			}
+
+			progressText := progressTextForEvent(event, responseStarted)
+			if input.ProgressSink != nil && strings.TrimSpace(progressText) != "" && progressText != lastProgressText {
+				if err := input.ProgressSink.Deliver(ctx, app.MessageProgress{Text: progressText}); err != nil {
+					ignoreProgressDeliveryError(err)
+				}
+				lastProgressText = progressText
+			}
+		case "turn.completed":
+			if event.Usage != nil {
+				result.Usage = &app.TokenUsage{
+					InputTokens:       event.Usage.InputTokens,
+					CachedInputTokens: event.Usage.CachedInputTokens,
+					OutputTokens:      event.Usage.OutputTokens,
+				}
+			}
+		case "turn.failed":
+			turnFailure = event.Error
+		case "error":
+			streamFailure = event.Message
 		}
 	}
 
+	if err := stream.Wait(); err != nil {
+		return app.RunTurnResult{}, err
+	}
+
+	if turnFailure != nil {
+		return app.RunTurnResult{}, errors.New(turnFailure.Message)
+	}
+
+	if streamFailure != "" {
+		return app.RunTurnResult{}, errors.New(streamFailure)
+	}
+
+	result.ThreadID = thread.ID()
 	return result, nil
+}
+
+func progressTextForEvent(event Event, responseStarted bool) string {
+	if event.Item == nil {
+		return ""
+	}
+
+	item := event.Item
+	if item.Type == agentMessageItemType {
+		return item.Text
+	}
+
+	if responseStarted {
+		return ""
+	}
+
+	switch item.Type {
+	case "command_execution":
+		command := strings.TrimSpace(item.Command)
+		if command == "" {
+			return "Running a command..."
+		}
+
+		return fmt.Sprintf("Running command: `%s`", command)
+	case "mcp_tool_call":
+		if item.Server != "" && item.Tool != "" {
+			return fmt.Sprintf("Using tool: `%s/%s`", item.Server, item.Tool)
+		}
+
+		if item.Tool != "" {
+			return fmt.Sprintf("Using tool: `%s`", item.Tool)
+		}
+
+		return "Using a tool..."
+	case "web_search":
+		query := strings.TrimSpace(item.Query)
+		if query == "" {
+			return "Searching the web..."
+		}
+
+		return fmt.Sprintf("Searching the web: `%s`", query)
+	case "file_change":
+		return "Applying file changes..."
+	default:
+		return ""
+	}
+}
+
+func ignoreProgressDeliveryError(err error) {
+	_ = err
 }
 
 func buildGatewayInput(input app.CodexTurnInput) (Input, error) {

--- a/internal/codex/gateway_test.go
+++ b/internal/codex/gateway_test.go
@@ -116,3 +116,45 @@ func TestGatewayRunTurn(t *testing.T) {
 		})
 	}
 }
+
+func TestGatewayRunTurnStreamsProgressUpdates(t *testing.T) {
+	t.Parallel()
+
+	client, _ := newTestClient(t, "stream-progress")
+	gateway := NewGateway(client, GatewayOptions{})
+
+	var progress []string
+	result, err := gateway.RunTurn(context.Background(), "", app.CodexTurnInput{
+		Prompt: "hello",
+		ProgressSink: app.MessageProgressSinkFunc(func(_ context.Context, update app.MessageProgress) error {
+			progress = append(progress, update.Text)
+			return nil
+		}),
+	})
+	if err != nil {
+		t.Fatalf("RunTurn() error = %v", err)
+	}
+
+	if result.ThreadID != "thread_stream" {
+		t.Fatalf("ThreadID = %q, want %q", result.ThreadID, "thread_stream")
+	}
+
+	if result.ResponseText != "Final helper response" {
+		t.Fatalf("ResponseText = %q, want %q", result.ResponseText, "Final helper response")
+	}
+
+	want := []string{
+		"Running command: `go test ./...`",
+		"Partial helper response",
+		"Final helper response",
+	}
+	if len(progress) != len(want) {
+		t.Fatalf("progress length = %d, want %d (%v)", len(progress), len(want), progress)
+	}
+
+	for index := range want {
+		if progress[index] != want[index] {
+			t.Fatalf("progress[%d] = %q, want %q", index, progress[index], want[index])
+		}
+	}
+}

--- a/internal/runtime/discord/live_message.go
+++ b/internal/runtime/discord/live_message.go
@@ -1,0 +1,123 @@
+package discord
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/bwmarrin/discordgo"
+)
+
+type liveMessagePresenter struct {
+	session   session
+	channelID string
+	replyToID string
+	workdir   string
+
+	mu         sync.Mutex
+	messageIDs []string
+	contents   []string
+}
+
+func newLiveMessagePresenter(
+	discordSession session,
+	channelID string,
+	replyToID string,
+	workdir string,
+) *liveMessagePresenter {
+	return &liveMessagePresenter{
+		session:   discordSession,
+		channelID: channelID,
+		replyToID: replyToID,
+		workdir:   workdir,
+	}
+}
+
+func (p *liveMessagePresenter) Active() bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	return len(p.messageIDs) > 0
+}
+
+func (p *liveMessagePresenter) Update(text string) error {
+	return p.syncText(text)
+}
+
+func (p *liveMessagePresenter) syncText(text string) error {
+	text = formatDiscordResponseText(text, p.workdir)
+	chunks := chunkText(text)
+	if len(chunks) == 0 {
+		return nil
+	}
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	return p.syncChunksLocked(chunks)
+}
+
+func (p *liveMessagePresenter) syncChunksLocked(chunks []string) error {
+	limit := minInt(len(chunks), len(p.messageIDs))
+	for index := 0; index < limit; index++ {
+		if p.contents[index] == chunks[index] {
+			continue
+		}
+
+		edit := discordgo.NewMessageEdit(p.channelID, p.messageIDs[index]).
+			SetContent(chunks[index])
+		edit.AllowedMentions = disallowMentions()
+
+		if _, err := p.session.ChannelMessageEditComplex(edit); err != nil {
+			return fmt.Errorf("edit channel message: %w", err)
+		}
+
+		p.contents[index] = chunks[index]
+	}
+
+	for index := len(p.messageIDs); index < len(chunks); index++ {
+		payload := &discordgo.MessageSend{
+			Content:         chunks[index],
+			AllowedMentions: disallowMentions(),
+		}
+		if index == 0 && p.replyToID != "" {
+			payload.Reference = replyReference(p.channelID, p.replyToID)
+		}
+
+		message, err := p.session.ChannelMessageSendComplex(p.channelID, payload)
+		if err != nil {
+			return fmt.Errorf("send channel message: %w", err)
+		}
+
+		messageID := ""
+		if message != nil {
+			messageID = message.ID
+		}
+
+		p.messageIDs = append(p.messageIDs, messageID)
+		p.contents = append(p.contents, chunks[index])
+	}
+
+	for len(p.messageIDs) > len(chunks) {
+		lastIndex := len(p.messageIDs) - 1
+		messageID := p.messageIDs[lastIndex]
+		if strings.TrimSpace(messageID) != "" {
+			if err := p.session.ChannelMessageDelete(p.channelID, messageID); err != nil {
+				return fmt.Errorf("delete channel message: %w", err)
+			}
+		}
+
+		p.messageIDs = p.messageIDs[:lastIndex]
+		p.contents = p.contents[:lastIndex]
+	}
+
+	return nil
+}
+
+func minInt(left int, right int) int {
+	if left < right {
+		return left
+	}
+
+	return right
+}

--- a/internal/runtime/discord/runtime.go
+++ b/internal/runtime/discord/runtime.go
@@ -267,6 +267,15 @@ func (r *Runtime) handleMessageCreate(_ *discordgo.Session, event *discordgo.Mes
 		return
 	}
 
+	livePresenter := newLiveMessagePresenter(discordSession, request.ChannelID, request.MessageID, r.config.CodexWorkdir)
+	request.ProgressSink = app.MessageProgressSinkFunc(func(ctx context.Context, progress app.MessageProgress) error {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
+		return livePresenter.Update(progress.Text)
+	})
+
 	deferredSink := app.DeferredReplySinkFunc(func(ctx context.Context, response app.MessageResponse) error {
 		logAttrs := []any{
 			"event", "deferred_reply_delivery",
@@ -320,8 +329,15 @@ func (r *Runtime) handleMessageCreate(_ *discordgo.Session, event *discordgo.Mes
 		}
 	}
 
-	if err := r.presentMessageResponse(discordSession, request.ChannelID, response); err != nil {
-		r.logger.Error("present message response", "error", err, "channel_id", request.ChannelID, "message_id", request.MessageID)
+	var presentErr error
+	if livePresenter.Active() {
+		presentErr = livePresenter.Update(response.Text)
+	} else {
+		presentErr = r.presentMessageResponse(discordSession, request.ChannelID, response)
+	}
+
+	if presentErr != nil {
+		r.logger.Error("present message response", "error", presentErr, "channel_id", request.ChannelID, "message_id", request.MessageID)
 	}
 }
 

--- a/internal/runtime/discord/runtime_test.go
+++ b/internal/runtime/discord/runtime_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -152,6 +153,76 @@ func TestRuntimeMentionHandlingRepliesToTriggerMessage(t *testing.T) {
 
 	if fakeSession.sentMessages[0].Reference == nil || fakeSession.sentMessages[0].Reference.MessageID != "message-1" {
 		t.Fatal("first sent message missing reply reference")
+	}
+}
+
+func TestRuntimeMentionHandlingStreamsProgressByEditingReply(t *testing.T) {
+	t.Parallel()
+
+	messageService := &fakeMessageService{
+		handle: func(ctx context.Context, request app.MessageRequest, sink app.DeferredReplySink) (app.MessageResponse, error) {
+			if request.ProgressSink == nil {
+				t.Fatal("ProgressSink = nil, want non-nil")
+			}
+
+			if err := request.ProgressSink.Deliver(ctx, app.MessageProgress{Text: "Thinking..."}); err != nil {
+				return app.MessageResponse{}, err
+			}
+
+			if err := request.ProgressSink.Deliver(ctx, app.MessageProgress{Text: "Partial streamed response"}); err != nil {
+				return app.MessageResponse{}, err
+			}
+
+			if request.Cleanup != nil {
+				request.Cleanup()
+			}
+
+			return app.MessageResponse{
+				Text:      "Final streamed response",
+				ReplyToID: "message-1",
+			}, nil
+		},
+	}
+	fakeSession := newFakeSession("bot-user")
+	runtime := newTestRuntimeWithServices(t, config.ModeDaily, fakeSession, messageService, &fakeTaskCommandService{})
+
+	if err := runtime.Start(context.Background()); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	t.Cleanup(func() {
+		_ = runtime.Close()
+	})
+
+	fakeSession.dispatchMessage(&discordgo.MessageCreate{
+		Message: &discordgo.Message{
+			ID:        "message-1",
+			ChannelID: "channel-1",
+			Content:   "<@bot-user> hello there",
+			Author:    &discordgo.User{ID: "user-1"},
+			Mentions: []*discordgo.User{
+				{ID: "bot-user"},
+			},
+		},
+	})
+
+	if len(fakeSession.sentMessages) != 1 {
+		t.Fatalf("sent message count = %d, want %d", len(fakeSession.sentMessages), 1)
+	}
+
+	if fakeSession.sentMessages[0].Content != "Thinking..." {
+		t.Fatalf("initial content = %q, want %q", fakeSession.sentMessages[0].Content, "Thinking...")
+	}
+
+	if len(fakeSession.editedMessages) != 2 {
+		t.Fatalf("edited message count = %d, want %d", len(fakeSession.editedMessages), 2)
+	}
+
+	if got := stringPointerValue(fakeSession.editedMessages[0].Content); got != "Partial streamed response" {
+		t.Fatalf("first edit content = %q, want %q", got, "Partial streamed response")
+	}
+
+	if got := stringPointerValue(fakeSession.editedMessages[1].Content); got != "Final streamed response" {
+		t.Fatalf("second edit content = %q, want %q", got, "Final streamed response")
 	}
 }
 
@@ -1048,6 +1119,14 @@ func commandInteractionEvent(commandName string, userID string, action string, t
 	}
 }
 
+func stringPointerValue(value *string) string {
+	if value == nil {
+		return ""
+	}
+
+	return *value
+}
+
 type fakeSession struct {
 	selfUserID string
 
@@ -1062,6 +1141,8 @@ type fakeSession struct {
 	interactionHandlers []func(*discordgo.Session, *discordgo.InteractionCreate)
 
 	sentMessages         []*discordgo.MessageSend
+	editedMessages       []*discordgo.MessageEdit
+	deletedMessageIDs    []string
 	interactionResponses []*discordgo.InteractionResponse
 	interactionEdits     []*discordgo.WebhookEdit
 	followups            []*discordgo.WebhookParams
@@ -1110,7 +1191,27 @@ func (s *fakeSession) ChannelMessageSendComplex(
 	options ...discordgo.RequestOption,
 ) (*discordgo.Message, error) {
 	s.sentMessages = append(s.sentMessages, data)
-	return &discordgo.Message{ID: "sent-message", ChannelID: channelID}, nil
+	return &discordgo.Message{
+		ID:        "sent-message-" + strconv.Itoa(len(s.sentMessages)),
+		ChannelID: channelID,
+	}, nil
+}
+
+func (s *fakeSession) ChannelMessageEditComplex(
+	data *discordgo.MessageEdit,
+	options ...discordgo.RequestOption,
+) (*discordgo.Message, error) {
+	s.editedMessages = append(s.editedMessages, data)
+	return &discordgo.Message{ID: data.ID, ChannelID: data.Channel}, nil
+}
+
+func (s *fakeSession) ChannelMessageDelete(
+	channelID string,
+	messageID string,
+	options ...discordgo.RequestOption,
+) error {
+	s.deletedMessageIDs = append(s.deletedMessageIDs, messageID)
+	return nil
 }
 
 func (s *fakeSession) InteractionRespond(

--- a/internal/runtime/discord/session.go
+++ b/internal/runtime/discord/session.go
@@ -19,6 +19,15 @@ type session interface {
 		data *discordgo.MessageSend,
 		options ...discordgo.RequestOption,
 	) (*discordgo.Message, error)
+	ChannelMessageEditComplex(
+		data *discordgo.MessageEdit,
+		options ...discordgo.RequestOption,
+	) (*discordgo.Message, error)
+	ChannelMessageDelete(
+		channelID string,
+		messageID string,
+		options ...discordgo.RequestOption,
+	) error
 	InteractionRespond(
 		interaction *discordgo.Interaction,
 		resp *discordgo.InteractionResponse,


### PR DESCRIPTION
## Summary

- stream immediate Discord replies by forwarding Codex progress through the app/runtime boundary
- edit in-flight Discord replies in place instead of waiting for the final buffered response
- update runtime tests and active plan documentation for the new streaming behavior

## Background

Immediate turns previously waited for the final Codex response before Discord users saw any answer. This increased perceived latency even though the Codex integration already supported streamed events internally.

## Related issue(s)

- None

## Implementation details

- added `MessageProgressSink` to the app-facing turn contract and forwarded streamed Codex events through the gateway
- introduced a Discord live-message presenter that sends an initial reply and updates it through message edits as progress arrives
- kept queued turns on the existing acknowledgement plus deferred-reply path
- expanded tests for gateway progress delivery, message-service behavior, and Discord runtime edit flows
- updated architecture, product docs, README, and the active fake-runtime validation ExecPlan

## Test coverage

- `go test ./...`
- `make lint`

## Breaking changes

- None

## Notes

- immediate-turn progress delivery remains best-effort and does not fail the Codex turn if Discord edit delivery fails

Created by Codex
