### PR TITLE
Add versioned SQLite migration runner

### DIFF
--- a/cmd/39claw/main.go
+++ b/cmd/39claw/main.go
@@ -114,20 +114,22 @@ func run(ctx context.Context, lookupEnv func(string) (string, bool)) error {
 	}
 	slog.SetDefault(logger)
 
-	store, err := sqlitestore.Open(cfg.SQLitePath)
+	db, err := sqlitestore.OpenDB(ctx, cfg.SQLitePath)
 	if err != nil {
-		return fmt.Errorf("open sqlite store: %w", err)
+		return fmt.Errorf("open sqlite database: %w", err)
 	}
 	defer func() {
-		closeErr := store.Close()
+		closeErr := db.Close()
 		if closeErr != nil && !errors.Is(closeErr, context.Canceled) {
-			logger.Error("close sqlite store", "error", closeErr)
+			logger.Error("close sqlite database", "error", closeErr)
 		}
 	}()
 
-	if err := store.InitSchema(ctx); err != nil {
-		return fmt.Errorf("initialize sqlite schema: %w", err)
+	if err := sqlitestore.Migrate(ctx, db); err != nil {
+		return fmt.Errorf("migrate sqlite database: %w", err)
 	}
+
+	store := sqlitestore.New(db)
 
 	client := newCodexClient(codex.Options{
 		ExecutablePath: cfg.CodexExecutable,

--- a/cmd/39claw/main_test.go
+++ b/cmd/39claw/main_test.go
@@ -250,7 +250,7 @@ func TestRun(t *testing.T) {
 			cancel := func() {}
 			if tt.wantErr == "" {
 				var timeoutCtx context.Context
-				timeoutCtx, cancel = context.WithTimeout(context.Background(), 100*time.Millisecond)
+					timeoutCtx, cancel = context.WithTimeout(context.Background(), 2*time.Second)
 				ctx = timeoutCtx
 			}
 			defer cancel()

--- a/docs/design-docs/sqlite-migrations.md
+++ b/docs/design-docs/sqlite-migrations.md
@@ -1,14 +1,13 @@
 # SQLite Migrations
 
-This document proposes a migration structure for 39claw's local SQLite schema.
+This document describes the migration structure now used for 39claw's local SQLite schema.
 
-It is a design draft, not a statement that the full migration runner already exists in the repository today.
-The goal is to replace the current "create tables on startup and patch selected columns inline" approach with a versioned, testable, and explicit schema-evolution path.
+The repository now replaces the old "create tables on startup and patch selected columns inline" approach with a versioned, testable, and explicit schema-evolution path.
 
 ## Why This Change Is Needed
 
-The current store implementation initializes schema directly inside `internal/store/sqlite/store.go`.
-That keeps the first implementation small, but it becomes harder to reason about as the schema evolves.
+The original store implementation initialized schema directly inside `internal/store/sqlite/store.go`.
+That kept the first implementation small, but it became harder to reason about as the schema evolved.
 
 The current approach has three limits:
 
@@ -27,9 +26,9 @@ The current approach has three limits:
 - preserve compatibility with already-created local databases
 - keep migration logic separate from query and store logic
 
-## Proposed Package Shape
+## Package Shape
 
-The package boundary remains `internal/store/sqlite`, but responsibilities should split more explicitly:
+The package boundary remains `internal/store/sqlite`, but responsibilities are now split explicitly:
 
 - `internal/store/sqlite/db.go`
   - open the SQLite database
@@ -51,10 +50,10 @@ This keeps the store package small without introducing an external migration dep
 
 ## Startup Flow
 
-The intended startup flow is:
+The current startup flow is:
 
 ```text
-open database -> apply pragmas -> run migrations -> construct store -> serve requests
+OpenDB -> apply pragmas -> Migrate -> New(store) -> serve requests
 ```
 
 The migration step should happen exactly once per opened database handle during startup.
@@ -62,7 +61,7 @@ Store methods should not contain hidden schema-altering behavior after this refa
 
 ## Migration History Table
 
-The database should contain a dedicated history table:
+The database contains a dedicated history table:
 
 ```sql
 CREATE TABLE IF NOT EXISTS schema_migrations (
@@ -136,9 +135,9 @@ If a later migration truly needs procedural branching, `migrate.go` may support 
 
 ## Initial Version Mapping
 
-If 39claw adopts this structure, the first migration set should reflect the schema that users may already have in the field.
+The first migration set reflects the schema that users may already have in the field.
 
-Recommended initial sequence:
+Current initial sequence:
 
 1. `0001_initial_schema.sql`
    - create `schema_migrations`
@@ -155,11 +154,11 @@ Recommended initial sequence:
    - rewrite legacy `daily` logical thread keys from `YYYY-MM-DD` to `YYYY-MM-DD#1`
    - insert or backfill matching `daily_sessions` rows
 
-This sequence mirrors the repository's current and planned state without pretending the original schema always existed in one step.
+This sequence mirrors the repository's shipped legacy states without pretending the original schema always existed in one step.
 
 ## Compatibility With Existing Databases
 
-Existing user databases created by the current startup schema path need a bootstrap rule.
+Existing user databases created by the old inline startup schema path need a bootstrap rule.
 
 Recommended bootstrap behavior:
 
@@ -227,5 +226,5 @@ This design does not currently propose:
 
 ## Recommendation
 
-This migration structure is worth adopting before the repository lands the `daily_sessions` feature and its legacy data rewrite.
-That upcoming work is the point where versioned migrations start paying for themselves instead of adding ceremony too early.
+Keep future SQLite schema work on top of this migration foundation.
+In particular, the planned `daily_sessions` feature and legacy daily-key rewrite should land as new migration versions instead of reopening ad hoc startup schema mutation.

--- a/docs/exec-plans/active/12-daily-clear-generation.md
+++ b/docs/exec-plans/active/12-daily-clear-generation.md
@@ -70,7 +70,9 @@ Implementation has not started yet. The intended outcome is a `daily` mode that 
 - `internal/dailymemory/service.go`
   - runs the hidden preflight refresh and currently assumes one thread per local day
 - `internal/store/sqlite/store.go`
-  - creates the SQLite schema and persists `thread_bindings`, `tasks`, and `active_tasks`
+  - persists `thread_bindings`, `tasks`, and `active_tasks` after startup migrations have already prepared the schema
+- `migrations/sqlite`
+  - owns versioned SQLite schema changes, so `daily_sessions` must land as a new migration instead of inline startup schema mutation
 - `internal/runtime/discord/commands.go`
   - defines the slash-command choices and help output
 - `internal/runtime/discord/interaction_mapper.go`
@@ -102,7 +104,7 @@ Start this plan only after confirming the repository still matches these assumpt
 - `internal/app/message_service_impl.go` still runs the daily-memory preflight before visible thread-binding lookup
 - `internal/dailymemory/service.go` still expects a date-like logical key and writes `AGENT_MEMORY/YYYY-MM-DD.md`
 - `internal/runtime/discord/commands.go` still owns the root command choices and currently exposes `action:help` only for `daily` mode
-- `internal/store/sqlite/store.go` still creates `thread_bindings`, `tasks`, and `active_tasks`
+- the repository now uses embedded SQLite migrations under `migrations/sqlite`, so this plan must add `daily_sessions` through new migration files rather than through inline `store.go` schema setup
 - `make test` and `make lint` pass before implementation work begins
 
 Verify that state with:
@@ -130,7 +132,7 @@ This plan fixes the following product and implementation choices:
 
 At the end of this milestone, SQLite should persist which same-day generation is active for each local date, and legacy `daily` thread bindings should be normalized from `YYYY-MM-DD` to `YYYY-MM-DD#1`.
 
-Add a new table in `internal/store/sqlite/store.go` named `daily_sessions` with these columns:
+Add a new migration under `migrations/sqlite` that creates a `daily_sessions` table with these columns:
 
 - `local_date TEXT NOT NULL`
 - `generation INTEGER NOT NULL`
@@ -236,7 +238,7 @@ Finish by running `make test` and `make lint`, then update this plan's `Progress
 
 ## Plan of Work
 
-Begin in `internal/store/sqlite/store.go`. Add the `daily_sessions` table, active-generation uniqueness, and the legacy `daily` key migration. Extend the app-facing store contract with focused daily-session methods rather than overloading task methods.
+Begin in `migrations/sqlite` by adding the `daily_sessions` migration files plus any legacy-key backfill migration needed for `daily`. Then extend the app-facing store contract with focused daily-session methods rather than overloading task methods.
 
 Next, introduce a small app-level daily-session resolver and use it from `internal/app/message_service_impl.go` before the visible turn loads a thread binding or calls the daily-memory refresher. The visible `daily` path should always operate on the generation key, not on the raw bucket string.
 

--- a/docs/exec-plans/completed/13-sqlite-migration-runner.md
+++ b/docs/exec-plans/completed/13-sqlite-migration-runner.md
@@ -13,12 +13,12 @@ This change matters because the repository currently creates and mutates schema 
 ## Progress
 
 - [x] (2026-04-06 00:00Z) Reviewed the current SQLite startup path, the inline schema initialization in `internal/store/sqlite/store.go`, the new design note in `docs/design-docs/sqlite-migrations.md`, and the active `daily` rotation plan to confirm that the migration runner should land as a separate prerequisite.
-- [ ] Create embedded migration assets under `migrations/sqlite` plus `migrations/embed.go` and move the current baseline schema into versioned SQL files.
-- [ ] Add `internal/store/sqlite/db.go` and `internal/store/sqlite/migrate.go` so startup can open the database, apply pragmas, create `schema_migrations`, and run pending migrations transactionally.
-- [ ] Add a bootstrap reconciliation path for legacy databases that were created before `schema_migrations` existed.
-- [ ] Update `cmd/39claw/main.go` and the store package so schema setup happens through `Migrate()` before store construction, not through inline schema mutation inside CRUD-oriented code.
-- [ ] Replace store tests that depend on `InitSchema()` with migration-aware coverage and keep reopen-oriented persistence tests passing.
-- [ ] Run `make test` and `make lint`, then update this plan with evidence and any follow-up work that should be deferred to a later plan.
+- [x] (2026-04-09 06:20Z) Added embedded migration assets under `migrations/sqlite` plus `migrations/embed.go`, splitting the historical schema into `0001_initial_schema.sql` and `0002_task_worktree_metadata.sql`.
+- [x] (2026-04-09 06:45Z) Added `internal/store/sqlite/db.go` and `internal/store/sqlite/migrate.go` so startup can open SQLite, apply pragmas, create `schema_migrations`, and run pending migrations transactionally.
+- [x] (2026-04-09 07:00Z) Implemented bootstrap reconciliation for known legacy databases that predate `schema_migrations`, including recognition of already-satisfied versions and branch-name backfill preservation.
+- [x] (2026-04-09 07:10Z) Updated `cmd/39claw/main.go` and the store package so startup follows `OpenDB -> Migrate -> New`, while keeping `InitSchema()` only as a thin compatibility shim.
+- [x] (2026-04-09 07:25Z) Replaced inline-schema test assumptions with migration-aware helpers and added dedicated migration coverage for fresh and legacy databases.
+- [x] (2026-04-09 07:40Z) Ran focused and full validation with `go test ./internal/store/sqlite -run 'TestStore|TestMigrate' -v`, `go test ./cmd/39claw -v`, `go test ./...`, and `./scripts/lint -c .golangci.yml`; `make` is not installed in this environment, so the repository-equivalent direct commands were used instead.
 
 ## Surprises & Discoveries
 
@@ -30,6 +30,12 @@ This change matters because the repository currently creates and mutates schema 
 
 - Observation: The active `daily` generation plan currently assumes it can add `daily_sessions` directly in store initialization. That assumption should be revised only after this plan lands so the later feature can target the new migration foundation rather than the old inline path.
   Evidence: `docs/exec-plans/active/12-daily-clear-generation.md`
+
+- Observation: The legacy bootstrap path only needs to recognize the exact table sets and column shapes that older 39claw builds could have produced. Treating partially-customized local schemas as supported would add complexity without improving the supported upgrade path.
+  Evidence: `internal/store/sqlite/migrate.go`, `internal/store/sqlite/migrate_test.go`
+
+- Observation: Keeping `InitSchema()` as a thin shim avoided a larger test-only churn while still removing schema evolution policy from CRUD code and from production startup.
+  Evidence: `internal/store/sqlite/store.go`, `cmd/39claw/main.go`
 
 ## Decision Log
 
@@ -45,9 +51,19 @@ This change matters because the repository currently creates and mutates schema 
   Rationale: Early users may already have local databases created by the inline `InitSchema()` path. A migration runner that only works for fresh databases would strand those users and would not be a complete replacement.
   Date/Author: 2026-04-06 / Codex
 
+- Decision: Model the historical schema as two production migrations: a baseline table-creation step and a separate task-worktree metadata step.
+  Rationale: Splitting the already-shipped additive task columns into `0002` preserves the real upgrade boundary that legacy databases need, keeps bootstrap reconciliation easy to reason about, and gives later features a clean place to append new versions.
+  Date/Author: 2026-04-09 / Codex
+
+- Decision: Reject unsupported legacy table sets during bootstrap instead of trying to infer arbitrary partially-migrated states.
+  Rationale: The repository only needs to upgrade shapes that 39claw itself previously produced. Failing fast on unknown legacy states is safer than pretending a generic schema-diff engine exists.
+  Date/Author: 2026-04-09 / Codex
+
 ## Outcomes & Retrospective
 
-Implementation has not started yet. The intended outcome is a repository where SQLite schema evolution is versioned, repeatable, and observable through dedicated migration history, while existing local databases still upgrade safely. This plan will be complete when fresh databases migrate from embedded SQL, legacy databases bootstrap into the same latest shape, and the startup path no longer relies on CRUD code to alter schema.
+Implementation completed on 2026-04-09. The repository now owns SQLite schema evolution through embedded, versioned migrations plus a narrow bootstrap path for legacy pre-runner databases. Fresh databases migrate through `migrations/sqlite/*.sql`, legacy databases reconcile into `schema_migrations` before any later versions run, and production startup no longer relies on CRUD code to mutate schema.
+
+The main tradeoff is that `InitSchema()` still exists as a compatibility shim for callers and tests, but it now delegates directly to `Migrate()` and no longer carries inline schema policy. That kept the refactor smaller while preserving a clean production ordering of `OpenDB -> Migrate -> New`.
 
 ## Context and Orientation
 
@@ -88,9 +104,9 @@ Begin this plan only after confirming the repository still matches these assumpt
 
 Verify that state with:
 
-    cd /home/filepang/playground/39claw
-    make test
-    make lint
+    cd /home/filepang/workspaces/39claw/39claw
+    go test ./...
+    ./scripts/lint -c .golangci.yml
 
 If the repository has drifted away from that shape, update this ExecPlan first so it remains self-contained and truthful.
 
@@ -210,12 +226,12 @@ Finally, clean up the now-redundant inline schema code, rerun the full checks, a
 
 ## Concrete Steps
 
-Run all commands from `/home/filepang/playground/39claw`.
+Run all commands from `/home/filepang/workspaces/39claw/39claw`.
 
 1. Confirm the baseline repository state before refactoring.
 
-    make test
-    make lint
+    go test ./...
+    ./scripts/lint -c .golangci.yml
 
 2. Implement the migration asset package and runner, then run focused SQLite tests while iterating.
 
@@ -227,8 +243,8 @@ Run all commands from `/home/filepang/playground/39claw`.
 
 4. Run the full required checks before considering the plan complete.
 
-    make test
-    make lint
+    go test ./...
+    ./scripts/lint -c .golangci.yml
 
 5. If the user also wants a commit after implementation, stage only the intended files and create an English Conventional Commit message after all checks pass.
 
@@ -241,8 +257,9 @@ Expected command outcomes:
     --- PASS: TestMigrateLegacyDatabaseBootstrap (0.00s)
     PASS
 
-    $ make lint
-    <repository lint command exits with status 0 and no reported violations>
+    $ ./scripts/lint -c .golangci.yml
+    0 issues.
+    Linting passed
 
 ## Validation and Acceptance
 
@@ -270,9 +287,9 @@ For startup integration:
 
 The required automated proof is:
 
-    cd /home/filepang/playground/39claw
-    make test
-    make lint
+    cd /home/filepang/workspaces/39claw/39claw
+    go test ./...
+    ./scripts/lint -c .golangci.yml
 
 This plan is complete only when both commands pass and the plan's living sections are updated with the actual results.
 
@@ -305,6 +322,13 @@ Important functions or entrypoints that should exist by the end of implementatio
 - a database-opening helper in `internal/store/sqlite/db.go`
 - `func Migrate(ctx context.Context, db *sql.DB) error` in `internal/store/sqlite/migrate.go`
 - a startup path in `cmd/39claw/main.go` that calls the migration runner before constructing the store
+
+Validation completed on 2026-04-09 with:
+
+- `go test ./internal/store/sqlite -run 'TestStore|TestMigrate' -v`
+- `go test ./cmd/39claw -v`
+- `go test ./...`
+- `./scripts/lint -c .golangci.yml`
 
 Short example of the intended startup shape:
 
@@ -356,3 +380,4 @@ In `internal/store/sqlite/store.go`, keep:
 By the end of this plan, `store.go` should no longer be the place that defines the repository's schema evolution policy.
 
 Revision note (2026-04-06): Created this plan after narrowing scope away from `daily_sessions`. The user chose to land the migration runner first and to revise the active `daily` generation plan only after that infrastructure exists.
+Revision note (2026-04-09): Completed the migration runner, legacy bootstrap path, startup refactor, migration-focused tests, and the `daily` plan follow-up update that now targets versioned SQL files.

--- a/docs/exec-plans/index.md
+++ b/docs/exec-plans/index.md
@@ -25,11 +25,11 @@ Plans in this directory should be written and maintained in line with `.agents/P
 
 These plans are intended to be executed in the order listed below. Most plans follow numeric order, but infrastructure prerequisites may require picking up a later-numbered plan first when it explicitly prepares the repository for another active plan.
 
-- [Build a versioned SQLite migration runner and bootstrap path](./active/13-sqlite-migration-runner.md)
 - [Add shared daily generation rotation and `action:clear` to `daily` mode](./active/12-daily-clear-generation.md)
 
 ## Recently Completed Plans
 
+- [Build a versioned SQLite migration runner and bootstrap path](./completed/13-sqlite-migration-runner.md)
 - [Prefer the remote default branch when creating `task` worktrees](./completed/14-task-worktree-remote-base.md)
 - [Build fake runtime validation infrastructure for adapter-level tests](./completed/11-fake-runtime-validation.md)
 - [Add first-stage tag-driven release automation](./completed/10-first-stage-release-automation.md)

--- a/internal/store/sqlite/db.go
+++ b/internal/store/sqlite/db.go
@@ -1,0 +1,70 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+const (
+	driverName               = "sqlite"
+	sqliteDirectoryPermsMode = 0o755
+)
+
+var sqlitePragmas = []string{
+	`PRAGMA foreign_keys = ON`,
+	`PRAGMA journal_mode = WAL`,
+	`PRAGMA synchronous = NORMAL`,
+	`PRAGMA busy_timeout = 5000`,
+}
+
+func OpenDB(ctx context.Context, path string) (*sql.DB, error) {
+	if path == "" {
+		return nil, errors.New("sqlite path must not be empty")
+	}
+
+	if path != ":memory:" {
+		dir := filepath.Dir(path)
+		if dir != "." {
+			if err := os.MkdirAll(dir, sqliteDirectoryPermsMode); err != nil {
+				return nil, fmt.Errorf("create sqlite directory: %w", err)
+			}
+		}
+	}
+
+	db, err := sql.Open(driverName, path)
+	if err != nil {
+		return nil, fmt.Errorf("open sqlite database: %w", err)
+	}
+
+	db.SetMaxOpenConns(1)
+
+	if err := applyPragmas(ctx, db); err != nil {
+		_ = db.Close()
+		return nil, err
+	}
+
+	return db, nil
+}
+
+func Open(path string) (*Store, error) {
+	db, err := OpenDB(context.Background(), path)
+	if err != nil {
+		return nil, err
+	}
+
+	return New(db), nil
+}
+
+func applyPragmas(ctx context.Context, db *sql.DB) error {
+	for _, pragma := range sqlitePragmas {
+		if _, err := db.ExecContext(ctx, pragma); err != nil {
+			return fmt.Errorf("apply sqlite pragma %q: %w", pragma, err)
+		}
+	}
+
+	return nil
+}

--- a/internal/store/sqlite/migrate.go
+++ b/internal/store/sqlite/migrate.go
@@ -1,0 +1,347 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"io/fs"
+	"path/filepath"
+	"slices"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/HatsuneMiku3939/39claw/migrations"
+)
+
+const schemaMigrationsTable = "schema_migrations"
+
+const taskWorktreeMetadataVersion = 2
+
+var legacyTaskWorktreeColumns = []string{
+	"branch_name",
+	"base_ref",
+	"worktree_path",
+	"worktree_status",
+	"worktree_created_at",
+	"worktree_pruned_at",
+	"last_used_at",
+}
+
+type migrationFile struct {
+	version int
+	name    string
+	sql     string
+}
+
+func Migrate(ctx context.Context, db *sql.DB) error {
+	if db == nil {
+		return fmt.Errorf("sqlite db must not be nil")
+	}
+
+	migrationFiles, err := loadMigrationFiles()
+	if err != nil {
+		return err
+	}
+
+	schemaExists, err := tableExists(ctx, db, schemaMigrationsTable)
+	if err != nil {
+		return err
+	}
+
+	legacyAppTablesExist, err := applicationTablesExist(ctx, db)
+	if err != nil {
+		return err
+	}
+
+	if !schemaExists && legacyAppTablesExist {
+		if err := bootstrapLegacySchemaMigrations(ctx, db); err != nil {
+			return err
+		}
+	}
+
+	if err := ensureSchemaMigrationsTable(ctx, db); err != nil {
+		return err
+	}
+
+	appliedVersions, err := appliedMigrationVersions(ctx, db)
+	if err != nil {
+		return err
+	}
+
+	for _, migrationFile := range migrationFiles {
+		if appliedVersions[migrationFile.version] {
+			continue
+		}
+
+		if err := applyMigration(ctx, db, migrationFile); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func loadMigrationFiles() ([]migrationFile, error) {
+	entries, err := fs.ReadDir(migrations.SQLite, "sqlite")
+	if err != nil {
+		return nil, fmt.Errorf("read sqlite migrations: %w", err)
+	}
+
+	migrationFiles := make([]migrationFile, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+
+		name := entry.Name()
+		if filepath.Ext(name) != ".sql" {
+			continue
+		}
+
+		version, err := parseMigrationVersion(name)
+		if err != nil {
+			return nil, err
+		}
+
+		sqlBytes, err := fs.ReadFile(migrations.SQLite, filepath.Join("sqlite", name))
+		if err != nil {
+			return nil, fmt.Errorf("read sqlite migration %q: %w", name, err)
+		}
+
+		migrationFiles = append(migrationFiles, migrationFile{
+			version: version,
+			name:    name,
+			sql:     string(sqlBytes),
+		})
+	}
+
+	slices.SortFunc(migrationFiles, func(left, right migrationFile) int {
+		return left.version - right.version
+	})
+
+	return migrationFiles, nil
+}
+
+func parseMigrationVersion(name string) (int, error) {
+	prefix, _, ok := strings.Cut(name, "_")
+	if !ok {
+		return 0, fmt.Errorf("parse migration version from %q: missing underscore separator", name)
+	}
+
+	version, err := strconv.Atoi(prefix)
+	if err != nil {
+		return 0, fmt.Errorf("parse migration version from %q: %w", name, err)
+	}
+
+	return version, nil
+}
+
+func ensureSchemaMigrationsTable(ctx context.Context, db *sql.DB) error {
+	if _, err := db.ExecContext(ctx, `CREATE TABLE IF NOT EXISTS schema_migrations (
+		version INTEGER PRIMARY KEY,
+		applied_at TEXT NOT NULL
+	)`); err != nil {
+		return fmt.Errorf("ensure schema_migrations table: %w", err)
+	}
+
+	return nil
+}
+
+func appliedMigrationVersions(ctx context.Context, db *sql.DB) (map[int]bool, error) {
+	rows, err := db.QueryContext(ctx, `SELECT version FROM schema_migrations ORDER BY version ASC`)
+	if err != nil {
+		return nil, fmt.Errorf("query applied schema migrations: %w", err)
+	}
+	defer rows.Close()
+
+	appliedVersions := make(map[int]bool)
+	for rows.Next() {
+		var version int
+		if err := rows.Scan(&version); err != nil {
+			return nil, fmt.Errorf("scan applied schema migration: %w", err)
+		}
+		appliedVersions[version] = true
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate applied schema migrations: %w", err)
+	}
+
+	return appliedVersions, nil
+}
+
+func applyMigration(ctx context.Context, db *sql.DB, migrationFile migrationFile) error {
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin sqlite migration %s: %w", migrationFile.name, err)
+	}
+	defer func() {
+		rollbackErr := tx.Rollback()
+		if rollbackErr != nil && !errors.Is(rollbackErr, sql.ErrTxDone) {
+			return
+		}
+	}()
+
+	if _, err := tx.ExecContext(ctx, migrationFile.sql); err != nil {
+		return fmt.Errorf("execute sqlite migration %s: %w", migrationFile.name, err)
+	}
+
+	if _, err := tx.ExecContext(
+		ctx,
+		`INSERT INTO schema_migrations (version, applied_at) VALUES (?, ?)`,
+		migrationFile.version,
+		time.Now().UTC().Format(time.RFC3339Nano),
+	); err != nil {
+		return fmt.Errorf("record sqlite migration %s: %w", migrationFile.name, err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit sqlite migration %s: %w", migrationFile.name, err)
+	}
+
+	return nil
+}
+
+func bootstrapLegacySchemaMigrations(ctx context.Context, db *sql.DB) error {
+	if err := ensureSchemaMigrationsTable(ctx, db); err != nil {
+		return err
+	}
+
+	satisfiedVersions, err := detectLegacySatisfiedVersions(ctx, db)
+	if err != nil {
+		return err
+	}
+
+	for _, version := range satisfiedVersions {
+		if _, err := db.ExecContext(
+			ctx,
+			`INSERT OR IGNORE INTO schema_migrations (version, applied_at) VALUES (?, ?)`,
+			version,
+			time.Now().UTC().Format(time.RFC3339Nano),
+		); err != nil {
+			return fmt.Errorf("record legacy sqlite migration version %d: %w", version, err)
+		}
+	}
+
+	return nil
+}
+
+func detectLegacySatisfiedVersions(ctx context.Context, db *sql.DB) ([]int, error) {
+	threadBindingsExists, err := tableExists(ctx, db, "thread_bindings")
+	if err != nil {
+		return nil, err
+	}
+
+	tasksExists, err := tableExists(ctx, db, "tasks")
+	if err != nil {
+		return nil, err
+	}
+
+	activeTasksExists, err := tableExists(ctx, db, "active_tasks")
+	if err != nil {
+		return nil, err
+	}
+
+	if !threadBindingsExists || !tasksExists || !activeTasksExists {
+		return nil, fmt.Errorf("bootstrap legacy sqlite schema: unsupported legacy table set")
+	}
+
+	satisfiedVersions := []int{1}
+
+	taskColumns, err := tableColumnNames(ctx, db, "tasks")
+	if err != nil {
+		return nil, err
+	}
+
+	if hasAllColumns(taskColumns, legacyTaskWorktreeColumns) {
+		if _, err := db.ExecContext(
+			ctx,
+			`UPDATE tasks SET branch_name = 'task/' || task_id WHERE branch_name = ''`,
+		); err != nil {
+			return nil, fmt.Errorf("backfill legacy task branch names during bootstrap: %w", err)
+		}
+
+		satisfiedVersions = append(satisfiedVersions, taskWorktreeMetadataVersion)
+	}
+
+	return satisfiedVersions, nil
+}
+
+func applicationTablesExist(ctx context.Context, db *sql.DB) (bool, error) {
+	for _, tableName := range []string{"thread_bindings", "tasks", "active_tasks"} {
+		exists, err := tableExists(ctx, db, tableName)
+		if err != nil {
+			return false, err
+		}
+
+		if exists {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+func tableExists(ctx context.Context, db *sql.DB, tableName string) (bool, error) {
+	row := db.QueryRowContext(
+		ctx,
+		`SELECT EXISTS(
+			SELECT 1
+			FROM sqlite_master
+			WHERE type = 'table' AND name = ?
+		)`,
+		tableName,
+	)
+
+	var exists bool
+	if err := row.Scan(&exists); err != nil {
+		return false, fmt.Errorf("query sqlite table %q existence: %w", tableName, err)
+	}
+
+	return exists, nil
+}
+
+func tableColumnNames(ctx context.Context, db *sql.DB, tableName string) ([]string, error) {
+	rows, err := db.QueryContext(ctx, fmt.Sprintf(`PRAGMA table_info(%s)`, tableName))
+	if err != nil {
+		return nil, fmt.Errorf("query sqlite table %q info: %w", tableName, err)
+	}
+	defer rows.Close()
+
+	columnNames := make([]string, 0)
+	for rows.Next() {
+		var cid int
+		var name string
+		var columnType string
+		var notNull int
+		var defaultValue sql.NullString
+		var primaryKey int
+		if err := rows.Scan(&cid, &name, &columnType, &notNull, &defaultValue, &primaryKey); err != nil {
+			return nil, fmt.Errorf("scan sqlite table %q info: %w", tableName, err)
+		}
+		columnNames = append(columnNames, name)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate sqlite table %q info: %w", tableName, err)
+	}
+
+	return columnNames, nil
+}
+
+func hasAllColumns(existingColumns []string, requiredColumns []string) bool {
+	existing := make(map[string]struct{}, len(existingColumns))
+	for _, columnName := range existingColumns {
+		existing[columnName] = struct{}{}
+	}
+
+	for _, requiredColumn := range requiredColumns {
+		if _, ok := existing[requiredColumn]; !ok {
+			return false
+		}
+	}
+
+	return true
+}

--- a/internal/store/sqlite/migrate_test.go
+++ b/internal/store/sqlite/migrate_test.go
@@ -1,0 +1,180 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"slices"
+	"testing"
+)
+
+func TestMigrateFreshDatabase(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "39claw.db")
+	db, err := OpenDB(context.Background(), path)
+	if err != nil {
+		t.Fatalf("OpenDB() error = %v", err)
+	}
+	defer func() {
+		if closeErr := db.Close(); closeErr != nil {
+			t.Fatalf("db.Close() error = %v", closeErr)
+		}
+	}()
+
+	if err := Migrate(context.Background(), db); err != nil {
+		t.Fatalf("Migrate() error = %v", err)
+	}
+
+	versions := appliedVersionsForTest(t, db)
+	if !slices.Equal(versions, []int{1, 2}) {
+		t.Fatalf("applied migration versions = %v, want %v", versions, []int{1, 2})
+	}
+
+	for _, tableName := range []string{"schema_migrations", "thread_bindings", "tasks", "active_tasks"} {
+		exists, err := tableExists(context.Background(), db, tableName)
+		if err != nil {
+			t.Fatalf("tableExists(%q) error = %v", tableName, err)
+		}
+		if !exists {
+			t.Fatalf("table %q exists = false, want true", tableName)
+		}
+	}
+
+	taskColumns, err := tableColumnNames(context.Background(), db, "tasks")
+	if err != nil {
+		t.Fatalf("tableColumnNames(tasks) error = %v", err)
+	}
+
+	if !hasAllColumns(taskColumns, legacyTaskWorktreeColumns) {
+		t.Fatalf("tasks columns = %v, want worktree metadata columns present", taskColumns)
+	}
+}
+
+func TestMigrateLegacyDatabaseBootstrapRecognizesLatestSchema(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "39claw.db")
+	db, err := sql.Open(driverName, path)
+	if err != nil {
+		t.Fatalf("sql.Open() error = %v", err)
+	}
+
+	ctx := context.Background()
+	if _, err := db.ExecContext(ctx, `CREATE TABLE thread_bindings (
+		mode TEXT NOT NULL,
+		logical_thread_key TEXT NOT NULL,
+		codex_thread_id TEXT NOT NULL,
+		task_id TEXT NULL,
+		created_at TEXT NOT NULL,
+		updated_at TEXT NOT NULL,
+		PRIMARY KEY (mode, logical_thread_key)
+	);`); err != nil {
+		t.Fatalf("create thread_bindings table error = %v", err)
+	}
+
+	if _, err := db.ExecContext(ctx, `CREATE TABLE tasks (
+		task_id TEXT PRIMARY KEY,
+		discord_user_id TEXT NOT NULL,
+		task_name TEXT NOT NULL,
+		status TEXT NOT NULL,
+		branch_name TEXT NOT NULL DEFAULT '',
+		base_ref TEXT NULL,
+		worktree_path TEXT NULL,
+		worktree_status TEXT NOT NULL DEFAULT 'pending',
+		created_at TEXT NOT NULL,
+		updated_at TEXT NOT NULL,
+		closed_at TEXT NULL,
+		worktree_created_at TEXT NULL,
+		worktree_pruned_at TEXT NULL,
+		last_used_at TEXT NULL
+	);`); err != nil {
+		t.Fatalf("create tasks table error = %v", err)
+	}
+
+	if _, err := db.ExecContext(ctx, `CREATE TABLE active_tasks (
+		discord_user_id TEXT PRIMARY KEY,
+		task_id TEXT NOT NULL,
+		updated_at TEXT NOT NULL
+	);`); err != nil {
+		t.Fatalf("create active_tasks table error = %v", err)
+	}
+
+	if _, err := db.ExecContext(
+		ctx,
+		`INSERT INTO tasks (
+			task_id, discord_user_id, task_name, status, branch_name, base_ref, worktree_path, worktree_status,
+			created_at, updated_at, closed_at, worktree_created_at, worktree_pruned_at, last_used_at
+		) VALUES (?, ?, ?, ?, ?, NULL, NULL, ?, ?, ?, NULL, NULL, NULL, NULL)`,
+		"task-1",
+		"user-1",
+		"Already migrated task",
+		"open",
+		"",
+		"pending",
+		"2026-04-05T15:04:00Z",
+		"2026-04-05T15:04:00Z",
+	); err != nil {
+		t.Fatalf("insert latest legacy task error = %v", err)
+	}
+
+	if err := db.Close(); err != nil {
+		t.Fatalf("db.Close() error = %v", err)
+	}
+
+	reopened, err := OpenDB(context.Background(), path)
+	if err != nil {
+		t.Fatalf("OpenDB() reopen error = %v", err)
+	}
+	defer func() {
+		if closeErr := reopened.Close(); closeErr != nil {
+			t.Fatalf("reopened.Close() error = %v", closeErr)
+		}
+	}()
+
+	if err := Migrate(ctx, reopened); err != nil {
+		t.Fatalf("Migrate() reopen error = %v", err)
+	}
+
+	versions := appliedVersionsForTest(t, reopened)
+	if !slices.Equal(versions, []int{1, 2}) {
+		t.Fatalf("applied migration versions = %v, want %v", versions, []int{1, 2})
+	}
+
+	store := New(reopened)
+	task, ok, err := store.GetTask(ctx, "user-1", "task-1")
+	if err != nil {
+		t.Fatalf("GetTask() error = %v", err)
+	}
+	if !ok {
+		t.Fatal("GetTask() ok = false, want true")
+	}
+	if task.BranchName != "task/task-1" {
+		t.Fatalf("BranchName = %q, want %q", task.BranchName, "task/task-1")
+	}
+}
+
+func appliedVersionsForTest(t *testing.T, db *sql.DB) []int {
+	t.Helper()
+
+	rows, err := db.QueryContext(context.Background(), `SELECT version FROM schema_migrations ORDER BY version ASC`)
+	if err != nil {
+		t.Fatalf("query schema_migrations versions error = %v", err)
+	}
+	defer rows.Close()
+
+	versions := make([]int, 0)
+	for rows.Next() {
+		var version int
+		if err := rows.Scan(&version); err != nil {
+			t.Fatalf("scan schema_migrations version error = %v", err)
+		}
+		versions = append(versions, version)
+	}
+
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate schema_migrations versions error = %v", err)
+	}
+
+	return versions
+}

--- a/internal/store/sqlite/store.go
+++ b/internal/store/sqlite/store.go
@@ -5,8 +5,6 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"os"
-	"path/filepath"
 	"time"
 
 	"github.com/HatsuneMiku3939/39claw/internal/app"
@@ -15,53 +13,9 @@ import (
 	_ "modernc.org/sqlite"
 )
 
-const (
-	driverName               = "sqlite"
-	sqliteDirectoryPermsMode = 0o755
-)
-
-var taskColumnDefinitions = []struct {
-	name       string
-	definition string
-}{
-	{name: "branch_name", definition: `TEXT NOT NULL DEFAULT ''`},
-	{name: "base_ref", definition: `TEXT NULL`},
-	{name: "worktree_path", definition: `TEXT NULL`},
-	{name: "worktree_status", definition: `TEXT NOT NULL DEFAULT 'pending'`},
-	{name: "worktree_created_at", definition: `TEXT NULL`},
-	{name: "worktree_pruned_at", definition: `TEXT NULL`},
-	{name: "last_used_at", definition: `TEXT NULL`},
-}
-
 type Store struct {
 	db    *sql.DB
 	clock func() time.Time
-}
-
-func Open(path string) (*Store, error) {
-	if path == "" {
-		return nil, errors.New("sqlite path must not be empty")
-	}
-
-	if path != ":memory:" {
-		dir := filepath.Dir(path)
-		if dir != "." {
-			if err := os.MkdirAll(dir, sqliteDirectoryPermsMode); err != nil {
-				return nil, fmt.Errorf("create sqlite directory: %w", err)
-			}
-		}
-	}
-
-	db, err := sql.Open(driverName, path)
-	if err != nil {
-		return nil, fmt.Errorf("open sqlite database: %w", err)
-	}
-
-	db.SetMaxOpenConns(1)
-	return &Store{
-		db:    db,
-		clock: time.Now().UTC,
-	}, nil
 }
 
 func New(db *sql.DB) *Store {
@@ -76,57 +30,7 @@ func (s *Store) Close() error {
 }
 
 func (s *Store) InitSchema(ctx context.Context) error {
-	statements := []string{
-		`CREATE TABLE IF NOT EXISTS thread_bindings (
-			mode TEXT NOT NULL,
-			logical_thread_key TEXT NOT NULL,
-			codex_thread_id TEXT NOT NULL,
-			task_id TEXT NULL,
-			created_at TEXT NOT NULL,
-			updated_at TEXT NOT NULL,
-			PRIMARY KEY (mode, logical_thread_key)
-		);`,
-		`CREATE TABLE IF NOT EXISTS tasks (
-			task_id TEXT PRIMARY KEY,
-			discord_user_id TEXT NOT NULL,
-			task_name TEXT NOT NULL,
-			status TEXT NOT NULL,
-			branch_name TEXT NOT NULL DEFAULT '',
-			base_ref TEXT NULL,
-			worktree_path TEXT NULL,
-			worktree_status TEXT NOT NULL DEFAULT 'pending',
-			created_at TEXT NOT NULL,
-			updated_at TEXT NOT NULL,
-			closed_at TEXT NULL,
-			worktree_created_at TEXT NULL,
-			worktree_pruned_at TEXT NULL,
-			last_used_at TEXT NULL
-		);`,
-		`CREATE TABLE IF NOT EXISTS active_tasks (
-			discord_user_id TEXT PRIMARY KEY,
-			task_id TEXT NOT NULL,
-			updated_at TEXT NOT NULL
-		);`,
-	}
-
-	for _, statement := range statements {
-		if _, err := s.db.ExecContext(ctx, statement); err != nil {
-			return fmt.Errorf("exec schema statement: %w", err)
-		}
-	}
-
-	if err := s.ensureTaskColumns(ctx); err != nil {
-		return err
-	}
-
-	if _, err := s.db.ExecContext(
-		ctx,
-		`UPDATE tasks SET branch_name = 'task/' || task_id WHERE branch_name = ''`,
-	); err != nil {
-		return fmt.Errorf("backfill task branch names: %w", err)
-	}
-
-	return nil
+	return Migrate(ctx, s.db)
 }
 
 func (s *Store) GetThreadBinding(ctx context.Context, mode string, logicalThreadKey string) (app.ThreadBinding, bool, error) {
@@ -577,45 +481,6 @@ func scanTask(scanner interface{ Scan(dest ...any) error }) (app.Task, bool, err
 	}
 
 	return task, true, nil
-}
-
-func (s *Store) ensureTaskColumns(ctx context.Context) error {
-	rows, err := s.db.QueryContext(ctx, `PRAGMA table_info(tasks)`)
-	if err != nil {
-		return fmt.Errorf("query task table info: %w", err)
-	}
-	defer rows.Close()
-
-	existingColumns := make(map[string]struct{})
-	for rows.Next() {
-		var cid int
-		var name string
-		var columnType string
-		var notNull int
-		var defaultValue sql.NullString
-		var primaryKey int
-		if err := rows.Scan(&cid, &name, &columnType, &notNull, &defaultValue, &primaryKey); err != nil {
-			return fmt.Errorf("scan task table info: %w", err)
-		}
-		existingColumns[name] = struct{}{}
-	}
-
-	if err := rows.Err(); err != nil {
-		return fmt.Errorf("iterate task table info: %w", err)
-	}
-
-	for _, column := range taskColumnDefinitions {
-		if _, ok := existingColumns[column.name]; ok {
-			continue
-		}
-
-		statement := fmt.Sprintf(`ALTER TABLE tasks ADD COLUMN %s %s`, column.name, column.definition)
-		if _, err := s.db.ExecContext(ctx, statement); err != nil {
-			return fmt.Errorf("add tasks.%s column: %w", column.name, err)
-		}
-	}
-
-	return nil
 }
 
 func nullableString(value string) any {

--- a/internal/store/sqlite/store_test.go
+++ b/internal/store/sqlite/store_test.go
@@ -11,15 +11,32 @@ import (
 	"github.com/HatsuneMiku3939/39claw/internal/app"
 )
 
-func TestStoreInitSchemaIsIdempotent(t *testing.T) {
+func TestMigrateIsIdempotent(t *testing.T) {
 	t.Parallel()
 
-	store := newTestStore(t)
+	db, err := OpenDB(context.Background(), filepath.Join(t.TempDir(), "39claw.db"))
+	if err != nil {
+		t.Fatalf("OpenDB() error = %v", err)
+	}
+	defer func() {
+		if closeErr := db.Close(); closeErr != nil {
+			t.Fatalf("db.Close() error = %v", closeErr)
+		}
+	}()
 
 	for i := 0; i < 2; i++ {
-		if err := store.InitSchema(context.Background()); err != nil {
-			t.Fatalf("InitSchema() error = %v", err)
+		if err := Migrate(context.Background(), db); err != nil {
+			t.Fatalf("Migrate() error = %v", err)
 		}
+	}
+
+	var count int
+	if err := db.QueryRowContext(context.Background(), `SELECT COUNT(*) FROM schema_migrations`).Scan(&count); err != nil {
+		t.Fatalf("query schema_migrations count error = %v", err)
+	}
+
+	if count != 2 {
+		t.Fatalf("schema_migrations count = %d, want %d", count, 2)
 	}
 }
 
@@ -80,18 +97,7 @@ func TestStoreThreadBindingPersistsAcrossReopen(t *testing.T) {
 
 	path := filepath.Join(t.TempDir(), "39claw.db")
 
-	store, err := Open(path)
-	if err != nil {
-		t.Fatalf("Open() error = %v", err)
-	}
-
-	store.clock = func() time.Time {
-		return time.Date(2026, time.April, 5, 15, 4, 0, 0, time.UTC)
-	}
-
-	if err := store.InitSchema(context.Background()); err != nil {
-		t.Fatalf("InitSchema() error = %v", err)
-	}
+	store := newMigratedStoreAtPath(t, path)
 
 	if err := store.UpsertThreadBinding(context.Background(), app.ThreadBinding{
 		Mode:             "daily",
@@ -105,19 +111,12 @@ func TestStoreThreadBindingPersistsAcrossReopen(t *testing.T) {
 		t.Fatalf("Close() error = %v", err)
 	}
 
-	reopened, err := Open(path)
-	if err != nil {
-		t.Fatalf("Open() reopen error = %v", err)
-	}
+	reopened := newMigratedStoreAtPath(t, path)
 	defer func() {
 		if closeErr := reopened.Close(); closeErr != nil {
 			t.Fatalf("Close() reopen error = %v", closeErr)
 		}
 	}()
-
-	if err := reopened.InitSchema(context.Background()); err != nil {
-		t.Fatalf("InitSchema() reopen error = %v", err)
-	}
 
 	binding, ok, err := reopened.GetThreadBinding(context.Background(), "daily", "2026-04-05")
 	if err != nil {
@@ -138,19 +137,8 @@ func TestStoreTaskStatePersistsAcrossReopen(t *testing.T) {
 
 	path := filepath.Join(t.TempDir(), "39claw.db")
 
-	store, err := Open(path)
-	if err != nil {
-		t.Fatalf("Open() error = %v", err)
-	}
-
-	store.clock = func() time.Time {
-		return time.Date(2026, time.April, 5, 15, 4, 0, 0, time.UTC)
-	}
-
+	store := newMigratedStoreAtPath(t, path)
 	ctx := context.Background()
-	if err := store.InitSchema(ctx); err != nil {
-		t.Fatalf("InitSchema() error = %v", err)
-	}
 
 	if err := store.CreateTask(ctx, app.Task{
 		TaskID:        "task-1",
@@ -171,19 +159,12 @@ func TestStoreTaskStatePersistsAcrossReopen(t *testing.T) {
 		t.Fatalf("Close() error = %v", err)
 	}
 
-	reopened, err := Open(path)
-	if err != nil {
-		t.Fatalf("Open() reopen error = %v", err)
-	}
+	reopened := newMigratedStoreAtPath(t, path)
 	defer func() {
 		if closeErr := reopened.Close(); closeErr != nil {
 			t.Fatalf("Close() reopen error = %v", closeErr)
 		}
 	}()
-
-	if err := reopened.InitSchema(ctx); err != nil {
-		t.Fatalf("InitSchema() reopen error = %v", err)
-	}
 
 	task, ok, err := reopened.GetTask(ctx, "user-1", "task-1")
 	if err != nil {
@@ -374,7 +355,7 @@ func TestStoreCloseTaskKeepsDifferentActiveTask(t *testing.T) {
 	}
 }
 
-func TestStoreInitSchemaMigratesExistingTaskTable(t *testing.T) {
+func TestMigrateLegacyDatabaseBootstrapAddsTaskWorktreeColumns(t *testing.T) {
 	t.Parallel()
 
 	path := filepath.Join(t.TempDir(), "39claw.db")
@@ -382,6 +363,18 @@ func TestStoreInitSchemaMigratesExistingTaskTable(t *testing.T) {
 	db, err := sql.Open(driverName, path)
 	if err != nil {
 		t.Fatalf("sql.Open() error = %v", err)
+	}
+
+	if _, err := db.ExecContext(context.Background(), `CREATE TABLE thread_bindings (
+		mode TEXT NOT NULL,
+		logical_thread_key TEXT NOT NULL,
+		codex_thread_id TEXT NOT NULL,
+		task_id TEXT NULL,
+		created_at TEXT NOT NULL,
+		updated_at TEXT NOT NULL,
+		PRIMARY KEY (mode, logical_thread_key)
+	);`); err != nil {
+		t.Fatalf("create legacy thread_bindings table error = %v", err)
 	}
 
 	if _, err := db.ExecContext(context.Background(), `CREATE TABLE tasks (
@@ -394,6 +387,14 @@ func TestStoreInitSchemaMigratesExistingTaskTable(t *testing.T) {
 		closed_at TEXT NULL
 	);`); err != nil {
 		t.Fatalf("create legacy tasks table error = %v", err)
+	}
+
+	if _, err := db.ExecContext(context.Background(), `CREATE TABLE active_tasks (
+		discord_user_id TEXT PRIMARY KEY,
+		task_id TEXT NOT NULL,
+		updated_at TEXT NOT NULL
+	);`); err != nil {
+		t.Fatalf("create legacy active_tasks table error = %v", err)
 	}
 
 	createdAt := time.Date(2026, time.April, 5, 15, 4, 0, 0, time.UTC).Format(time.RFC3339Nano)
@@ -415,19 +416,7 @@ func TestStoreInitSchemaMigratesExistingTaskTable(t *testing.T) {
 		t.Fatalf("db.Close() error = %v", err)
 	}
 
-	store, err := Open(path)
-	if err != nil {
-		t.Fatalf("Open() error = %v", err)
-	}
-	defer func() {
-		if closeErr := store.Close(); closeErr != nil {
-			t.Fatalf("Close() error = %v", closeErr)
-		}
-	}()
-
-	if err := store.InitSchema(context.Background()); err != nil {
-		t.Fatalf("InitSchema() error = %v", err)
-	}
+	store := newMigratedStoreAtPath(t, path)
 
 	task, ok, err := store.GetTask(context.Background(), "user-1", "task-1")
 	if err != nil {
@@ -506,24 +495,32 @@ func TestStoreUpdateTaskAndListClosedReadyTasks(t *testing.T) {
 func newTestStore(t *testing.T) *Store {
 	t.Helper()
 
-	store, err := Open(filepath.Join(t.TempDir(), "39claw.db"))
-	if err != nil {
-		t.Fatalf("Open() error = %v", err)
-	}
-
-	store.clock = func() time.Time {
-		return time.Date(2026, time.April, 5, 15, 4, 0, 0, time.UTC)
-	}
-
-	if err := store.InitSchema(context.Background()); err != nil {
-		t.Fatalf("InitSchema() error = %v", err)
-	}
-
+	store := newMigratedStoreAtPath(t, filepath.Join(t.TempDir(), "39claw.db"))
 	t.Cleanup(func() {
 		if closeErr := store.Close(); closeErr != nil {
 			t.Fatalf("Close() error = %v", closeErr)
 		}
 	})
+
+	return store
+}
+
+func newMigratedStoreAtPath(t *testing.T, path string) *Store {
+	t.Helper()
+
+	db, err := OpenDB(context.Background(), path)
+	if err != nil {
+		t.Fatalf("OpenDB() error = %v", err)
+	}
+
+	if err := Migrate(context.Background(), db); err != nil {
+		t.Fatalf("Migrate() error = %v", err)
+	}
+
+	store := New(db)
+	store.clock = func() time.Time {
+		return time.Date(2026, time.April, 5, 15, 4, 0, 0, time.UTC)
+	}
 
 	return store
 }

--- a/migrations/embed.go
+++ b/migrations/embed.go
@@ -1,0 +1,8 @@
+package migrations
+
+import "embed"
+
+// SQLite contains the embedded SQLite migration files.
+//
+//go:embed sqlite/*.sql
+var SQLite embed.FS

--- a/migrations/sqlite/0001_initial_schema.sql
+++ b/migrations/sqlite/0001_initial_schema.sql
@@ -1,0 +1,25 @@
+CREATE TABLE IF NOT EXISTS thread_bindings (
+    mode TEXT NOT NULL,
+    logical_thread_key TEXT NOT NULL,
+    codex_thread_id TEXT NOT NULL,
+    task_id TEXT NULL,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    PRIMARY KEY (mode, logical_thread_key)
+);
+
+CREATE TABLE IF NOT EXISTS tasks (
+    task_id TEXT PRIMARY KEY,
+    discord_user_id TEXT NOT NULL,
+    task_name TEXT NOT NULL,
+    status TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    closed_at TEXT NULL
+);
+
+CREATE TABLE IF NOT EXISTS active_tasks (
+    discord_user_id TEXT PRIMARY KEY,
+    task_id TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+);

--- a/migrations/sqlite/0002_task_worktree_metadata.sql
+++ b/migrations/sqlite/0002_task_worktree_metadata.sql
@@ -1,0 +1,11 @@
+ALTER TABLE tasks ADD COLUMN branch_name TEXT NOT NULL DEFAULT '';
+ALTER TABLE tasks ADD COLUMN base_ref TEXT NULL;
+ALTER TABLE tasks ADD COLUMN worktree_path TEXT NULL;
+ALTER TABLE tasks ADD COLUMN worktree_status TEXT NOT NULL DEFAULT 'pending';
+ALTER TABLE tasks ADD COLUMN worktree_created_at TEXT NULL;
+ALTER TABLE tasks ADD COLUMN worktree_pruned_at TEXT NULL;
+ALTER TABLE tasks ADD COLUMN last_used_at TEXT NULL;
+
+UPDATE tasks
+SET branch_name = 'task/' || task_id
+WHERE branch_name = '';


### PR DESCRIPTION
## Summary

- add embedded versioned SQLite migrations and a migration runner
- move startup to `OpenDB -> Migrate -> New`
- bootstrap known legacy databases into `schema_migrations`

## Background

The SQLite store previously created and mutated schema inline inside store code. That made future schema changes harder to reason about and left no durable migration history for existing local databases.

## Related issue(s)

- None.

## Implementation details

- added `migrations/embed.go` and `migrations/sqlite/*.sql` for the baseline schema and the historical task worktree metadata upgrade
- added `internal/store/sqlite/db.go` for database opening and SQLite pragma setup
- added `internal/store/sqlite/migrate.go` for ordered migration execution, applied-version tracking, and legacy bootstrap reconciliation
- updated `cmd/39claw/main.go` to run migrations before constructing the store
- kept `InitSchema()` as a thin compatibility shim and replaced inline-schema test assumptions with migration-focused coverage
- updated the migration design doc and execution plans so future schema work targets versioned SQL files

## Test coverage

- `go test ./internal/store/sqlite -run 'TestStore|TestMigrate' -v`
- `go test ./cmd/39claw -v`
- `go test ./...`
- `./scripts/lint -c .golangci.yml`

## Breaking changes

- None.

## Notes

- legacy bootstrap intentionally supports only schema shapes previously produced by 39claw
- `make` is not installed in this environment, so equivalent direct validation commands were used

Created by Codex