### PR TITLE
docs: define shared daily clear generation design

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -221,16 +221,20 @@ Purpose:
 Logical key concept:
 
 ```text
-thread_key = local_date
+daily_bucket = local_date
+active_thread_key = local_date + "#" + generation
 ```
 
 Behavior:
 
-- incoming messages automatically resolve to today's bucket
-- if a thread exists for that key, resume it by passing the saved thread ID into the next turn
-- otherwise run the first turn without a saved thread ID and persist the returned thread ID
-- when the date changes, the logical bucket changes automatically and the next visible turn starts a fresh Codex thread for the new key
-- before that first visible new-day turn, 39claw resumes the previous daily thread once and runs a runtime-managed durable-memory refresh into `${CLAW_CODEX_WORKDIR}/AGENT_MEMORY/MEMORY.md` plus `${CLAW_CODEX_WORKDIR}/AGENT_MEMORY/YYYY-MM-DD.md`
+- incoming messages automatically resolve to today's daily bucket
+- each daily bucket has exactly one active shared generation at a time
+- if a thread exists for the active generation key, resume it by passing the saved thread ID into the next turn
+- otherwise run the first turn without a saved thread ID and persist the returned thread ID for that generation
+- `/<instance-command> action:clear` rotates the active shared same-day generation to a fresh logical thread key
+- when the date changes, the active generation resets to `#1` for the new bucket and the next visible turn starts a fresh Codex thread for that new key
+- before the first visible turn of a new generation, 39claw resumes the previous recorded daily generation once and runs a runtime-managed durable-memory refresh into `${CLAW_CODEX_WORKDIR}/AGENT_MEMORY/MEMORY.md` plus `${CLAW_CODEX_WORKDIR}/AGENT_MEMORY/YYYY-MM-DD.<generation>.md`
+- `action:clear` is rejected while the current active generation still has in-flight or queued work
 - Codex answers by following repository guidance and consulting the documentation in that repository
 
 Properties:
@@ -238,7 +242,8 @@ Properties:
 - no explicit thread command is required for normal usage
 - simple and low-friction
 - best for shared, conversation-oriented assistant flows
-- same-day continuity comes from the remote Codex thread
+- same-day continuity comes from the currently active shared generation
+- users can explicitly reset the shared same-day thread without waiting for the next day
 - cross-day durable memory can be projected into Markdown files inside the workdir without 39claw modifying user-owned `AGENTS.md`
 - whether normal visible turns consult those memory files is controlled by the user-owned instructions in the workdir
 
@@ -246,6 +251,7 @@ Tradeoffs:
 
 - long-running work still crosses a fresh remote-thread boundary at the start of a new day
 - unrelated same-day conversations may influence one another inside the shared daily context
+- `action:clear` rotates the shared daily context for the whole bot instance rather than for one user
 - timezone must be an explicit configuration concern
 - the durable-memory bridge requires a write-capable Codex sandbox because 39claw must update files inside `CLAW_CODEX_WORKDIR`
 

--- a/README.md
+++ b/README.md
@@ -120,7 +120,8 @@ go build -o ./bin/39claw ./cmd/39claw
 
 Use `daily` mode when you want a lightweight shared assistant for day-to-day work.
 
-- messages on the same local date share the same conversation context
+- messages route through one active shared generation per local date
+- `/<instance-command> action:clear` can rotate the current day's shared generation to a fresh thread when the current one is idle
 - the next local date starts a fresh Codex thread automatically
 - durable preferences and long-lived context can be projected into runtime-managed files under `AGENT_MEMORY/`
 - if you want visible turns to consult that memory, add the necessary guidance to your own `AGENTS.md`
@@ -134,7 +135,7 @@ If you want visible turns to consult the projected memory files, add guidance li
 If `AGENT_MEMORY/` exists in the current workspace, consult its durable memory files when they are relevant to the user's request.
 
 - Read `AGENT_MEMORY/MEMORY.md` as the primary durable memory file.
-- Read the most relevant dated note in `AGENT_MEMORY/YYYY-MM-DD.md` when bridge context is useful.
+- Read the most relevant dated note in `AGENT_MEMORY/YYYY-MM-DD.<generation>.md` when bridge context is useful.
 - Prefer the latest explicit user instruction when it conflicts with stored memory.
 - Treat `AGENT_MEMORY/` as durable context only. Do not treat it as a source of temporary TODO items or transient chat history.
 ```
@@ -167,6 +168,11 @@ For every instance:
 - `/<instance-command> action:help`
   - show the supported command surface for the current bot instance
 
+In `daily` mode, the same root command also supports:
+
+- `/<instance-command> action:clear`
+  - rotate the shared same-day daily session to a fresh generation when the current one is idle
+
 In `task` mode, the same root command also supports:
 
 - `/<instance-command> action:task-current`
@@ -179,8 +185,6 @@ In `task` mode, the same root command also supports:
   - switch the active task
 - `/<instance-command> action:task-close task_id:<id>`
   - close a task
-
-In `daily` mode, the root command exposes only `action:help`.
 
 ### Busy conversations
 

--- a/docs/design-docs/architecture-overview.md
+++ b/docs/design-docs/architecture-overview.md
@@ -22,7 +22,7 @@ Each bot instance is configured against a repository-shaped working directory, a
 This leads to two distinct mode families on the same foundation:
 
 - `daily`
-  - knowledge-oriented interaction against repository instructions and documentation, with fresh daily threads plus a runtime-managed durable-memory bridge under `AGENT_MEMORY/`
+  - knowledge-oriented interaction against repository instructions and documentation, with one active shared generation per local day plus a runtime-managed durable-memory bridge under `AGENT_MEMORY/`
 - `task`
   - execution-oriented interaction against a Git work repository where each task eventually runs inside its own task-specific worktree
 
@@ -52,7 +52,8 @@ Processes one user turn end to end by resolving the thread target, coordinating 
 
 ### Thread Policy
 
-Converts Discord context into a logical thread key according to the globally configured mode.
+Converts Discord context into a logical thread bucket according to the globally configured mode.
+In `daily` mode, the policy still resolves only the local date and the application layer expands that bucket into the active generation key.
 
 ### Thread Store
 
@@ -79,8 +80,8 @@ Adapts normalized application output into Discord-safe responses.
 3. Application service resolves the logical thread key and any frozen routing context needed for later queued execution
 4. Queue coordinator decides whether the turn runs immediately, waits in the same-key queue, or is rejected because five waiting turns already exist
 5. If the turn was queued, the runtime immediately posts a queued acknowledgment reply
-6. When the turn starts running, `daily` mode may first run a hidden preflight refresh against the previous daily thread to update `AGENT_MEMORY`
-7. Thread store checks whether a Codex thread already exists for the visible turn
+6. When the turn starts running, `daily` mode may first resolve or create the active same-day generation and then run a hidden preflight refresh against the previous recorded daily generation to update `AGENT_MEMORY`
+7. Thread store checks whether a Codex thread already exists for the visible generation key
 8. Application service sends the turn through the Codex gateway with the saved thread ID when one exists
 9. If no saved thread exists yet, the first turn creates one and returns its thread ID
 10. Application service persists the returned binding

--- a/docs/design-docs/implementation-spec.md
+++ b/docs/design-docs/implementation-spec.md
@@ -61,6 +61,8 @@ The following internal contracts should be treated as stable v1 design targets e
   - returns a normalized final response plus the thread ID that should be persisted
 - `TaskCommandService`
   - implements the `action:task-current`, `action:task-list`, `action:task-new`, `action:task-switch`, and `action:task-close` workflow behind the configured root command
+- `DailyCommandService`
+  - implements the `action:clear` workflow behind the configured root command when the bot instance runs in `daily` mode
 
 The application layer should depend on these responsibilities rather than on Discord SDK details or raw SQL.
 
@@ -68,9 +70,9 @@ The concrete v1 message path lives in the application layer rather than in the D
 The message service is responsible for:
 
 - ignoring unsupported non-mention chatter
-- resolving the logical thread key
+- resolving the logical thread bucket and any active daily generation metadata
 - rejecting overlapping turns for the same logical thread key
-- running the daily durable-memory preflight before the first visible turn of a new local day when the previous day's thread binding exists
+- running the daily durable-memory preflight before the first visible turn of a new daily generation when the previous generation's thread binding exists
 - loading and upserting SQLite thread bindings
 - calling the Codex gateway and returning a normalized reply payload
 
@@ -78,11 +80,14 @@ The message service is responsible for:
 
 SQLite is the required v1 storage backend.
 
-The storage model uses three tables:
+The storage model uses four tables:
 
 - `thread_bindings`
   - stores `mode`, `logical_thread_key`, `codex_thread_id`, nullable `task_id`, `created_at`, and `updated_at`
   - enforces one binding per `(mode, logical_thread_key)`
+- `daily_sessions`
+  - stores `local_date`, `generation`, `logical_thread_key`, nullable `previous_logical_thread_key`, `activation_reason`, `is_active`, `created_at`, and `updated_at`
+  - enforces one active row per `local_date`
 - `tasks`
   - stores `task_id`, `discord_user_id`, `task_name`, `status`, `branch_name`, nullable `base_ref`, nullable `worktree_path`, `worktree_status`, `created_at`, `updated_at`, nullable `closed_at`, nullable `worktree_created_at`, nullable `worktree_pruned_at`, and nullable `last_used_at`
   - uses ULID strings for `task_id`
@@ -98,11 +103,11 @@ Closing a task marks it `closed` and removes its `active_tasks` mapping when tha
 
 The logical thread key defaults are:
 
-- `daily`: configured local date formatted as `YYYY-MM-DD`
+- `daily`: configured local date formatted as `YYYY-MM-DD` for the outer bucket, with the active visible thread key normalized to `YYYY-MM-DD#<generation>`
 - `task`: `discord_user_id + task_id`
 
 When the bot runs in `daily` mode, 39claw also manages a durable memory projection inside `${CLAW_CODEX_WORKDIR}/AGENT_MEMORY`.
-`MEMORY.md` is the primary durable-memory file, and `YYYY-MM-DD.md` stores the bridge note created during the first-message preflight for a new local day.
+`MEMORY.md` is the primary durable-memory file, and `YYYY-MM-DD.<generation>.md` stores the bridge note created during the first-message preflight for a new daily generation.
 
 ## Discord Behavior Defaults
 
@@ -114,12 +119,14 @@ Each bot instance should expose one slash-command surface whose root name comes 
 That root command should always expose `action:help`.
 Task-control command responses are ephemeral by default.
 When a bot instance runs in `daily` mode, task actions must return a clear not-available response instead of pretending the command worked.
+When a bot instance runs in `daily` mode, the root command should also expose `action:clear`.
 When a bot instance runs in `task` mode, the root command should expose `action:task-current`, `action:task-list`, `action:task-new`, `action:task-switch`, and `action:task-close`.
 
 When a bot instance runs in `task` mode, normal messages without an active task must not be routed to Codex.
 They should return actionable guidance that points the user to `action:task-new`, `action:task-list`, or `action:task-switch` on the configured root command.
-When a bot instance runs in `daily` mode, the first visible turn of a new local day should still start a fresh Codex thread, but 39claw must first run a hidden durable-memory refresh against the previous day's thread when that previous binding exists.
+When a bot instance runs in `daily` mode, the first visible turn of a new daily generation should still start a fresh Codex thread, but 39claw must first run a hidden durable-memory refresh against the previous recorded generation's thread when that previous binding exists.
 If that preflight fails or times out, 39claw should log the failure and continue with the visible turn instead of blocking the user.
+If `action:clear` is invoked while the current active daily generation still has in-flight or queued work, 39claw should reject the clear request with an ephemeral retry-later response instead of rotating immediately.
 39claw must not create or modify user-owned instruction files such as `AGENTS.md`; if a deployment wants visible turns to consult `AGENT_MEMORY`, the deployment must express that through its own checked-in instructions.
 When a bot instance runs in `task` mode, `CLAW_CODEX_WORKDIR` must be a Git repository.
 `task-new` creates task metadata only; the first normal message for a pending or failed task creates the task worktree lazily from `main` or `master`.
@@ -207,7 +214,8 @@ The repository should treat validation as three layers:
 The initial implementation should demonstrate the following observable behavior.
 Most of these outcomes should be proven through automated contract coverage plus fake runtime tests, while the narrow live-platform remainder should be handled as optional hardening:
 
-- In `daily` mode, the first qualifying mention creates a thread binding, a second same-day mention reuses it, and the first mention on the next local date creates a new binding after the durable-memory preflight refreshes `AGENT_MEMORY` from the previous day's thread when that previous binding exists.
+- In `daily` mode, the first qualifying mention creates generation `#1`, a second same-day mention reuses the active generation, and the first mention on the next local date creates a fresh `#1` generation after the durable-memory preflight refreshes `AGENT_MEMORY` from the last active prior-day generation when that previous binding exists.
+- In `daily` mode, `/<instance-command> action:clear` rotates the shared same-day generation only when the current generation is idle, and the next mention creates or resumes a fresh same-day binding after the durable-memory preflight refreshes `AGENT_MEMORY` from the previous recorded generation when that previous binding exists.
 - In `daily` mode, startup does not create or rewrite `AGENTS.md`.
 - A mention-triggered message with text plus image attachments reaches Codex as multipart input.
 - A mention-triggered message with only one or more usable image attachments is accepted and answered.

--- a/docs/design-docs/state-and-storage.md
+++ b/docs/design-docs/state-and-storage.md
@@ -41,12 +41,31 @@ This state is required in `daily` mode.
 It lives inside the configured Codex workdir instead of SQLite:
 
 - `${CLAW_CODEX_WORKDIR}/AGENT_MEMORY/MEMORY.md`
-- `${CLAW_CODEX_WORKDIR}/AGENT_MEMORY/YYYY-MM-DD.md`
+- `${CLAW_CODEX_WORKDIR}/AGENT_MEMORY/YYYY-MM-DD.<generation>.md`
 
 `MEMORY.md` is the compact primary memory file that carries durable facts such as user preferences or long-lived workflow context across local-day boundaries.
-The dated file records what the new-day preflight promoted, updated, or rejected when it resumed the previous daily Codex thread.
+The dated generation-scoped file records what the preflight promoted, updated, or rejected when it resumed the previous daily Codex thread before the first visible turn of a fresh generation.
 
-### 3. Active Task State
+### 3. Daily Session State
+
+This state is only required for `daily` mode.
+
+It stores the active shared generation for each local date and the previous generation used as the durable-memory preflight source.
+
+Conceptually:
+
+```text
+local_date -> active_generation -> logical_thread_key
+```
+
+This metadata allows 39claw to:
+
+- keep one active shared same-day generation at a time
+- rotate to a fresh generation when `action:clear` is invoked
+- keep old same-day generations addressable for durable-memory preflight
+- avoid inferring the active daily session from `updated_at` or other implicit heuristics
+
+### 4. Active Task State
 
 This state is only required for `task` mode.
 
@@ -60,7 +79,7 @@ user -> active_task_id
 
 This allows ordinary messages to be routed without forcing the user to repeat the task identifier in every message.
 
-### 4. Task Worktree Metadata
+### 5. Task Worktree Metadata
 
 This state is only required for `task` mode.
 
@@ -92,10 +111,11 @@ Reasons:
 The current concept points toward:
 
 - `thread_bindings`
+- `daily_sessions`
 - `tasks`
 - `active_tasks`
 
-SQLite remains the source of truth for remote thread bindings and task metadata.
+SQLite remains the source of truth for remote thread bindings, daily-session metadata, and task metadata.
 The `AGENT_MEMORY` Markdown files are intentionally stored in the Codex workdir so Codex can read and update them directly during the daily memory-bridge preflight.
 
 The design should favor explicit structured columns over packing all data into a single opaque key string, unless implementation simplicity proves more valuable.

--- a/docs/design-docs/thread-modes.md
+++ b/docs/design-docs/thread-modes.md
@@ -13,29 +13,34 @@ The user should not need to manage thread state explicitly.
 
 ### Thread Key Concept
 
-The logical thread key is derived from:
+The daily routing bucket is derived from:
 
 - current local date
 
 Conceptually:
 
 ```text
-thread_key = local_date
+daily_bucket = local_date
+active_thread_key = local_date + "#" + generation
 ```
 
 ### Behavior
 
-- when a message arrives, 39claw computes the key automatically
-- if a Codex thread is already bound to that key, 39claw resumes it
-- if no binding exists, 39claw creates a new Codex thread
-- when the date changes, a new logical thread is used automatically
-- before the first visible turn for that new day, 39claw may resume the previous day's Codex thread once to refresh durable Markdown memory under `AGENT_MEMORY/`
-- the visible turn for the new day still starts a fresh Codex thread even when durable memory is carried forward
+- when a message arrives, 39claw computes the current local-date bucket automatically
+- each local-date bucket has exactly one active shared generation at a time
+- if a Codex thread is already bound to the active generation key, 39claw resumes it
+- if no binding exists for the active generation key, 39claw creates a new Codex thread
+- `/<instance-command> action:clear` rotates the active shared generation to a fresh same-day key such as `YYYY-MM-DD#2`
+- if the active shared generation still has in-flight or queued work, `action:clear` is rejected instead of interleaving old and new replies
+- when the date changes, a new bucket is used automatically and its first active generation starts at `#1`
+- before the first visible turn for a new generation, 39claw may resume the previous recorded daily generation once to refresh durable Markdown memory under `AGENT_MEMORY/`
+- the visible turn for a new generation still starts a fresh Codex thread even when durable memory is carried forward
 
 ### UX Properties
 
 - no explicit thread command is required for normal use
-- continuity exists within the same day
+- continuity exists within the currently active same-day generation
+- users can intentionally reset the shared same-day thread without waiting for midnight
 - the remote thread resets naturally across days
 - durable preferences or long-lived context can still carry forward through runtime-managed memory files
 
@@ -52,6 +57,7 @@ Costs:
 
 - long-running work may still be split across remote thread boundaries
 - unrelated same-day conversations may share context
+- resetting the shared same-day thread affects the whole bot instance, not just the user who issued `action:clear`
 - the definition of "day" depends on a configured timezone
 - the durable-memory bridge depends on a write-capable Codex sandbox and managed files inside the configured workdir
 

--- a/docs/exec-plans/active/12-daily-clear-generation.md
+++ b/docs/exec-plans/active/12-daily-clear-generation.md
@@ -1,0 +1,384 @@
+# Add shared daily generation rotation and `action:clear` to `daily` mode
+
+This ExecPlan is a living document. The sections `Progress`, `Surprises & Discoveries`, `Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work proceeds.
+
+This document must be maintained in accordance with `.agents/PLANS.md`.
+
+## Purpose / Big Picture
+
+After this plan, users of a `daily`-mode bot should be able to intentionally reset the current shared same-day conversation without waiting for the next local day. The bot should expose `/<instance-command> action:clear`, rotate the active shared same-day generation to a fresh Codex thread key, and run the durable-memory preflight on the first visible message of that new generation so durable preferences can carry forward through `AGENT_MEMORY/MEMORY.md` plus a generation-scoped bridge note such as `AGENT_MEMORY/2026-04-06.2.md`.
+
+This change matters because `daily` mode currently keeps one remote Codex thread for the whole local day. Long conversations can make that thread heavy, which weakens response quality and makes resets awkward. After this plan, the shared daily experience remains low-friction, but users also gain an explicit way to cut context growth and begin a fresh shared thread mid-day.
+
+## Progress
+
+- [x] (2026-04-06 00:00Z) Reviewed the current `daily` routing, daily-memory, command-surface, and SQLite design and captured the agreed direction for shared same-day generation rotation.
+- [x] (2026-04-06 00:00Z) Updated architecture, design, README, and product documents so the repository now describes `daily` mode as one active shared generation per day with `action:clear` and generation-scoped bridge notes.
+- [ ] Add explicit `daily_sessions` persistence and migrate legacy `daily` thread bindings from `YYYY-MM-DD` to `YYYY-MM-DD#1`.
+- [ ] Resolve the active `daily` generation through store-backed metadata before visible turns load or persist thread bindings.
+- [ ] Add `action:clear` to the `daily` command surface and route it through a dedicated app-level daily command service.
+- [ ] Extend queue coordination so `action:clear` can reject rotation while the current active generation is busy or queued.
+- [ ] Run the durable-memory preflight once per fresh generation and write `AGENT_MEMORY/YYYY-MM-DD.<generation>.md`.
+- [ ] Add tests for migration, same-day rotation, clear rejection while busy, same-day preflight after clear, and next-day carry-over from the last active prior-day generation.
+- [ ] Run `make test` and `make lint`, then update this plan with proof artifacts and any deferred follow-up work.
+
+## Surprises & Discoveries
+
+- Observation: The current `daily` thread policy still does the right outer-bucket job. It returns only the configured local date, so the smallest safe change is to keep that bucket and add explicit generation metadata on top of it.
+  Evidence: `internal/thread/policy.go`
+
+- Observation: The current daily-memory preflight assumes the logical thread key itself is a date and looks up only the previous calendar day. That assumption breaks as soon as one day can contain multiple fresh starts.
+  Evidence: `internal/dailymemory/service.go`
+
+- Observation: The Discord root command already centralizes discovery for both modes. Extending it with `action:clear` is cleaner than introducing a second standalone slash command.
+  Evidence: `internal/runtime/discord/commands.go`, `internal/runtime/discord/runtime.go`
+
+## Decision Log
+
+- Decision: Keep the `daily` thread policy focused on the local-date bucket and resolve the active shared generation later in the application layer.
+  Rationale: The current policy contract is already correct for “what day is this message in?” and changing it would enlarge the implementation blast radius. A second store-backed daily-session layer is the smallest coherent change.
+  Date/Author: 2026-04-06 / Codex
+
+- Decision: Use `/<instance-command> action:clear` instead of a standalone `/clear`.
+  Rationale: The repository already standardizes on one instance-specific root command. Reusing that surface keeps command discovery, help output, and runtime routing consistent.
+  Date/Author: 2026-04-06 / Codex
+
+- Decision: Model `daily` as one active shared generation per local date and persist that metadata explicitly.
+  Rationale: Inferring the current generation from `updated_at` or other implicit heuristics would be fragile and hard to test. Explicit state makes migration, rotation, and preflight sourcing deterministic.
+  Date/Author: 2026-04-06 / Codex
+
+- Decision: Reject `action:clear` while the current shared generation still has in-flight or queued work.
+  Rationale: Allowing rotation while old replies are still pending would create confusing post-clear replies from the old generation. A safe rejection is easier to explain and preserves reply ordering.
+  Date/Author: 2026-04-06 / Codex
+
+- Decision: Store bridge notes as `AGENT_MEMORY/YYYY-MM-DD.<generation>.md`.
+  Rationale: One date can now have multiple fresh starts, so the bridge note must identify which generation it belongs to while keeping `MEMORY.md` as the single durable summary file.
+  Date/Author: 2026-04-06 / Codex
+
+## Outcomes & Retrospective
+
+Implementation has not started yet. The intended outcome is a `daily` mode that still behaves like a shared day-based assistant but can intentionally rotate to a fresh same-day Codex thread when conversation length becomes a problem. This plan will be complete when the runtime can persist active daily generations, expose `action:clear`, reject clear while busy, refresh durable memory from the previous recorded generation, and prove the full behavior through automated tests.
+
+## Context and Orientation
+
+39claw is a thin Discord-to-Codex gateway. The current `daily` implementation uses a single logical thread key per configured local date. That flow is spread across these files:
+
+- `internal/thread/policy.go`
+  - resolves the `daily` bucket as `YYYY-MM-DD`
+- `internal/app/message_service_impl.go`
+  - prepares normal messages, runs the daily-memory preflight, loads or creates thread bindings, and sends the visible Codex turn
+- `internal/dailymemory/service.go`
+  - runs the hidden preflight refresh and currently assumes one thread per local day
+- `internal/store/sqlite/store.go`
+  - creates the SQLite schema and persists `thread_bindings`, `tasks`, and `active_tasks`
+- `internal/runtime/discord/commands.go`
+  - defines the slash-command choices and help output
+- `internal/runtime/discord/interaction_mapper.go`
+  - normalizes Discord slash-command inputs into command requests
+- `internal/runtime/discord/runtime.go`
+  - routes commands and normal messages into the application layer
+- `docs/product-specs/daily-mode-user-flow.md`
+  - explains the intended user-facing `daily` behavior
+
+For this plan, these terms are important:
+
+A “daily bucket” is the configured local date string such as `2026-04-06`. It is the outer grouping for `daily` mode.
+
+A “daily generation” is one concrete shared visible conversation within that bucket, identified by a logical thread key such as `2026-04-06#2`.
+
+The “active generation” is the only same-day generation that new normal messages should target.
+
+A “bridge note” is the generation-scoped Markdown file created or refreshed during preflight, for example `AGENT_MEMORY/2026-04-06.2.md`.
+
+A “legacy daily binding” is a pre-migration `thread_bindings` row whose logical thread key is only `YYYY-MM-DD`.
+
+The architecture must stay thin. `thread_bindings` remain the source of truth for actual Codex thread IDs. New daily-only metadata should describe which same-day generation is active and which previous generation should be used as the preflight source.
+
+## Starting State
+
+Start this plan only after confirming the repository still matches these assumptions:
+
+- `internal/thread/policy.go` still resolves `daily` as only the configured local date
+- `internal/app/message_service_impl.go` still runs the daily-memory preflight before visible thread-binding lookup
+- `internal/dailymemory/service.go` still expects a date-like logical key and writes `AGENT_MEMORY/YYYY-MM-DD.md`
+- `internal/runtime/discord/commands.go` still owns the root command choices and currently exposes `action:help` only for `daily` mode
+- `internal/store/sqlite/store.go` still creates `thread_bindings`, `tasks`, and `active_tasks`
+- `make test` and `make lint` pass before implementation work begins
+
+Verify that state with:
+
+    cd /home/filepang/playground/39claw
+    make test
+    make lint
+
+If the repository has drifted away from that shape, update this ExecPlan first so it remains self-contained and truthful.
+
+## Preconditions
+
+This plan fixes the following product and implementation choices:
+
+- `daily` mode remains shared for the whole bot instance, not per-user
+- `action:clear` rotates the shared same-day generation for the whole instance
+- the first generation for any new local date is always `#1`
+- each local date has at most one active generation at a time
+- `action:clear` must fail safely when the current generation still has in-flight or queued work
+- the first visible message of a fresh generation runs the hidden durable-memory preflight when a previous recorded generation exists
+- `MEMORY.md` remains the primary durable-memory file
+- bridge notes are generation-scoped and use `AGENT_MEMORY/YYYY-MM-DD.<generation>.md`
+
+## Milestone 1: Add explicit daily-session persistence and migration
+
+At the end of this milestone, SQLite should persist which same-day generation is active for each local date, and legacy `daily` thread bindings should be normalized from `YYYY-MM-DD` to `YYYY-MM-DD#1`.
+
+Add a new table in `internal/store/sqlite/store.go` named `daily_sessions` with these columns:
+
+- `local_date TEXT NOT NULL`
+- `generation INTEGER NOT NULL`
+- `logical_thread_key TEXT NOT NULL`
+- `previous_logical_thread_key TEXT NULL`
+- `activation_reason TEXT NOT NULL`
+- `is_active INTEGER NOT NULL DEFAULT 1`
+- `created_at TEXT NOT NULL`
+- `updated_at TEXT NOT NULL`
+
+Use `PRIMARY KEY (local_date, generation)` and `UNIQUE (logical_thread_key)`. Add a partial unique index so only one row per `local_date` may have `is_active = 1`.
+
+Extend the store API so the application layer can:
+
+- load the active daily generation for a local date
+- load the latest recorded generation before a local date
+- create generation `#1` when a date has not been seen before
+- rotate to the next same-day generation transactionally
+
+During schema initialization, add a migration that rewrites legacy `daily` thread-binding keys from `YYYY-MM-DD` to `YYYY-MM-DD#1` and backfills matching active `daily_sessions` rows. The migration must be idempotent.
+
+## Milestone 2: Resolve the active generation before visible turns
+
+At the end of this milestone, normal `daily` messages should target the active generation key such as `2026-04-06#2`, not the bare date bucket.
+
+Keep `internal/thread/policy.go` unchanged for `daily`. It should still return only the local-date bucket string.
+
+Introduce a small daily-session resolver in the application layer. It should accept the bucket date and do the following:
+
+- if an active generation exists for that date, return it
+- if no active generation exists, create generation `#1`
+- when creating generation `#1`, record the most recent active generation from an earlier day as `previous_logical_thread_key` if one exists
+
+Update `internal/app/message_service_impl.go` so the visible `daily` path resolves a generation before it calls the preflight or loads a thread binding. The actual `thread_bindings` key used for `daily` turns must always be the generation key such as `2026-04-06#2`.
+
+## Milestone 3: Add `action:clear` and reject it while busy
+
+At the end of this milestone, `daily` mode should expose `/<instance-command> action:clear`, and invoking it on an idle active generation should rotate the shared same-day session to the next generation.
+
+Add `action:clear` to:
+
+- `internal/runtime/discord/interaction_mapper.go`
+- `internal/runtime/discord/commands.go`
+- `internal/runtime/discord/runtime.go`
+
+Do not route this through the task command service. Add a dedicated app-level daily command service, for example `DailyCommandService`, with one method equivalent to:
+
+    Clear(ctx context.Context, userID string, receivedAt time.Time) (MessageResponse, error)
+
+That service must:
+
+- resolve today's active generation
+- inspect the queue state for that logical key
+- reject the clear with an ephemeral retry-later response if the current generation has in-flight or queued work
+- otherwise rotate to the next same-day generation and confirm success
+
+To support this safety check, extend the queue coordinator interface with a lightweight status or snapshot method that reports whether a key is in flight and how many items are queued.
+
+## Milestone 4: Run durable-memory preflight per generation
+
+At the end of this milestone, the first visible message of any fresh generation should run the hidden durable-memory refresh from the immediately previous recorded generation rather than only from the previous calendar day.
+
+Change the daily-memory refresher contract so it receives resolved generation metadata rather than just a date-like logical key. Then update `internal/dailymemory/service.go` to:
+
+- skip preflight if the current generation already has a thread binding
+- skip preflight if `previous_logical_thread_key` is empty
+- otherwise load the previous generation's thread binding directly by that key
+- create or preserve `AGENT_MEMORY/MEMORY.md`
+- create or preserve `AGENT_MEMORY/YYYY-MM-DD.<generation>.md`
+- run the hidden Codex turn against the previous generation's thread ID
+
+Keep the preflight idempotence rule simple: once the fresh generation has a visible thread binding, that generation's first-turn preflight has already happened or was intentionally skipped.
+
+## Milestone 5: Update tests and validate the full behavior
+
+At the end of this milestone, the repository should prove the new `daily` behavior through automated tests and aligned documentation.
+
+Add or update tests in these areas:
+
+- `internal/store/sqlite/store_test.go`
+  - legacy daily-key migration to `#1`
+  - one active generation per date
+  - same-day rotation to `#2`
+  - prior-generation lookup
+- `internal/app/message_service_test.go`
+  - first same-day message creates generation `#1`
+  - follow-up same-day message reuses the active generation
+  - first visible message after clear targets a fresh generation
+  - same-day preflight after clear uses the immediately previous generation
+  - first message on a new day uses generation `#1` and preflights from the last active prior-day generation
+- `internal/dailymemory/service_test.go`
+  - generation-scoped bridge note paths
+  - previous-generation sourcing
+  - existing-thread-binding short-circuit
+- `internal/runtime/discord/runtime_test.go`
+  - `daily` help includes `action:clear`
+  - `action:clear` succeeds when idle
+  - `action:clear` is rejected ephemerally when the current generation is busy or queued
+- queue tests under `internal/thread`
+  - queue snapshot behavior used by clear safety checks
+
+Finish by running `make test` and `make lint`, then update this plan's `Progress`, `Surprises & Discoveries`, and `Outcomes & Retrospective` sections with the actual results.
+
+## Plan of Work
+
+Begin in `internal/store/sqlite/store.go`. Add the `daily_sessions` table, active-generation uniqueness, and the legacy `daily` key migration. Extend the app-facing store contract with focused daily-session methods rather than overloading task methods.
+
+Next, introduce a small app-level daily-session resolver and use it from `internal/app/message_service_impl.go` before the visible turn loads a thread binding or calls the daily-memory refresher. The visible `daily` path should always operate on the generation key, not on the raw bucket string.
+
+Then extend the root command surface with `action:clear` and add a dedicated daily command service. Wire that service through `cmd/39claw/main.go` and `internal/runtime/discord/runtime.go`. Extend the queue coordinator with a snapshot method so the clear path can fail safely while the current generation is busy.
+
+After that, change the daily-memory preflight to operate per generation and to write generation-scoped bridge notes. Make sure same-day clear uses the immediately previous generation as the durable-memory source and that the next local day uses the last active generation from the previous day.
+
+Finally, update tests and rerun the full checks. This plan is not complete until the repository docs, behavior, and automated proofs all agree.
+
+## Concrete Steps
+
+Run all commands from `/home/filepang/playground/39claw`.
+
+1. Confirm the starting state and baseline health.
+
+    make test
+    make lint
+
+2. Implement the store and migration changes, then run focused store tests.
+
+    go test ./internal/store/sqlite -run 'TestStore' -v
+
+3. Implement daily-generation resolution and generation-scoped preflight, then run the focused app and memory tests.
+
+    go test ./internal/app ./internal/dailymemory -run 'TestMessageService|TestRefresher' -v
+
+4. Implement `action:clear` and the busy-clear rejection path, then run the runtime and queue tests.
+
+    go test ./internal/runtime/discord ./internal/thread -run 'TestRuntime|TestQueue' -v
+
+5. Run the full repository checks.
+
+    make test
+    make lint
+
+6. Record concise proof artifacts in this plan before marking it complete.
+
+## Validation and Acceptance
+
+This plan is complete when all of the following are true:
+
+- SQLite persists explicit same-day `daily` generation state
+- legacy `daily` thread-binding keys are migrated from `YYYY-MM-DD` to `YYYY-MM-DD#1`
+- each local date has at most one active generation
+- the first same-day message for a fresh date uses generation `#1`
+- same-day follow-up messages reuse the active generation
+- `/<instance-command> action:clear` exists in `daily` mode
+- `action:clear` rotates the shared same-day generation only when the current generation is idle
+- `action:clear` is rejected ephemerally when the current generation has in-flight or queued work
+- the first visible message after clear starts or resumes a fresh same-day generation key and runs preflight from the immediately previous generation when that generation has a binding
+- the first visible message on a new local day starts generation `#1` and uses the last active prior-day generation as the preflight source
+- bridge notes are written to `AGENT_MEMORY/YYYY-MM-DD.<generation>.md`
+- `MEMORY.md` remains the primary durable-memory file
+- `make test` passes
+- `make lint` passes
+
+The most important human-readable proof scenario is:
+
+1. Mention the bot on `2026-04-06` and create visible generation `2026-04-06#1`.
+2. Invoke `/<instance-command> action:clear`.
+3. Mention the bot again on `2026-04-06`.
+4. Observe that the visible turn uses a fresh thread binding for `2026-04-06#2`.
+5. Observe that the hidden preflight ran against the `2026-04-06#1` thread and wrote `AGENT_MEMORY/2026-04-06.2.md`.
+
+The most important safety proof is:
+
+1. Start one visible turn for the current active generation.
+2. Queue a second visible turn for that same generation.
+3. Invoke `action:clear`.
+4. Observe an ephemeral rejection that tells the user the current shared generation is still busy.
+5. Observe that the active generation does not rotate until the prior work has drained.
+
+## Idempotence and Recovery
+
+The schema migration must be safe to run more than once. Only legacy daily keys without `#` should be rewritten, and daily-session backfill should use conflict-safe inserts.
+
+If implementation is interrupted after the migration but before the application and runtime code are updated, do not ship that partial state. Finish the app-layer and runtime work in the same branch so the migrated data shape and the running code agree.
+
+If the busy-clear rejection path becomes unexpectedly invasive, update this plan before weakening the contract. Do not silently ship a version that allows `action:clear` to interleave with old queued replies.
+
+## Artifacts and Notes
+
+Useful key transitions to keep visible in tests:
+
+    2026-04-06 first visible message -> active generation 2026-04-06#1
+    2026-04-06 action:clear -> active generation 2026-04-06#2
+    2026-04-06 next visible message -> preflight from 2026-04-06#1, visible binding persisted for 2026-04-06#2
+    2026-04-07 first visible message -> active generation 2026-04-07#1, preflight from the last active 2026-04-06 generation
+
+Useful bridge note paths:
+
+    AGENT_MEMORY/2026-04-06.1.md
+    AGENT_MEMORY/2026-04-06.2.md
+    AGENT_MEMORY/2026-04-07.1.md
+
+Suggested success response for `action:clear`:
+
+    Started a fresh shared daily session for today. Your next mention will use a new thread.
+
+Suggested rejection response for `action:clear` while busy:
+
+    The current shared daily session is still busy. Please wait for queued work to finish, then retry `action:clear`.
+
+## Interfaces and Dependencies
+
+Add a new daily-session type in `internal/app`:
+
+    type DailySession struct {
+        LocalDate                string
+        Generation               int
+        LogicalThreadKey         string
+        PreviousLogicalThreadKey string
+        ActivationReason         string
+        IsActive                 bool
+        CreatedAt                time.Time
+        UpdatedAt                time.Time
+    }
+
+Extend the app-facing store contract with daily-session methods equivalent to:
+
+    GetActiveDailySession(ctx context.Context, localDate string) (DailySession, bool, error)
+    GetLatestDailySessionBefore(ctx context.Context, localDate string) (DailySession, bool, error)
+    CreateDailySession(ctx context.Context, session DailySession) error
+    RotateDailySession(ctx context.Context, localDate string, next DailySession) error
+
+Extend the queue coordinator with a lightweight status shape:
+
+    type QueueSnapshot struct {
+        InFlight bool
+        Queued   int
+    }
+
+    Snapshot(key string) QueueSnapshot
+
+Change the daily-memory refresher boundary to accept the resolved generation metadata instead of a bare date-like logical key.
+
+Add an app-level daily command service interface shaped like:
+
+    type DailyCommandService interface {
+        Clear(ctx context.Context, userID string, receivedAt time.Time) (MessageResponse, error)
+    }
+
+Keep the Discord runtime thin. It should normalize command input, call the correct application service, and present the response. All same-day generation and busy-clear business rules belong in the application and store layers.
+
+Revision Note: 2026-04-06 / Codex - Created this active ExecPlan after agreeing that `daily` clear rotates the whole shared bot-instance conversation, not per-user state, and that busy same-day generations must reject clear requests instead of rotating immediately.

--- a/docs/exec-plans/index.md
+++ b/docs/exec-plans/index.md
@@ -26,6 +26,7 @@ Plans in this directory should be written and maintained in line with `.agents/P
 These plans are intended to be executed in numeric order. Each plan is self-contained, but later plans name the repository state they expect to find and explain how to recover if that state is missing.
 
 - [Build fake runtime validation infrastructure for adapter-level tests](./active/11-fake-runtime-validation.md)
+- [Add shared daily generation rotation and `action:clear` to `daily` mode](./active/12-daily-clear-generation.md)
 
 ## Recently Completed Plans
 

--- a/docs/product-specs/daily-mode-user-flow.md
+++ b/docs/product-specs/daily-mode-user-flow.md
@@ -18,6 +18,7 @@ At a product level, this mode should feel like talking to a living knowledge bas
 In `daily` mode, the bot should feel like:
 
 - a shared conversation that continues during the current day
+- a tool that can intentionally start a fresh shared same-day thread when users need to cut down context growth
 - a fresh remote thread on a new day without losing durable preferences or other long-lived context
 - a tool that does not require explicit setup for normal use
 
@@ -31,12 +32,18 @@ The user should be able to send a message without first creating a task, selecti
 
 Messages handled on the same local date should feel like they continue the same line of work unless the product explicitly says otherwise.
 
-### 3. Day boundaries should reset the thread cleanly without discarding durable memory
+### 3. Same-day resets should be explicit and shared
+
+If a user invokes `/<instance-command> action:clear`, the bot should start a fresh shared same-day generation for the whole bot instance.
+That reset should apply to the shared daily context, not only to the user who issued the command.
+If the current shared generation is still busy, the bot should reject the clear request and ask the user to retry after the queued work finishes.
+
+### 4. Day boundaries should reset the thread cleanly without discarding durable memory
 
 When the relevant local date changes, the user should experience a fresh conversation thread.
 That reset should feel predictable rather than surprising, while durable facts that matter on future days may still carry forward through the runtime-managed memory bridge.
 
-### 4. The bot should avoid over-explaining thread mechanics
+### 5. The bot should avoid over-explaining thread mechanics
 
 The user does not need internal detail about logical keys or Codex thread IDs during normal operation.
 
@@ -49,8 +56,9 @@ Expected flow:
 1. The user sends a normal message in a supported channel.
 2. 39claw determines that the message should be handled.
 3. 39claw resolves the current daily thread bucket.
-4. If no thread exists for that bucket, 39claw creates a new one automatically.
-5. The user receives a normal response.
+4. If no active generation exists for that bucket yet, 39claw creates generation `#1` automatically.
+5. If no thread exists for that active generation, 39claw creates a new one automatically.
+6. The user receives a normal response.
 
 Expected user perception:
 
@@ -62,7 +70,7 @@ Expected user perception:
 Expected flow:
 
 1. The user sends another message on the same local date.
-2. 39claw routes the message to the already bound daily thread.
+2. 39claw routes the message to the current active same-day generation.
 3. The response reflects same-day continuity.
 
 Expected user perception:
@@ -75,7 +83,7 @@ Expected user perception:
 Expected flow:
 
 1. The user sends a message for the current daily conversation while an earlier same-day turn is still executing.
-2. 39claw accepts the later message into the per-day waiting queue if capacity remains.
+2. 39claw accepts the later message into the active-generation waiting queue if capacity remains.
 3. The bot immediately posts a short queued acknowledgment as a reply to the later message.
 4. After the earlier turn completes, 39claw executes the queued message in the same daily thread.
 5. The user receives the real answer later as a reply to the queued message.
@@ -85,16 +93,32 @@ Expected user perception:
 - “The bot accepted my message instead of making me retry manually.”
 - “The later answer still belongs to the message I actually sent.”
 
+### Scenario: A user intentionally clears today's shared context
+
+Expected flow:
+
+1. A user invokes `/<instance-command> action:clear`.
+2. 39claw checks whether the current active daily generation is idle.
+3. If the generation is idle, 39claw rotates the shared same-day session to the next generation and confirms the reset.
+4. The next normal message on the same local date targets that fresh generation.
+5. Before the first visible reply on the new generation, 39claw may run a hidden memory-refresh preflight against the previous generation and update `AGENT_MEMORY/MEMORY.md` plus `AGENT_MEMORY/YYYY-MM-DD.<generation>.md`.
+
+Expected user perception:
+
+- “We intentionally started fresh for today.”
+- “The next message uses a new thread without losing durable memory.”
+
 ### Scenario: First message on a new day
 
 Expected flow:
 
 1. The user sends a message after the local date has changed.
 2. 39claw resolves a new daily bucket automatically.
-3. If no thread exists for the new bucket and a previous-day daily thread exists, 39claw first runs a hidden memory-refresh preflight against that previous thread.
-4. The preflight updates `AGENT_MEMORY/MEMORY.md` plus today's `AGENT_MEMORY/YYYY-MM-DD.md` note.
-5. 39claw creates the new day's visible Codex thread.
-6. The response begins from a fresh thread and may reflect durable remembered preferences or long-lived context when the deployment's own instructions tell Codex to consult the projected memory files.
+3. If no active generation exists for the new bucket yet, 39claw creates generation `#1` automatically.
+4. If no thread exists for the new generation and a previous recorded daily generation exists, 39claw first runs a hidden memory-refresh preflight against that previous thread.
+5. The preflight updates `AGENT_MEMORY/MEMORY.md` plus today's `AGENT_MEMORY/YYYY-MM-DD.<generation>.md` note.
+6. 39claw creates the new day's visible Codex thread.
+7. The response begins from a fresh thread and may reflect durable remembered preferences or long-lived context when the deployment's own instructions tell Codex to consult the projected memory files.
 
 Expected user perception:
 
@@ -111,7 +135,7 @@ The user should not have to manually select a thread for normal use in `daily` m
 
 Continuity should be preserved:
 
-- on the same configured local date
+- within the active generation on the same configured local date
 
 Across different days, same-thread continuity should not be assumed, but durable memory may still be projected forward through the runtime-managed Markdown bridge.
 Whether that projected memory affects normal visible turns depends on the deployment's own instructions rather than on 39claw rewriting user-owned instruction files.
@@ -123,7 +147,7 @@ The bot should behave as if continuity is normal, not as if the user is performi
 
 ### Reset clarity
 
-If a date-boundary reset causes confusion, the product may need a lightweight explanation, but this should not be the default for every first message of the day.
+If a date-boundary reset or explicit `action:clear` reset causes confusion, the product may need a lightweight explanation, but this should not be the default for every fresh generation.
 
 ## Failure and Edge Cases
 
@@ -136,6 +160,7 @@ If the bot cannot resolve or create the required thread, it should:
 - tell the user whether retrying is likely to help
 
 If the hidden new-day memory refresh fails, the bot should still continue with the visible reply instead of failing the whole user request.
+If `action:clear` is requested while the active generation is still busy or has queued work, the bot should reject the clear request and tell the user to retry later.
 
 ### Timezone confusion
 
@@ -163,6 +188,7 @@ If multiple same-day requests stack up while one turn is already running, up to 
 ## Decisions
 
 - The bot should not proactively mention that a new day created a fresh context.
+- The bot may expose `/<instance-command> action:clear` so users can intentionally rotate the shared same-day generation.
 - There should not be an explicit command for inspecting the current daily context in v1.
 - The configured timezone should not be surfaced proactively to end users in normal daily-mode flow.
 - The bot should not provide lightweight guidance when channel changes preserve continuity.

--- a/docs/product-specs/discord-command-behavior.md
+++ b/docs/product-specs/discord-command-behavior.md
@@ -108,7 +108,7 @@ This means:
 
 - every bot instance should expose exactly one slash-command search result
 - bot instances configured for `task` mode should expose task actions through that root command
-- bot instances configured for `daily` mode should expose only `help` through that root command
+- bot instances configured for `daily` mode should expose `help` plus `clear` through that root command
 - users should not need to guess between natural-language task control and slash-command task control
 
 ### Minimum command capabilities
@@ -130,6 +130,11 @@ Every instance should also support:
 
 - `/<instance-command> action:help`
   - show the commands available for that bot instance
+
+Instances running in `daily` mode should also support:
+
+- `/<instance-command> action:clear`
+  - rotate the shared same-day daily session to a fresh generation when the current one is idle
 
 ### Expected command properties
 
@@ -159,6 +164,9 @@ For `action:task-new`, the success response should set the expectation that the 
 For `action:task-close`, the success response does not need to describe background worktree pruning in detail, but the product behavior should remain consistent with the task retention policy.
 
 When `action:help` succeeds, the response should give a concise list of supported actions and a short explanation of when to use them.
+
+When `action:clear` succeeds in `daily` mode, the response should tell the user that the next mention will use a fresh shared same-day thread.
+When `action:clear` is rejected because the current shared generation is busy or queued, the response should explain that the user needs to retry after the current work finishes.
 
 ### Failure behavior
 
@@ -236,6 +244,7 @@ The product should make it easy for users to discover supported command behavior
 Possible mechanisms include:
 
 - an instance-specific root command with `action:help`
+- a `daily`-mode `action:clear` response that confirms the next mention will start fresh
 - task-mode guidance that points users toward task actions when task context is missing
 - short affordance text after successful state-changing commands
 
@@ -257,5 +266,6 @@ This command behavior layer is not intended to:
 - v1 normal-message triggering should be mention-only.
 - each bot instance should register exactly one slash command whose name identifies that instance in Discord search.
 - `action:help` should stay structurally simple in v1, but it should only describe commands that are actually available in the current bot instance.
+- `daily` mode may expose `action:clear` on that same root command so users can intentionally rotate the shared same-day generation.
 - Unsupported invocation patterns should be ignored rather than acknowledged with lightweight feedback.
 - In `task` mode, the configured workdir is a Git repository source for task worktrees rather than only one shared execution directory.


### PR DESCRIPTION
## Summary

- document the shared daily generation model for `daily` mode
- define the `action:clear` command and busy-state rejection behavior
- add an active ExecPlan for the implementation work

## Background

`daily` mode currently assumes one shared remote thread per local day. This documentation update captures the agreed design for rotating the shared same-day conversation into a fresh generation when the active thread grows too large, while preserving durable memory behavior.

## Related issue(s)

- None.

## Implementation details

- update architecture, design, product, and README documents to describe one active shared generation per local date
- document `action:clear` on the instance-specific root command and specify that it is rejected while the current generation is busy or queued
- document generation-scoped bridge notes under `AGENT_MEMORY/YYYY-MM-DD.<generation>.md`
- add `docs/exec-plans/active/12-daily-clear-generation.md` and index it from the ExecPlan directory

## Test coverage

- run `make test`
- run `make lint`

## Breaking changes

- None. This PR updates documentation and planning only.

## Notes

- The implementation work itself is intentionally deferred to the new active ExecPlan.

Created by Codex