### PR TITLE
Prefer remote default branches for task worktrees

### DIFF
--- a/docs/design-docs/implementation-spec.md
+++ b/docs/design-docs/implementation-spec.md
@@ -131,7 +131,8 @@ If that preflight fails or times out, 39claw should log the failure and continue
 If `action:clear` is invoked while the current active daily generation still has in-flight or queued work, 39claw should reject the clear request with an ephemeral retry-later response instead of rotating immediately.
 39claw must not create or modify user-owned instruction files such as `AGENTS.md`; if a deployment wants visible turns to consult `AGENT_MEMORY`, the deployment must express that through its own checked-in instructions.
 When a bot instance runs in `task` mode, `CLAW_CODEX_WORKDIR` must be a Git repository.
-`task-new` creates task metadata only; the first normal message for a pending or failed task creates the task worktree lazily from `main` or `master`.
+`task-new` creates task metadata only; the first normal message for a pending or failed task creates the task worktree lazily from the remote default branch when possible by trying `origin/HEAD`, then `origin/main`, then `origin/master`, and only then falling back to local `main` or `master`.
+If the source repository has an `origin` remote, 39claw should try `git fetch origin --prune` before detecting that base ref, but a fetch failure should not block task execution by itself.
 Once the task worktree is ready, Codex runs with the task-specific `worktree_path` as the effective working directory for that turn.
 Closed tasks keep their task branches, but only the fifteen most recently closed ready tasks keep their worktrees; older closed ready worktrees are force-pruned.
 

--- a/docs/design-docs/task-mode-worktrees.md
+++ b/docs/design-docs/task-mode-worktrees.md
@@ -25,7 +25,9 @@ This turns `task` mode into an execution-oriented workflow instead of a long-liv
 - Each task owns one task-specific branch name.
 - Each task may also own one task-specific Git worktree created from that source repository.
 - Worktrees are created lazily on the first normal message that needs to run Codex for the task.
-- The base ref for worktree creation is detected automatically by checking `main` first and `master` second.
+- The base ref for worktree creation is detected automatically by preferring the remote default branch state.
+- When the source repository has an `origin` remote, worktree preparation should try `git fetch origin --prune` as a best-effort refresh before resolving the base ref.
+- Base-ref resolution should prefer `origin/HEAD`, then `origin/main`, then `origin/master`, and only then fall back to local `main` or `master`.
 - Closing a task does not delete its branch.
 - Closed-task worktrees are treated as disposable cache-like workspaces.
 - The system keeps the most recent fifteen closed-task worktrees and prunes older closed-task worktrees with forced removal.
@@ -86,11 +88,12 @@ The first normal message sent to an active task with `worktree_status=pending` o
 The preparation flow is:
 
 1. load the active task record
-2. detect the base ref by checking for `main`, then `master`, in the source repository
-3. create the task worktree under `${CLAW_DATADIR}/worktrees/<task_id>`
-4. create or attach the reserved task branch for that worktree
-5. persist `base_ref`, `worktree_path`, `worktree_created_at`, and `worktree_status=ready`
-6. run Codex with the task-specific worktree path as the working directory
+2. refresh `origin` metadata with a best-effort `git fetch origin --prune` when the source repository has an `origin` remote
+3. detect the base ref by preferring `origin/HEAD`, then `origin/main`, then `origin/master`, and only then falling back to local `main` or `master`
+4. create the task worktree under `${CLAW_DATADIR}/worktrees/<task_id>`
+5. create or attach the reserved task branch for that worktree
+6. persist `base_ref`, `worktree_path`, `worktree_created_at`, and `worktree_status=ready`
+7. run Codex with the task-specific worktree path as the working directory
 
 If any step fails, Codex must not run for that turn.
 
@@ -139,6 +142,8 @@ Lazy worktree creation failure is handled at normal-message time:
 - the task remains `open`
 - the task moves to `worktree_status=failed`
 - the next normal message retries worktree preparation automatically
+
+If the best-effort `git fetch origin --prune` step fails, the system should log the refresh failure but still continue base-ref detection using any already-available remote-tracking refs and then the local fallback branches.
 
 Pruning failure must not reopen or invalidate the closed task.
 If pruning fails, the system should keep the task in `closed + ready`, log the failure, and try again during a later cleanup opportunity.

--- a/docs/exec-plans/active/14-task-worktree-remote-base.md
+++ b/docs/exec-plans/active/14-task-worktree-remote-base.md
@@ -1,0 +1,175 @@
+# Prefer the remote default branch when creating `task` worktrees
+
+This ExecPlan is a living document. The sections `Progress`, `Surprises & Discoveries`, `Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work proceeds.
+
+This document must be maintained in accordance with `.agents/PLANS.md`.
+
+## Purpose / Big Picture
+
+After this plan, a newly prepared `task` worktree should start from the shared remote default branch state instead of inheriting whatever commits happen to exist on the local source checkout. That means two tasks created around the same time should branch from the same remote baseline even if the operator's local `main` or `master` already contains unpublished commits.
+
+The user-visible proof is concrete. In `task` mode, if the source repository has a local-only commit on `master` but `origin/master` points to an older shared commit, the first normal message for a new task should create a worktree whose `base_ref` points at the remote-tracking branch and whose checked-out history excludes the local-only commit. If remote metadata is stale, the bot should attempt `git fetch origin --prune` before detecting the base ref. If the fetch fails, the bot should still fall back safely to the best available local default branch instead of blocking task execution.
+
+## Progress
+
+- [x] (2026-04-06 08:06Z) Reviewed the current task worktree design, implementation, and repository workflow requirements, and confirmed that base-ref detection is still local-branch-only.
+- [x] (2026-04-05 21:21Z) Added remote-aware base-ref resolution to the task workspace manager, including a best-effort `git fetch origin --prune` before detection when `origin` exists.
+- [x] (2026-04-05 21:21Z) Added focused tests proving that remote-tracking refs are preferred over local default branches and that task worktree creation still falls back to local `master` when `origin` refresh fails.
+- [x] (2026-04-05 21:21Z) Updated task-mode design and product documentation so the remote-first base-ref behavior is now described consistently.
+- [x] (2026-04-05 21:21Z) Ran `make test` and `make lint` after the implementation landed.
+- [ ] Archive this completed plan from `active/` to `completed/`, update `docs/exec-plans/index.md`, and carry any intentionally deferred follow-up into `docs/exec-plans/tech-debt-tracker.md` if needed.
+
+## Surprises & Discoveries
+
+- Observation: The current implementation stores `base_ref` on the task record, so once the first successful worktree creation chooses a branch reference, later turns will keep reusing that original decision.
+  Evidence: `internal/app/task_workspace.go`
+
+- Observation: The current design documentation promises automatic detection of `main` or `master`, but it does not yet distinguish between local branches and remote-tracking branches.
+  Evidence: `docs/design-docs/task-mode-worktrees.md` and `docs/design-docs/implementation-spec.md`
+
+- Observation: This repository itself does not currently expose `refs/remotes/origin/HEAD`, so the production-friendly detection order must keep explicit fallbacks to `origin/main` and `origin/master`.
+  Evidence: `git symbolic-ref --short refs/remotes/origin/HEAD` exits with `fatal: ref refs/remotes/origin/HEAD is not a symbolic ref` in `/home/filepang/playground/39claw`
+
+- Observation: Real Git integration tests can reproduce the correctness goal by creating a local-only commit after pushing the shared baseline to a bare remote, then asserting that the task worktree still resolves to the remote-tracking commit.
+  Evidence: `internal/app/task_workspace_test.go`
+
+## Decision Log
+
+- Decision: Prefer remote-tracking default-branch references for new task worktrees, but keep a local-branch fallback path.
+  Rationale: The feature exists to reduce accidental divergence between concurrent tasks, but task execution should remain resilient when `origin` metadata is missing or temporarily unreachable.
+  Date/Author: 2026-04-06 / Codex
+
+- Decision: Treat `git fetch origin --prune` as best effort rather than a hard precondition.
+  Rationale: A hard fetch requirement would turn transient network or credential issues into avoidable task-mode outages. A best-effort refresh still improves correctness without sacrificing availability.
+  Date/Author: 2026-04-06 / Codex
+
+## Outcomes & Retrospective
+
+Implementation is complete and validated locally. The task workspace manager now refreshes `origin` on a best-effort basis, prefers the remote default branch state for first-time worktree creation, and still falls back safely to local `main` or `master` when the remote cannot be used. The remaining work is repository workflow only: archive this finished plan, open the pull request, confirm CI, and merge.
+
+## Context and Orientation
+
+39claw is a Go-based Discord bot that routes messages into Codex threads. In `task` mode, each task can own an isolated Git worktree created lazily from a shared source repository configured by `CLAW_CODEX_WORKDIR`. The task workspace lifecycle lives in `internal/app/task_workspace.go`. The function `EnsureReady` prepares the worktree on the first normal message, and the helper `detectBaseRef` currently checks only local `main` and `master` branches.
+
+The relevant files for this plan are:
+
+- `internal/app/task_workspace.go`
+  - task worktree creation, base-ref detection, and pruning logic
+- `internal/app/task_workspace_test.go`
+  - integration-style tests that create temporary Git repositories and exercise real worktree behavior
+- `docs/design-docs/task-mode-worktrees.md`
+  - the design note that defines task worktree lifecycle rules
+- `docs/design-docs/implementation-spec.md`
+  - the implementation-facing summary of task-mode behavior
+- `docs/product-specs/task-mode-user-flow.md`
+  - the user-facing task-mode workflow expectations
+- `docs/exec-plans/index.md`
+  - the active/completed plan index that must reflect this work while it is in progress and after it is archived
+
+Terms used in this plan:
+
+- remote-tracking branch: the local Git reference that mirrors a branch on the remote repository, such as `origin/master`
+- remote default branch: the branch that should represent the shared team baseline for new worktrees; in this repository it may be discoverable via `origin/HEAD`, `origin/main`, or `origin/master`
+- local fallback: the existing behavior of using local `main` or `master` when the remote default branch cannot be resolved
+
+## Plan of Work
+
+Start in `internal/app/task_workspace.go`. Add a best-effort remote refresh step that runs `git fetch origin --prune` before base-ref resolution for a task that does not yet have `BaseRef` stored. Keep failures non-fatal, but log them so operators can diagnose stale remote metadata. Then replace the current local-only `detectBaseRef` helper with remote-aware detection that tries `origin/HEAD`, then `origin/main`, then `origin/master`, and only afterward falls back to local `main` and `master`.
+
+Keep the data model stable. `Task.BaseRef` should continue storing the chosen ref string so later turns and reopen flows remain deterministic. The worktree creation command should still use the resolved ref exactly once when the task branch does not exist yet.
+
+Next, extend `internal/app/task_workspace_test.go` with real Git scenarios. One test should create a bare remote plus a cloned source repository, add a local-only commit on `master`, and prove that a newly created task worktree uses the remote-tracking branch instead of inheriting the unpublished commit. Another test should cover the safe fallback case where the source repository has no usable remote default branch but still has a valid local default branch.
+
+Finally, update the task worktree design and implementation docs so they explain the remote-first rule and best-effort refresh behavior in plain language. If the final implementation introduces any meaningful operator caveat, record it in this plan before archiving.
+
+## Concrete Steps
+
+Run all commands from `/home/filepang/playground/39claw`.
+
+1. Confirm the repository starts from a passing baseline.
+
+    make test
+    make lint
+
+2. Implement remote-aware base-ref resolution and best-effort fetch in:
+
+    - `internal/app/task_workspace.go`
+    - `internal/app/task_workspace_test.go`
+
+3. Update the affected docs:
+
+    - `docs/design-docs/task-mode-worktrees.md`
+    - `docs/design-docs/implementation-spec.md`
+    - `docs/product-specs/task-mode-user-flow.md`
+    - `docs/exec-plans/index.md`
+
+4. Run focused tests while iterating.
+
+    go test ./internal/app
+
+5. Run the full repository checks before committing.
+
+    make test
+    make lint
+
+    Observed result on 2026-04-05:
+
+        ok  	github.com/HatsuneMiku3939/39claw/cmd/39claw	0.208s
+        ok  	github.com/HatsuneMiku3939/39claw/cmd/codexplay	(cached)
+        ok  	github.com/HatsuneMiku3939/39claw/internal/app	(cached)
+        ok  	github.com/HatsuneMiku3939/39claw/internal/codex	(cached)
+        ok  	github.com/HatsuneMiku3939/39claw/internal/config	(cached)
+        ok  	github.com/HatsuneMiku3939/39claw/internal/dailymemory	(cached)
+        ok  	github.com/HatsuneMiku3939/39claw/internal/observe	(cached)
+        ok  	github.com/HatsuneMiku3939/39claw/internal/releaseconfig	(cached)
+        ok  	github.com/HatsuneMiku3939/39claw/internal/runtime/discord	0.035s
+        ok  	github.com/HatsuneMiku3939/39claw/internal/store/sqlite	(cached)
+        ok  	github.com/HatsuneMiku3939/39claw/internal/thread	(cached)
+        ?   	github.com/HatsuneMiku3939/39claw/version	[no test files]
+        0 issues.
+        Linting passed
+
+6. Create a conventional-commit change, open a GitHub pull request with the required template sections, wait for CI to pass, merge with a merge commit, and then archive this plan into `docs/exec-plans/completed/`.
+
+## Validation and Acceptance
+
+This plan is complete when all of the following are true:
+
+- a new task worktree prefers the remote default branch reference when the source repository has a usable `origin` remote
+- best-effort `git fetch origin --prune` runs before first-time base-ref detection and does not block task execution when it fails
+- the chosen `base_ref` is persisted on the task and remains stable for later task turns
+- automated tests prove both the remote-first path and the local fallback path
+- `make test` passes
+- `make lint` passes
+
+Acceptance is behavioral. A contributor should be able to create a source repository where local `master` has extra unpublished commits, prepare a new task worktree, and observe that the task worktree starts from the shared remote baseline rather than the local-only history.
+
+## Idempotence and Recovery
+
+The new detection flow must remain safe to retry. If a task already has `BaseRef` stored, later turns must reuse it without re-detecting. If `git fetch origin --prune` fails because the network is unavailable or credentials are missing, worktree creation should continue by probing the existing remote-tracking refs and then the local default branches. Tests should construct their own temporary repositories so rerunning them does not depend on developer-local Git state.
+
+## Artifacts and Notes
+
+Expected detection order after this plan:
+
+    git fetch origin --prune   # best effort
+    resolve origin/HEAD if it points to a commit
+    otherwise resolve origin/main
+    otherwise resolve origin/master
+    otherwise resolve local main
+    otherwise resolve local master
+
+Expected observable proof for the remote-first test:
+
+    source repo local master: commit B
+    origin/master: commit A
+    new task worktree branch: task/<id> based on commit A
+    task BaseRef: origin/master (or the equivalent remote default ref)
+
+## Interfaces and Dependencies
+
+The implementation should stay within the existing `internal/app` package and continue using the standard library only. The task workspace manager should keep using `runGit(ctx, args...)` so subprocess behavior and logging stay centralized. No new configuration flag is needed; the repository should simply become smarter about choosing the base ref for new task worktrees.
+
+Revision Note: 2026-04-06 / Codex - Created this active ExecPlan after deciding to prefer the remote default branch for new task worktrees while keeping a safe local fallback.
+
+Revision Note: 2026-04-05 / Codex - Updated the living sections after implementing remote-first task worktree base-ref detection, adding tests, and recording local validation results.

--- a/docs/exec-plans/index.md
+++ b/docs/exec-plans/index.md
@@ -25,6 +25,7 @@ Plans in this directory should be written and maintained in line with `.agents/P
 
 These plans are intended to be executed in the order listed below. Most plans follow numeric order, but infrastructure prerequisites may require picking up a later-numbered plan first when it explicitly prepares the repository for another active plan.
 
+- [Prefer the remote default branch when creating `task` worktrees](./active/14-task-worktree-remote-base.md)
 - [Build fake runtime validation infrastructure for adapter-level tests](./active/11-fake-runtime-validation.md)
 - [Build a versioned SQLite migration runner and bootstrap path](./active/13-sqlite-migration-runner.md)
 - [Add shared daily generation rotation and `action:clear` to `daily` mode](./active/12-daily-clear-generation.md)

--- a/docs/product-specs/task-mode-user-flow.md
+++ b/docs/product-specs/task-mode-user-flow.md
@@ -115,12 +115,13 @@ Expected flow:
 1. The user creates or switches to a task that has no ready task worktree yet.
 2. The user sends a normal message to continue that task.
 3. 39claw detects that the task worktree is still pending or previously failed.
-4. 39claw prepares the task-specific Git worktree under the bot data directory.
+4. 39claw refreshes `origin` metadata on a best-effort basis when the source repository has an `origin` remote, then prepares the task-specific Git worktree under the bot data directory from the shared remote default branch when available.
 5. After workspace preparation succeeds, 39claw runs the Codex turn in that task worktree.
 
 Expected user perception:
 
 - “The bot prepared this task's workspace when I first used it.”
+- “New tasks start from the shared team baseline instead of some random local-only commit.”
 - “Later turns for this task should continue in the same isolated workspace.”
 
 ### Scenario: A message is queued for the active task and the user switches tasks before it runs

--- a/internal/app/task_workspace.go
+++ b/internal/app/task_workspace.go
@@ -109,6 +109,7 @@ func (m *GitTaskWorkspaceManager) EnsureReady(ctx context.Context, task Task) (T
 
 	baseRef := task.BaseRef
 	if baseRef == "" {
+		m.refreshOrigin(ctx)
 		detectedBaseRef, err := m.detectBaseRef(ctx)
 		if err != nil {
 			return Task{}, m.markTaskWorktreeFailed(ctx, task, "", err)
@@ -208,13 +209,21 @@ func (m *GitTaskWorkspaceManager) PruneClosed(ctx context.Context) error {
 }
 
 func (m *GitTaskWorkspaceManager) detectBaseRef(ctx context.Context) (string, error) {
-	for _, ref := range []string{"main", "master"} {
-		if _, err := m.runGit(ctx, "rev-parse", "--verify", "--quiet", ref+"^{commit}"); err == nil {
+	if ref, ok := m.originHeadRef(ctx); ok {
+		return ref, nil
+	}
+
+	for _, ref := range []string{"origin/main", "origin/master", "main", "master"} {
+		exists, err := m.refExists(ctx, ref)
+		if err != nil {
+			return "", err
+		}
+		if exists {
 			return ref, nil
 		}
 	}
 
-	return "", errors.New("detect task worktree base ref: expected local branch main or master")
+	return "", errors.New("detect task worktree base ref: expected origin/HEAD, origin/main, origin/master, main, or master")
 }
 
 func (m *GitTaskWorkspaceManager) branchExists(ctx context.Context, branchName string) (bool, error) {
@@ -229,6 +238,63 @@ func (m *GitTaskWorkspaceManager) branchExists(ctx context.Context, branchName s
 	}
 
 	return false, fmt.Errorf("check branch existence: %w", err)
+}
+
+func (m *GitTaskWorkspaceManager) refreshOrigin(ctx context.Context) {
+	exists, err := m.remoteExists(ctx, "origin")
+	if err != nil {
+		m.logger.Warn("check git remote before task worktree fetch", "remote", "origin", "error", err)
+		return
+	}
+	if !exists {
+		return
+	}
+
+	if _, err := m.runGit(ctx, "fetch", "origin", "--prune"); err != nil {
+		m.logger.Warn("refresh git remote before task worktree base ref detection", "remote", "origin", "error", err)
+	}
+}
+
+func (m *GitTaskWorkspaceManager) remoteExists(ctx context.Context, remoteName string) (bool, error) {
+	_, err := m.runGit(ctx, "remote", "get-url", remoteName)
+	if err == nil {
+		return true, nil
+	}
+
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) && exitErr.ExitCode() == 2 {
+		return false, nil
+	}
+
+	return false, fmt.Errorf("check remote existence: %w", err)
+}
+
+func (m *GitTaskWorkspaceManager) originHeadRef(ctx context.Context) (string, bool) {
+	ref, err := m.runGit(ctx, "symbolic-ref", "--quiet", "--short", "refs/remotes/origin/HEAD")
+	if err != nil || strings.TrimSpace(ref) == "" {
+		return "", false
+	}
+
+	exists, verifyErr := m.refExists(ctx, ref)
+	if verifyErr != nil || !exists {
+		return "", false
+	}
+
+	return ref, true
+}
+
+func (m *GitTaskWorkspaceManager) refExists(ctx context.Context, ref string) (bool, error) {
+	_, err := m.runGit(ctx, "rev-parse", "--verify", "--quiet", ref+"^{commit}")
+	if err == nil {
+		return true, nil
+	}
+
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
+		return false, nil
+	}
+
+	return false, fmt.Errorf("check ref existence %q: %w", ref, err)
 }
 
 func (m *GitTaskWorkspaceManager) prepareWorktreePath(ctx context.Context, worktreePath string) error {

--- a/internal/app/task_workspace_test.go
+++ b/internal/app/task_workspace_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -75,6 +76,134 @@ func TestGitTaskWorkspaceManagerEnsureReadyCreatesWorktree(t *testing.T) {
 
 	if _, err := os.Stat(filepath.Join(wantPath, ".git")); err != nil {
 		t.Fatalf("worktree .git stat error = %v", err)
+	}
+}
+
+func TestGitTaskWorkspaceManagerEnsureReadyPrefersRemoteDefaultBranch(t *testing.T) {
+	t.Parallel()
+
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git is required for worktree integration tests")
+	}
+
+	sourceRepo := createRemoteBackedGitRepository(t, "master")
+	writeFile(t, filepath.Join(sourceRepo, "local-only.txt"), "local only\n")
+	runGit(t, sourceRepo, "add", "local-only.txt")
+	runGit(t, sourceRepo, "commit", "-m", "local only commit")
+
+	localHead := gitOutput(t, sourceRepo, "rev-parse", "HEAD")
+	remoteHead := gitOutput(t, sourceRepo, "rev-parse", "origin/master")
+	if localHead == remoteHead {
+		t.Fatal("local HEAD unexpectedly matches origin/master")
+	}
+
+	dataDir := t.TempDir()
+	store := &memoryThreadStore{
+		tasks: map[string]app.Task{
+			"user-1:task-remote": {
+				TaskID:         "task-remote",
+				DiscordUserID:  "user-1",
+				TaskName:       "Remote base",
+				Status:         app.TaskStatusOpen,
+				BranchName:     app.DefaultTaskBranchName("task-remote"),
+				WorktreeStatus: app.TaskWorktreeStatusPending,
+				CreatedAt:      time.Date(2026, time.April, 6, 0, 0, 0, 0, time.UTC),
+			},
+		},
+	}
+
+	manager, err := app.NewTaskWorkspaceManager(app.TaskWorkspaceManagerDependencies{
+		Store:            store,
+		SourceRepository: sourceRepo,
+		DataDir:          dataDir,
+		GitExecutable:    "git",
+		Clock: func() time.Time {
+			return time.Date(2026, time.April, 6, 1, 0, 0, 0, time.UTC)
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewTaskWorkspaceManager() error = %v", err)
+	}
+
+	task, ok, err := store.GetTask(context.Background(), "user-1", "task-remote")
+	if err != nil {
+		t.Fatalf("GetTask() error = %v", err)
+	}
+	if !ok {
+		t.Fatal("GetTask() ok = false, want true")
+	}
+
+	readyTask, err := manager.EnsureReady(context.Background(), task)
+	if err != nil {
+		t.Fatalf("EnsureReady() error = %v", err)
+	}
+
+	if readyTask.BaseRef != "origin/master" {
+		t.Fatalf("BaseRef = %q, want %q", readyTask.BaseRef, "origin/master")
+	}
+
+	worktreeHead := gitOutput(t, readyTask.WorktreePath, "rev-parse", "HEAD")
+	if worktreeHead != remoteHead {
+		t.Fatalf("worktree HEAD = %q, want %q", worktreeHead, remoteHead)
+	}
+	if worktreeHead == localHead {
+		t.Fatal("worktree HEAD unexpectedly matched local-only source HEAD")
+	}
+}
+
+func TestGitTaskWorkspaceManagerEnsureReadyFallsBackToLocalBranchWhenFetchFails(t *testing.T) {
+	t.Parallel()
+
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git is required for worktree integration tests")
+	}
+
+	sourceRepo := createGitRepository(t, "master")
+	runGit(t, sourceRepo, "remote", "add", "origin", filepath.Join(t.TempDir(), "missing-remote.git"))
+
+	dataDir := t.TempDir()
+	store := &memoryThreadStore{
+		tasks: map[string]app.Task{
+			"user-1:task-local-fallback": {
+				TaskID:         "task-local-fallback",
+				DiscordUserID:  "user-1",
+				TaskName:       "Local fallback",
+				Status:         app.TaskStatusOpen,
+				BranchName:     app.DefaultTaskBranchName("task-local-fallback"),
+				WorktreeStatus: app.TaskWorktreeStatusPending,
+				CreatedAt:      time.Date(2026, time.April, 6, 0, 0, 0, 0, time.UTC),
+			},
+		},
+	}
+
+	manager, err := app.NewTaskWorkspaceManager(app.TaskWorkspaceManagerDependencies{
+		Store:            store,
+		SourceRepository: sourceRepo,
+		DataDir:          dataDir,
+		GitExecutable:    "git",
+		Clock: func() time.Time {
+			return time.Date(2026, time.April, 6, 1, 0, 0, 0, time.UTC)
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewTaskWorkspaceManager() error = %v", err)
+	}
+
+	task, ok, err := store.GetTask(context.Background(), "user-1", "task-local-fallback")
+	if err != nil {
+		t.Fatalf("GetTask() error = %v", err)
+	}
+	if !ok {
+		t.Fatal("GetTask() ok = false, want true")
+	}
+
+	readyTask, err := manager.EnsureReady(context.Background(), task)
+	if err != nil {
+		t.Fatalf("EnsureReady() error = %v", err)
+	}
+
+	if readyTask.BaseRef != "master" {
+		t.Fatalf("BaseRef = %q, want %q", readyTask.BaseRef, "master")
 	}
 }
 
@@ -169,6 +298,26 @@ func TestGitTaskWorkspaceManagerPruneClosedRemovesOldReadyWorktrees(t *testing.T
 	}
 }
 
+func createRemoteBackedGitRepository(t *testing.T, branch string) string {
+	t.Helper()
+
+	root := t.TempDir()
+	remote := filepath.Join(root, "remote.git")
+	source := filepath.Join(root, "source")
+
+	runGit(t, root, "init", "--bare", "-b", branch, remote)
+	runGit(t, root, "clone", remote, source)
+	runGit(t, source, "config", "user.email", "codex@example.com")
+	runGit(t, source, "config", "user.name", "Codex")
+
+	writeFile(t, filepath.Join(source, "README.md"), "hello\n")
+	runGit(t, source, "add", "README.md")
+	runGit(t, source, "commit", "-m", "initial commit")
+	runGit(t, source, "push", "-u", "origin", branch)
+
+	return source
+}
+
 func createGitRepository(t *testing.T, branch string) string {
 	t.Helper()
 
@@ -187,6 +336,27 @@ func createGitRepository(t *testing.T, branch string) string {
 	runGit(t, repo, "commit", "-m", "initial commit")
 
 	return repo
+}
+
+func writeFile(t *testing.T, path string, contents string) {
+	t.Helper()
+
+	if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
+		t.Fatalf("WriteFile(%s) error = %v", path, err)
+	}
+}
+
+func gitOutput(t *testing.T, workdir string, args ...string) string {
+	t.Helper()
+
+	cmd := exec.Command("git", args...)
+	cmd.Dir = workdir
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v error = %v\n%s", args, err, output)
+	}
+
+	return strings.TrimSpace(string(output))
 }
 
 func runGit(t *testing.T, workdir string, args ...string) {


### PR DESCRIPTION
## Summary

- prefer remote-tracking default branches for new task worktrees
- keep a best-effort fetch plus local fallback path
- cover the new behavior with integration tests and docs

## Background

Task-mode worktrees were previously created from local `main` or `master` only. That could leak unpublished local commits into new tasks and make parallel task work more divergent than intended.

## Related issue(s)

- None

## Implementation details

- attempt `git fetch origin --prune` before first-time base-ref detection when `origin` exists
- prefer `origin/HEAD`, then `origin/main`, then `origin/master`, before falling back to local `main` or `master`
- add integration coverage for remote-first selection and fetch-failure local fallback
- update the active ExecPlan plus task-mode docs to describe the new rule

## Test coverage

- `go test ./internal/app`
- `make test`
- `make lint`

## Breaking changes

- None

## Notes

- The active ExecPlan remains under `docs/exec-plans/active/` in this PR and will be archived after merge once the repository reflects the completed state.

Created by Codex
