### PR TITLE
fix: inherit parent env for codex exec

### DIFF
--- a/internal/codex/codex_test.go
+++ b/internal/codex/codex_test.go
@@ -177,6 +177,24 @@ func TestThreadRunPassesConfiguredEnvironmentVariables(t *testing.T) {
 	}
 }
 
+func TestThreadRunInheritsParentEnvironmentVariables(t *testing.T) {
+	t.Setenv("CODEX_TEST_PARENT_ENV", "inherited-value")
+
+	client, recorder := newTestClientWithEnv(t, "single-success", map[string]string{
+		"CODEX_HOME": "/tmp/custom-codex-home",
+	})
+	thread := client.StartThread(ThreadOptions{})
+
+	if _, err := thread.Run(context.Background(), TextInput("hello")); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	record := readInvocationRecord(t, recorder)
+	if record.Env["CODEX_TEST_PARENT_ENV"] != "inherited-value" {
+		t.Fatalf("CODEX_TEST_PARENT_ENV = %q, want %q", record.Env["CODEX_TEST_PARENT_ENV"], "inherited-value")
+	}
+}
+
 func TestRunReturnsTurnFailure(t *testing.T) {
 	t.Parallel()
 
@@ -384,7 +402,8 @@ func runHelperProcess() error {
 		Args:  args,
 		Stdin: string(stdin),
 		Env: map[string]string{
-			"CODEX_HOME": os.Getenv("CODEX_HOME"),
+			"CODEX_HOME":            os.Getenv("CODEX_HOME"),
+			"CODEX_TEST_PARENT_ENV": os.Getenv("CODEX_TEST_PARENT_ENV"),
 		},
 	}); err != nil {
 		return fmt.Errorf("append record: %w", err)

--- a/internal/codex/exec.go
+++ b/internal/codex/exec.go
@@ -158,11 +158,10 @@ func (e *executor) buildArgs(request execRequest) []string {
 }
 
 func (e *executor) buildEnv() map[string]string {
-	var env map[string]string
-	if len(e.env) > 0 {
-		env = cloneStringMap(e.env)
-	} else {
-		env = cloneCurrentEnv()
+	env := cloneCurrentEnv()
+
+	for key, value := range e.env {
+		env[key] = value
 	}
 
 	if env[originatorEnvKey] == "" {


### PR DESCRIPTION
## Summary

- preserve the parent process environment when spawning the Codex CLI
- keep explicit Codex env overrides such as `CODEX_HOME` working as intended
- add regression coverage for inherited environment variables

## Background

The previous `CLAW_CODEX_HOME` patch passed explicit environment overrides down to the Codex CLI process, but that path replaced the inherited process environment instead of merging with it. As a result, setting one override could unintentionally drop unrelated parent environment variables.

## Related issue(s)

- None.

## Implementation details

- change the Codex exec environment builder to always start from the current process environment
- apply configured env overrides on top of the inherited environment
- keep the Codex originator header and API key injection behavior unchanged
- add a regression test that verifies a parent environment variable still reaches the helper process when explicit env overrides are present

## Test coverage

- `make test`
- `make lint`

## Breaking changes

- None.

## Notes

- this PR fixes the follow-up bug discovered after the optional `CLAW_CODEX_HOME` support landed

Created by Codex