### PR TITLE
Archive completed ExecPlan 14

### DIFF
--- a/docs/exec-plans/completed/14-task-worktree-remote-base.md
+++ b/docs/exec-plans/completed/14-task-worktree-remote-base.md
@@ -17,7 +17,7 @@ The user-visible proof is concrete. In `task` mode, if the source repository has
 - [x] (2026-04-05 21:21Z) Added focused tests proving that remote-tracking refs are preferred over local default branches and that task worktree creation still falls back to local `master` when `origin` refresh fails.
 - [x] (2026-04-05 21:21Z) Updated task-mode design and product documentation so the remote-first base-ref behavior is now described consistently.
 - [x] (2026-04-05 21:21Z) Ran `make test` and `make lint` after the implementation landed.
-- [ ] Archive this completed plan from `active/` to `completed/`, update `docs/exec-plans/index.md`, and carry any intentionally deferred follow-up into `docs/exec-plans/tech-debt-tracker.md` if needed.
+- [x] (2026-04-05 21:27Z) Archived this completed plan into `docs/exec-plans/completed/`, updated `docs/exec-plans/index.md`, and confirmed that no additional follow-up needed to be added to `docs/exec-plans/tech-debt-tracker.md`.
 
 ## Surprises & Discoveries
 
@@ -43,9 +43,17 @@ The user-visible proof is concrete. In `task` mode, if the source repository has
   Rationale: A hard fetch requirement would turn transient network or credential issues into avoidable task-mode outages. A best-effort refresh still improves correctness without sacrificing availability.
   Date/Author: 2026-04-06 / Codex
 
+- Decision: Archive this ExecPlan without adding a new tech-debt entry.
+  Rationale: The implementation, tests, and documentation are complete, and no meaningful non-blocking follow-up beyond the already-documented task worktree ergonomics debt was introduced by this remote-base refinement.
+  Date/Author: 2026-04-05 / Codex
+
 ## Outcomes & Retrospective
 
-Implementation is complete and validated locally. The task workspace manager now refreshes `origin` on a best-effort basis, prefers the remote default branch state for first-time worktree creation, and still falls back safely to local `main` or `master` when the remote cannot be used. The remaining work is repository workflow only: archive this finished plan, open the pull request, confirm CI, and merge.
+This plan is now complete and archived. The task workspace manager refreshes `origin` on a best-effort basis, prefers the remote default branch state for first-time worktree creation, and still falls back safely to local `main` or `master` when the remote cannot be used. Automated coverage proves both the remote-first path and the fetch-failure fallback path, and the task-mode design plus product docs now describe the behavior consistently.
+
+The main lesson from this change is that the safest parallel-task baseline is not necessarily the most obvious local branch. Remote-tracking refs carry the shared team state that new isolated tasks should usually inherit. The implementation remained small because base-ref detection was already isolated inside the task workspace manager, so the repository could adopt the safer policy without changing task persistence, thread routing, or user commands.
+
+This plan no longer belongs in `active/` because its acceptance criteria are satisfied, local validation passed, the feature PR merged, and the repository documentation now matches the shipped behavior.
 
 ## Context and Orientation
 
@@ -173,3 +181,5 @@ The implementation should stay within the existing `internal/app` package and co
 Revision Note: 2026-04-06 / Codex - Created this active ExecPlan after deciding to prefer the remote default branch for new task worktrees while keeping a safe local fallback.
 
 Revision Note: 2026-04-05 / Codex - Updated the living sections after implementing remote-first task worktree base-ref detection, adding tests, and recording local validation results.
+
+Revision Note: 2026-04-05 / Codex - Archived this completed ExecPlan after the feature PR merged and the repository state matched the documented acceptance criteria.

--- a/docs/exec-plans/index.md
+++ b/docs/exec-plans/index.md
@@ -25,13 +25,13 @@ Plans in this directory should be written and maintained in line with `.agents/P
 
 These plans are intended to be executed in the order listed below. Most plans follow numeric order, but infrastructure prerequisites may require picking up a later-numbered plan first when it explicitly prepares the repository for another active plan.
 
-- [Prefer the remote default branch when creating `task` worktrees](./active/14-task-worktree-remote-base.md)
 - [Build fake runtime validation infrastructure for adapter-level tests](./active/11-fake-runtime-validation.md)
 - [Build a versioned SQLite migration runner and bootstrap path](./active/13-sqlite-migration-runner.md)
 - [Add shared daily generation rotation and `action:clear` to `daily` mode](./active/12-daily-clear-generation.md)
 
 ## Recently Completed Plans
 
+- [Prefer the remote default branch when creating `task` worktrees](./completed/14-task-worktree-remote-base.md)
 - [Add first-stage tag-driven release automation](./completed/10-first-stage-release-automation.md)
 - [Build the foundation, contracts, and bootstrap path](./completed/01-foundation-and-contracts.md)
 - [Implement `daily` mode routing and persistence](./completed/02-daily-mode-routing.md)


### PR DESCRIPTION
## Summary

- move ExecPlan 14 from `active/` to `completed/`
- update the ExecPlan index to reflect the archived state
- record the final archive note inside the completed plan

## Background

The remote-base task worktree change has already shipped and merged, so the active ExecPlan needed to be reconciled with the current repository state.

## Related issue(s)

- None

## Implementation details

- finalized the living sections in ExecPlan 14 to reflect merged implementation, validation, and archival rationale
- moved the plan into `docs/exec-plans/completed/` without renumbering it
- updated `docs/exec-plans/index.md` so the plan no longer appears under active work

## Test coverage

- `make test`
- `make lint`

## Breaking changes

- None

## Notes

- No new tech-debt entry was added because the remote-base refinement did not introduce additional deferred scope beyond existing task worktree follow-up notes.

Created by Codex
