### PR TITLE
Add daily generation rotation and clear command

### DIFF
--- a/cmd/39claw/main.go
+++ b/cmd/39claw/main.go
@@ -157,13 +157,24 @@ func run(ctx context.Context, lookupEnv func(string) (string, bool)) error {
 		ThreadOptions: threadOptions,
 	})
 
+	coordinator := thread.NewQueueCoordinator()
 	var dailyMemory app.DailyMemoryRefresher
+	var dailyCommand app.DailyCommandService
 	if cfg.Mode == config.ModeDaily {
 		dailyMemory = dailymemory.Refresher{
-			Timezone: cfg.Timezone,
-			Store:    store,
-			Gateway:  gateway,
-			Workdir:  cfg.CodexWorkdir,
+			Store:   store,
+			Gateway: gateway,
+			Workdir: cfg.CodexWorkdir,
+		}
+
+		dailyCommand, err = app.NewDailyCommandService(app.DailyCommandServiceDependencies{
+			CommandName: cfg.DiscordCommandName,
+			Timezone:    cfg.Timezone,
+			Store:       store,
+			Coordinator: coordinator,
+		})
+		if err != nil {
+			return fmt.Errorf("build daily command service: %w", err)
 		}
 	}
 
@@ -193,7 +204,7 @@ func run(ctx context.Context, lookupEnv func(string) (string, bool)) error {
 		WorkspaceManager: workspaceManager,
 		DailyMemory:      dailyMemory,
 		Gateway:          gateway,
-		Coordinator:      thread.NewQueueCoordinator(),
+		Coordinator:      coordinator,
 	})
 	if err != nil {
 		return fmt.Errorf("build message service: %w", err)
@@ -209,10 +220,11 @@ func run(ctx context.Context, lookupEnv func(string) (string, bool)) error {
 	}
 
 	runtime, err := newDiscordRuntime(runtimediscord.Dependencies{
-		Config:      cfg,
-		Logger:      logger,
-		Message:     messageService,
-		TaskCommand: taskService,
+		Config:       cfg,
+		Logger:       logger,
+		Message:      messageService,
+		DailyCommand: dailyCommand,
+		TaskCommand:  taskService,
 	})
 	if err != nil {
 		return fmt.Errorf("build discord runtime: %w", err)

--- a/docs/exec-plans/completed/12-daily-clear-generation.md
+++ b/docs/exec-plans/completed/12-daily-clear-generation.md
@@ -14,13 +14,13 @@ This change matters because `daily` mode currently keeps one remote Codex thread
 
 - [x] (2026-04-06 00:00Z) Reviewed the current `daily` routing, daily-memory, command-surface, and SQLite design and captured the agreed direction for shared same-day generation rotation.
 - [x] (2026-04-06 00:00Z) Updated architecture, design, README, and product documents so the repository now describes `daily` mode as one active shared generation per day with `action:clear` and generation-scoped bridge notes.
-- [ ] Add explicit `daily_sessions` persistence and migrate legacy `daily` thread bindings from `YYYY-MM-DD` to `YYYY-MM-DD#1`.
-- [ ] Resolve the active `daily` generation through store-backed metadata before visible turns load or persist thread bindings.
-- [ ] Add `action:clear` to the `daily` command surface and route it through a dedicated app-level daily command service.
-- [ ] Extend queue coordination so `action:clear` can reject rotation while the current active generation is busy or queued.
-- [ ] Run the durable-memory preflight once per fresh generation and write `AGENT_MEMORY/YYYY-MM-DD.<generation>.md`.
-- [ ] Add tests for migration, same-day rotation, clear rejection while busy, same-day preflight after clear, and next-day carry-over from the last active prior-day generation.
-- [ ] Run `make test` and `make lint`, then update this plan with proof artifacts and any deferred follow-up work.
+- [x] (2026-04-10 00:15Z) Added `0003_daily_sessions.sql`, created explicit `daily_sessions` persistence, and migrated legacy `daily` thread bindings from bare `YYYY-MM-DD` keys to `YYYY-MM-DD#1`.
+- [x] (2026-04-10 00:20Z) Added store-backed daily-session APIs plus an application-layer resolver so visible `daily` turns always target the active generation key before binding lookup.
+- [x] (2026-04-10 00:25Z) Added `action:clear` to the `daily` command surface and routed it through a dedicated app-level `DailyCommandService`.
+- [x] (2026-04-10 00:30Z) Extended queue coordination with snapshots so `action:clear` rejects rotation while the current active generation is busy or queued.
+- [x] (2026-04-10 00:35Z) Changed the daily-memory preflight to operate per generation and write generation-scoped bridge notes such as `AGENT_MEMORY/YYYY-MM-DD.<generation>.md`.
+- [x] (2026-04-10 00:45Z) Added migration, store, app, runtime, queue, and daily-memory tests for same-day generation reuse, clear rotation, busy clear rejection, same-day preflight after clear, and next-day carry-over from the last active prior-day generation.
+- [x] (2026-04-10 00:50Z) Ran `go test ./...` and `./scripts/lint -c .golangci.yml`; `make` is not installed in this environment, so the repository-equivalent direct commands were used instead.
 
 ## Surprises & Discoveries
 
@@ -32,6 +32,12 @@ This change matters because `daily` mode currently keeps one remote Codex thread
 
 - Observation: The Discord root command already centralizes discovery for both modes. Extending it with `action:clear` is cleaner than introducing a second standalone slash command.
   Evidence: `internal/runtime/discord/commands.go`, `internal/runtime/discord/runtime.go`
+
+- Observation: Persisting `daily_sessions` separately from `thread_bindings` kept Codex thread IDs as the only binding truth while still giving the application layer deterministic generation metadata. That split let legacy key migration stay small and testable.
+  Evidence: `migrations/sqlite/0003_daily_sessions.sql`, `internal/store/sqlite/daily_sessions.go`
+
+- Observation: The same queue snapshot is sufficient for both normal message admission and safe clear rejection; no second queue or daily-specific coordinator was needed.
+  Evidence: `internal/thread/queue.go`, `internal/app/daily_command_service.go`
 
 ## Decision Log
 
@@ -55,9 +61,19 @@ This change matters because `daily` mode currently keeps one remote Codex thread
   Rationale: One date can now have multiple fresh starts, so the bridge note must identify which generation it belongs to while keeping `MEMORY.md` as the single durable summary file.
   Date/Author: 2026-04-06 / Codex
 
+- Decision: Keep `action:clear` success responses explicit about the active generation key instead of only promising that the next mention will be fresh.
+  Rationale: The generation key is the exact state change the command performs, and exposing it makes tests and operator reasoning simpler without changing the user workflow.
+  Date/Author: 2026-04-10 / Codex
+
+- Decision: Let the app-level daily-session resolver create generation `#1`, while keeping same-day rotation itself transactional inside the store.
+  Rationale: First-use creation depends on previous-day lookup policy, while same-day clear must atomically deactivate the current generation and insert the next one. Splitting responsibilities this way keeps each layer narrow.
+  Date/Author: 2026-04-10 / Codex
+
 ## Outcomes & Retrospective
 
-Implementation has not started yet. The intended outcome is a `daily` mode that still behaves like a shared day-based assistant but can intentionally rotate to a fresh same-day Codex thread when conversation length becomes a problem. This plan will be complete when the runtime can persist active daily generations, expose `action:clear`, reject clear while busy, refresh durable memory from the previous recorded generation, and prove the full behavior through automated tests.
+Implementation completed on 2026-04-10. `daily` mode now persists active same-day generations in `daily_sessions`, rewrites legacy bare-date bindings to `#1`, resolves the active generation before visible turns, and exposes `/<instance-command> action:clear` for shared same-day rotation.
+
+The main tradeoff is that normal `daily` message routing still starts from the date bucket returned by `thread.Policy`, but the application layer immediately expands that bucket into generation metadata before any preflight or binding lookup happens. That kept the thread policy contract stable while still moving all visible `daily` behavior onto generation keys such as `2026-04-10#2`.
 
 ## Context and Orientation
 
@@ -109,9 +125,9 @@ Start this plan only after confirming the repository still matches these assumpt
 
 Verify that state with:
 
-    cd /home/filepang/playground/39claw
-    make test
-    make lint
+    cd /home/filepang/workspaces/39claw/39claw
+    go test ./...
+    ./scripts/lint -c .golangci.yml
 
 If the repository has drifted away from that shape, update this ExecPlan first so it remains self-contained and truthful.
 
@@ -250,12 +266,12 @@ Finally, update tests and rerun the full checks. This plan is not complete until
 
 ## Concrete Steps
 
-Run all commands from `/home/filepang/playground/39claw`.
+Run all commands from `/home/filepang/workspaces/39claw/39claw`.
 
 1. Confirm the starting state and baseline health.
 
-    make test
-    make lint
+    go test ./...
+    ./scripts/lint -c .golangci.yml
 
 2. Implement the store and migration changes, then run focused store tests.
 
@@ -271,8 +287,8 @@ Run all commands from `/home/filepang/playground/39claw`.
 
 5. Run the full repository checks.
 
-    make test
-    make lint
+    go test ./...
+    ./scripts/lint -c .golangci.yml
 
 6. Record concise proof artifacts in this plan before marking it complete.
 
@@ -292,8 +308,8 @@ This plan is complete when all of the following are true:
 - the first visible message on a new local day starts generation `#1` and uses the last active prior-day generation as the preflight source
 - bridge notes are written to `AGENT_MEMORY/YYYY-MM-DD.<generation>.md`
 - `MEMORY.md` remains the primary durable-memory file
-- `make test` passes
-- `make lint` passes
+- `go test ./...` passes
+- `./scripts/lint -c .golangci.yml` passes
 
 The most important human-readable proof scenario is:
 
@@ -334,13 +350,13 @@ Useful bridge note paths:
     AGENT_MEMORY/2026-04-06.2.md
     AGENT_MEMORY/2026-04-07.1.md
 
-Suggested success response for `action:clear`:
+Implemented success response for `action:clear`:
 
-    Started a fresh shared daily session for today. Your next mention will use a new thread.
+    Started a fresh shared daily conversation for today. The active generation is now `YYYY-MM-DD#2`.
 
-Suggested rejection response for `action:clear` while busy:
+Implemented rejection response for `action:clear` while busy:
 
-    The current shared daily session is still busy. Please wait for queued work to finish, then retry `action:clear`.
+    Today's shared daily conversation is still busy. Wait for pending replies to finish, then retry `/<instance-command> action:clear`.
 
 ## Interfaces and Dependencies
 
@@ -361,8 +377,8 @@ Extend the app-facing store contract with daily-session methods equivalent to:
 
     GetActiveDailySession(ctx context.Context, localDate string) (DailySession, bool, error)
     GetLatestDailySessionBefore(ctx context.Context, localDate string) (DailySession, bool, error)
-    CreateDailySession(ctx context.Context, session DailySession) error
-    RotateDailySession(ctx context.Context, localDate string, next DailySession) error
+    CreateDailySession(ctx context.Context, session DailySession) (DailySession, error)
+    RotateDailySession(ctx context.Context, localDate string, activationReason string) (DailySession, error)
 
 Extend the queue coordinator with a lightweight status shape:
 
@@ -384,3 +400,4 @@ Add an app-level daily command service interface shaped like:
 Keep the Discord runtime thin. It should normalize command input, call the correct application service, and present the response. All same-day generation and busy-clear business rules belong in the application and store layers.
 
 Revision Note: 2026-04-06 / Codex - Created this active ExecPlan after agreeing that `daily` clear rotates the whole shared bot-instance conversation, not per-user state, and that busy same-day generations must reject clear requests instead of rotating immediately.
+Revision Note: 2026-04-10 / Codex - Completed the daily-session migration, generation-aware routing, queue-safe clear command, generation-scoped daily-memory preflight, and the full test coverage for same-day and next-day rotation paths.

--- a/docs/exec-plans/index.md
+++ b/docs/exec-plans/index.md
@@ -25,10 +25,11 @@ Plans in this directory should be written and maintained in line with `.agents/P
 
 These plans are intended to be executed in the order listed below. Most plans follow numeric order, but infrastructure prerequisites may require picking up a later-numbered plan first when it explicitly prepares the repository for another active plan.
 
-- [Add shared daily generation rotation and `action:clear` to `daily` mode](./active/12-daily-clear-generation.md)
+- None.
 
 ## Recently Completed Plans
 
+- [Add shared daily generation rotation and `action:clear` to `daily` mode](./completed/12-daily-clear-generation.md)
 - [Build a versioned SQLite migration runner and bootstrap path](./completed/13-sqlite-migration-runner.md)
 - [Prefer the remote default branch when creating `task` worktrees](./completed/14-task-worktree-remote-base.md)
 - [Build fake runtime validation infrastructure for adapter-level tests](./completed/11-fake-runtime-validation.md)

--- a/internal/app/daily_command_service.go
+++ b/internal/app/daily_command_service.go
@@ -1,0 +1,93 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/HatsuneMiku3939/39claw/internal/config"
+)
+
+type DailyCommandService interface {
+	Clear(ctx context.Context, userID string, receivedAt time.Time) (MessageResponse, error)
+}
+
+type DailyCommandServiceDependencies struct {
+	CommandName string
+	Timezone    *time.Location
+	Store       ThreadStore
+	Coordinator QueueCoordinator
+}
+
+type DefaultDailyCommandService struct {
+	commands    commandSurface
+	timezone    *time.Location
+	store       ThreadStore
+	coordinator QueueCoordinator
+}
+
+func NewDailyCommandService(deps DailyCommandServiceDependencies) (*DefaultDailyCommandService, error) {
+	commandName := strings.TrimSpace(deps.CommandName)
+	if commandName == "" {
+		return nil, errors.New("command name must not be empty")
+	}
+
+	if deps.Timezone == nil {
+		return nil, errors.New("timezone must not be nil")
+	}
+
+	if deps.Store == nil {
+		return nil, errors.New("thread store must not be nil")
+	}
+
+	if deps.Coordinator == nil {
+		return nil, errors.New("queue coordinator must not be nil")
+	}
+
+	return &DefaultDailyCommandService{
+		commands:    newCommandSurface(commandName),
+		timezone:    deps.Timezone,
+		store:       deps.Store,
+		coordinator: deps.Coordinator,
+	}, nil
+}
+
+func (s *DefaultDailyCommandService) Clear(ctx context.Context, _ string, receivedAt time.Time) (MessageResponse, error) {
+	localDate := receivedAt.In(s.timezone).Format(time.DateOnly)
+
+	active, err := ResolveActiveDailySession(ctx, s.store, localDate)
+	if err != nil {
+		return MessageResponse{}, fmt.Errorf("resolve active daily session: %w", err)
+	}
+
+	snapshot := s.coordinator.Snapshot(buildExecutionKey(config.ModeDaily, active.LogicalThreadKey))
+	if snapshot.InFlight || snapshot.Queued > 0 {
+		return dailyCommandResponse(
+			fmt.Sprintf(
+				"Today's shared daily conversation is still busy. Wait for pending replies to finish, then retry `/%s action:clear`.",
+				s.commands.commandName,
+			),
+		), nil
+	}
+
+	next, err := s.store.RotateDailySession(ctx, localDate, DailySessionActivationClear)
+	if err != nil {
+		return MessageResponse{}, fmt.Errorf("rotate daily session: %w", err)
+	}
+
+	return dailyCommandResponse(
+		fmt.Sprintf(
+			"Started a fresh shared daily conversation for today. The active generation is now `%s`.",
+			next.LogicalThreadKey,
+		),
+	), nil
+}
+
+func dailyCommandResponse(text string) MessageResponse {
+	return MessageResponse{
+		Text:      text,
+		Ephemeral: true,
+	}
+}

--- a/internal/app/daily_command_service_test.go
+++ b/internal/app/daily_command_service_test.go
@@ -1,0 +1,113 @@
+package app_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/HatsuneMiku3939/39claw/internal/app"
+)
+
+func TestDailyCommandServiceClearCreatesAndRotatesTodaySession(t *testing.T) {
+	t.Parallel()
+
+	tokyo, err := time.LoadLocation("Asia/Tokyo")
+	if err != nil {
+		t.Fatalf("time.LoadLocation() error = %v", err)
+	}
+
+	store := &memoryThreadStore{}
+	coordinator := &stubQueueCoordinator{}
+	service, err := app.NewDailyCommandService(app.DailyCommandServiceDependencies{
+		CommandName: "release",
+		Timezone:    tokyo,
+		Store:       store,
+		Coordinator: coordinator,
+	})
+	if err != nil {
+		t.Fatalf("NewDailyCommandService() error = %v", err)
+	}
+
+	response, err := service.Clear(
+		context.Background(),
+		"user-1",
+		time.Date(2026, time.April, 5, 10, 0, 0, 0, tokyo),
+	)
+	if err != nil {
+		t.Fatalf("Clear() error = %v", err)
+	}
+
+	if !response.Ephemeral {
+		t.Fatal("Ephemeral = false, want true")
+	}
+
+	active, ok, err := store.GetActiveDailySession(context.Background(), "2026-04-05")
+	if err != nil {
+		t.Fatalf("GetActiveDailySession() error = %v", err)
+	}
+	if !ok {
+		t.Fatal("GetActiveDailySession() ok = false, want true")
+	}
+	if active.LogicalThreadKey != "2026-04-05#2" {
+		t.Fatalf("LogicalThreadKey = %q, want %q", active.LogicalThreadKey, "2026-04-05#2")
+	}
+	if active.PreviousLogicalThreadKey != "2026-04-05#1" {
+		t.Fatalf("PreviousLogicalThreadKey = %q, want %q", active.PreviousLogicalThreadKey, "2026-04-05#1")
+	}
+}
+
+func TestDailyCommandServiceClearRejectsBusyGeneration(t *testing.T) {
+	t.Parallel()
+
+	tokyo, err := time.LoadLocation("Asia/Tokyo")
+	if err != nil {
+		t.Fatalf("time.LoadLocation() error = %v", err)
+	}
+
+	store := &memoryThreadStore{}
+	if _, err := store.CreateDailySession(context.Background(), app.DailySession{
+		LocalDate:        "2026-04-05",
+		Generation:       1,
+		LogicalThreadKey: "2026-04-05#1",
+		ActivationReason: app.DailySessionActivationAutomatic,
+		IsActive:         true,
+	}); err != nil {
+		t.Fatalf("CreateDailySession() error = %v", err)
+	}
+
+	service, err := app.NewDailyCommandService(app.DailyCommandServiceDependencies{
+		CommandName: "release",
+		Timezone:    tokyo,
+		Store:       store,
+		Coordinator: &stubQueueCoordinator{
+			snapshot: app.QueueSnapshot{InFlight: true, Queued: 1},
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewDailyCommandService() error = %v", err)
+	}
+
+	response, err := service.Clear(
+		context.Background(),
+		"user-1",
+		time.Date(2026, time.April, 5, 10, 0, 0, 0, tokyo),
+	)
+	if err != nil {
+		t.Fatalf("Clear() error = %v", err)
+	}
+
+	if !response.Ephemeral {
+		t.Fatal("Ephemeral = false, want true")
+	}
+
+	active, ok, err := store.GetActiveDailySession(context.Background(), "2026-04-05")
+	if err != nil {
+		t.Fatalf("GetActiveDailySession() error = %v", err)
+	}
+	if !ok {
+		t.Fatal("GetActiveDailySession() ok = false, want true")
+	}
+	if active.LogicalThreadKey != "2026-04-05#1" {
+		t.Fatalf("LogicalThreadKey = %q, want %q", active.LogicalThreadKey, "2026-04-05#1")
+	}
+}

--- a/internal/app/daily_sessions.go
+++ b/internal/app/daily_sessions.go
@@ -1,0 +1,66 @@
+package app
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+const (
+	DailySessionActivationAutomatic = "automatic"
+	DailySessionActivationClear     = "clear"
+)
+
+func BuildDailyLogicalKey(localDate string, generation int) string {
+	return fmt.Sprintf("%s#%d", strings.TrimSpace(localDate), generation)
+}
+
+func ResolveActiveDailySession(ctx context.Context, store ThreadStore, localDate string) (DailySession, error) {
+	active, ok, err := store.GetActiveDailySession(ctx, localDate)
+	if err != nil {
+		return DailySession{}, fmt.Errorf("load active daily session: %w", err)
+	}
+
+	if ok {
+		return active, nil
+	}
+
+	previousLogicalKey := ""
+	previous, ok, err := store.GetLatestDailySessionBefore(ctx, localDate)
+	if err != nil {
+		return DailySession{}, fmt.Errorf("load previous daily session: %w", err)
+	}
+
+	if ok {
+		previousLogicalKey = previous.LogicalThreadKey
+	}
+
+	session, err := store.CreateDailySession(ctx, DailySession{
+		LocalDate:                localDate,
+		Generation:               1,
+		LogicalThreadKey:         BuildDailyLogicalKey(localDate, 1),
+		PreviousLogicalThreadKey: previousLogicalKey,
+		ActivationReason:         DailySessionActivationAutomatic,
+		IsActive:                 true,
+	})
+	if err != nil {
+		return DailySession{}, fmt.Errorf("create daily session: %w", err)
+	}
+
+	return session, nil
+}
+
+func ParseDailyLogicalKey(logicalKey string) (string, int, error) {
+	localDate, generationText, ok := strings.Cut(strings.TrimSpace(logicalKey), "#")
+	if !ok || localDate == "" || generationText == "" {
+		return "", 0, fmt.Errorf("invalid daily logical key %q", logicalKey)
+	}
+
+	generation, err := strconv.Atoi(generationText)
+	if err != nil || generation < 1 {
+		return "", 0, fmt.Errorf("invalid daily logical key %q", logicalKey)
+	}
+
+	return localDate, generation, nil
+}

--- a/internal/app/message_service.go
+++ b/internal/app/message_service.go
@@ -2,7 +2,6 @@ package app
 
 import (
 	"context"
-	"time"
 )
 
 type ThreadPolicy interface {
@@ -20,12 +19,16 @@ func (f DeferredReplySinkFunc) Deliver(ctx context.Context, response MessageResp
 }
 
 type DailyMemoryRefresher interface {
-	RefreshBeforeFirstDailyTurn(ctx context.Context, logicalKey string, receivedAt time.Time) error
+	RefreshBeforeFirstDailyTurn(ctx context.Context, session DailySession) error
 }
 
 type ThreadStore interface {
 	GetThreadBinding(ctx context.Context, mode string, logicalThreadKey string) (ThreadBinding, bool, error)
 	UpsertThreadBinding(ctx context.Context, binding ThreadBinding) error
+	GetActiveDailySession(ctx context.Context, localDate string) (DailySession, bool, error)
+	GetLatestDailySessionBefore(ctx context.Context, localDate string) (DailySession, bool, error)
+	CreateDailySession(ctx context.Context, session DailySession) (DailySession, error)
+	RotateDailySession(ctx context.Context, localDate string, activationReason string) (DailySession, error)
 	CreateTask(ctx context.Context, task Task) error
 	GetTask(ctx context.Context, discordUserID string, taskID string) (Task, bool, error)
 	UpdateTask(ctx context.Context, task Task) error
@@ -49,6 +52,7 @@ type CodexGateway interface {
 type QueueCoordinator interface {
 	Admit(key string, work func()) (QueueAdmission, error)
 	Complete(key string) (func(), bool)
+	Snapshot(key string) QueueSnapshot
 }
 
 type MessageService interface {

--- a/internal/app/message_service_impl.go
+++ b/internal/app/message_service_impl.go
@@ -180,15 +180,16 @@ func (s *DefaultMessageService) HandleMessage(ctx context.Context, request Messa
 }
 
 type preparedMessage struct {
-	logicalKey string
-	userID     string
-	taskID     string
-	channelID  string
-	replyToID  string
-	receivedAt time.Time
-	input      CodexTurnInput
-	sink       DeferredReplySink
-	cleanup    func()
+	logicalKey   string
+	dailySession DailySession
+	userID       string
+	taskID       string
+	channelID    string
+	replyToID    string
+	receivedAt   time.Time
+	input        CodexTurnInput
+	sink         DeferredReplySink
+	cleanup      func()
 }
 
 func (s *DefaultMessageService) prepareMessage(
@@ -222,6 +223,16 @@ func (s *DefaultMessageService) prepareMessage(
 		},
 		sink:    sink,
 		cleanup: cleanup,
+	}
+
+	if s.mode == config.ModeDaily {
+		session, err := ResolveActiveDailySession(ctx, s.store, logicalKey)
+		if err != nil {
+			return preparedMessage{}, MessageResponse{}, false, fmt.Errorf("resolve active daily session: %w", err)
+		}
+
+		prepared.logicalKey = session.LogicalThreadKey
+		prepared.dailySession = session
 	}
 
 	if s.mode == config.ModeTask {
@@ -262,7 +273,7 @@ func (s *DefaultMessageService) executePreparedMessage(ctx context.Context, prep
 	}
 
 	if s.mode == config.ModeDaily {
-		if err := s.dailyMemory.RefreshBeforeFirstDailyTurn(ctx, prepared.logicalKey, prepared.receivedAt); err != nil {
+		if err := s.dailyMemory.RefreshBeforeFirstDailyTurn(ctx, prepared.dailySession); err != nil {
 			slog.Error("refresh daily memory bridge", "logical_key", prepared.logicalKey, "error", err)
 		}
 	}

--- a/internal/app/message_service_test.go
+++ b/internal/app/message_service_test.go
@@ -94,7 +94,7 @@ func TestMessageServiceHandleMessageDailyReusesSameDayBinding(t *testing.T) {
 		t.Fatalf("second thread id = %q, want %q", calls[1].threadID, "thread-1")
 	}
 
-	binding, ok, err := store.GetThreadBinding(context.Background(), "daily", "2026-04-05")
+	binding, ok, err := store.GetThreadBinding(context.Background(), "daily", "2026-04-05#1")
 	if err != nil {
 		t.Fatalf("GetThreadBinding() error = %v", err)
 	}
@@ -200,11 +200,11 @@ func TestMessageServiceHandleMessageDailyRollsOverOnNextDay(t *testing.T) {
 		t.Fatalf("second thread id = %q, want empty", calls[1].threadID)
 	}
 
-	if _, ok, err := store.GetThreadBinding(context.Background(), "daily", "2026-04-05"); err != nil || !ok {
+	if _, ok, err := store.GetThreadBinding(context.Background(), "daily", "2026-04-05#1"); err != nil || !ok {
 		t.Fatalf("same-day binding lookup = ok:%v err:%v, want ok:true err:nil", ok, err)
 	}
 
-	nextBinding, ok, err := store.GetThreadBinding(context.Background(), "daily", "2026-04-06")
+	nextBinding, ok, err := store.GetThreadBinding(context.Background(), "daily", "2026-04-06#1")
 	if err != nil {
 		t.Fatalf("GetThreadBinding() next day error = %v", err)
 	}
@@ -223,10 +223,19 @@ func TestMessageServiceHandleMessageDailyRefreshesBeforeVisibleTurn(t *testing.T
 
 	store := &memoryThreadStore{
 		bindings: map[string]app.ThreadBinding{
-			"daily:2026-04-05": {
+			"daily:2026-04-05#1": {
 				Mode:             "daily",
-				LogicalThreadKey: "2026-04-05",
+				LogicalThreadKey: "2026-04-05#1",
 				CodexThreadID:    "thread-previous",
+			},
+		},
+		dailySessions: map[string]app.DailySession{
+			"2026-04-05:2026-04-05#1": {
+				LocalDate:        "2026-04-05",
+				Generation:       1,
+				LogicalThreadKey: "2026-04-05#1",
+				ActivationReason: app.DailySessionActivationAutomatic,
+				IsActive:         true,
 			},
 		},
 	}
@@ -265,8 +274,16 @@ func TestMessageServiceHandleMessageDailyRefreshesBeforeVisibleTurn(t *testing.T
 		t.Fatalf("RefreshBeforeFirstDailyTurn() call count = %d, want 1", len(calls))
 	}
 
-	if calls[0].logicalKey != "2026-04-06" {
-		t.Fatalf("refresher logical key = %q, want %q", calls[0].logicalKey, "2026-04-06")
+	if calls[0].session.LogicalThreadKey != "2026-04-06#1" {
+		t.Fatalf("refresher logical key = %q, want %q", calls[0].session.LogicalThreadKey, "2026-04-06#1")
+	}
+
+	if calls[0].session.PreviousLogicalThreadKey != "2026-04-05#1" {
+		t.Fatalf(
+			"refresher previous logical key = %q, want %q",
+			calls[0].session.PreviousLogicalThreadKey,
+			"2026-04-05#1",
+		)
 	}
 }
 
@@ -304,6 +321,87 @@ func TestMessageServiceHandleMessageDailyContinuesWhenRefreshFails(t *testing.T)
 
 	if got, want := sequence, []string{"refresh", "turn"}; len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
 		t.Fatalf("sequence = %v, want %v", got, want)
+	}
+}
+
+func TestMessageServiceHandleMessageDailyTargetsFreshGenerationAfterClear(t *testing.T) {
+	t.Parallel()
+
+	store := &memoryThreadStore{
+		bindings: map[string]app.ThreadBinding{
+			"daily:2026-04-05#1": {
+				Mode:             "daily",
+				LogicalThreadKey: "2026-04-05#1",
+				CodexThreadID:    "thread-previous",
+			},
+		},
+		dailySessions: map[string]app.DailySession{
+			"2026-04-05:2026-04-05#2": {
+				LocalDate:                "2026-04-05",
+				Generation:               2,
+				LogicalThreadKey:         "2026-04-05#2",
+				PreviousLogicalThreadKey: "2026-04-05#1",
+				ActivationReason:         app.DailySessionActivationClear,
+				IsActive:                 true,
+			},
+		},
+	}
+
+	refresher := &fakeDailyMemoryRefresher{}
+	gateway := &fakeCodexGateway{
+		results: []app.RunTurnResult{
+			{ThreadID: "thread-fresh", ResponseText: "Fresh same-day generation"},
+		},
+	}
+
+	service := newDailyMessageServiceWithRefresher(t, store, gateway, refresher, nil)
+
+	response, err := service.HandleMessage(context.Background(), app.MessageRequest{
+		MessageID:  "message-1",
+		Content:    "fresh start please",
+		Mentioned:  true,
+		ReceivedAt: time.Date(2026, time.April, 5, 10, 0, 0, 0, time.UTC),
+	}, nil)
+	if err != nil {
+		t.Fatalf("HandleMessage() error = %v", err)
+	}
+
+	if response.Text != "Fresh same-day generation" {
+		t.Fatalf("response text = %q, want %q", response.Text, "Fresh same-day generation")
+	}
+
+	calls := gateway.Calls()
+	if len(calls) != 1 {
+		t.Fatalf("RunTurn() call count = %d, want %d", len(calls), 1)
+	}
+	if calls[0].threadID != "" {
+		t.Fatalf("threadID = %q, want empty", calls[0].threadID)
+	}
+
+	refreshCalls := refresher.Calls()
+	if len(refreshCalls) != 1 {
+		t.Fatalf("RefreshBeforeFirstDailyTurn() call count = %d, want 1", len(refreshCalls))
+	}
+	if refreshCalls[0].session.LogicalThreadKey != "2026-04-05#2" {
+		t.Fatalf("refresher logical key = %q, want %q", refreshCalls[0].session.LogicalThreadKey, "2026-04-05#2")
+	}
+	if refreshCalls[0].session.PreviousLogicalThreadKey != "2026-04-05#1" {
+		t.Fatalf(
+			"refresher previous logical key = %q, want %q",
+			refreshCalls[0].session.PreviousLogicalThreadKey,
+			"2026-04-05#1",
+		)
+	}
+
+	binding, ok, err := store.GetThreadBinding(context.Background(), "daily", "2026-04-05#2")
+	if err != nil {
+		t.Fatalf("GetThreadBinding() error = %v", err)
+	}
+	if !ok {
+		t.Fatal("GetThreadBinding() ok = false, want true")
+	}
+	if binding.CodexThreadID != "thread-fresh" {
+		t.Fatalf("CodexThreadID = %q, want %q", binding.CodexThreadID, "thread-fresh")
 	}
 }
 
@@ -1298,6 +1396,7 @@ func (s stubThreadPolicy) ResolveMessageKey(context.Context, app.MessageRequest)
 type stubQueueCoordinator struct {
 	admission app.QueueAdmission
 	err       error
+	snapshot  app.QueueSnapshot
 }
 
 func (c *stubQueueCoordinator) Admit(string, func()) (app.QueueAdmission, error) {
@@ -1314,6 +1413,10 @@ func (c *stubQueueCoordinator) Admit(string, func()) (app.QueueAdmission, error)
 
 func (c *stubQueueCoordinator) Complete(string) (func(), bool) {
 	return nil, false
+}
+
+func (c *stubQueueCoordinator) Snapshot(string) app.QueueSnapshot {
+	return c.snapshot
 }
 
 type fakeCodexGateway struct {
@@ -1391,13 +1494,12 @@ type blockingCodexGateway struct {
 
 type noopDailyMemoryRefresher struct{}
 
-func (noopDailyMemoryRefresher) RefreshBeforeFirstDailyTurn(context.Context, string, time.Time) error {
+func (noopDailyMemoryRefresher) RefreshBeforeFirstDailyTurn(context.Context, app.DailySession) error {
 	return nil
 }
 
 type dailyMemoryCall struct {
-	logicalKey string
-	receivedAt time.Time
+	session app.DailySession
 }
 
 type fakeDailyMemoryRefresher struct {
@@ -1407,13 +1509,12 @@ type fakeDailyMemoryRefresher struct {
 	sequence *[]string
 }
 
-func (r *fakeDailyMemoryRefresher) RefreshBeforeFirstDailyTurn(_ context.Context, logicalKey string, receivedAt time.Time) error {
+func (r *fakeDailyMemoryRefresher) RefreshBeforeFirstDailyTurn(_ context.Context, session app.DailySession) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
 	r.calls = append(r.calls, dailyMemoryCall{
-		logicalKey: logicalKey,
-		receivedAt: receivedAt,
+		session: session,
 	})
 
 	if r.sequence != nil {
@@ -1547,10 +1648,11 @@ func (g *scriptedCodexGateway) Calls() []runTurnCall {
 }
 
 type memoryThreadStore struct {
-	mu          sync.Mutex
-	bindings    map[string]app.ThreadBinding
-	tasks       map[string]app.Task
-	activeTasks map[string]app.ActiveTask
+	mu            sync.Mutex
+	bindings      map[string]app.ThreadBinding
+	dailySessions map[string]app.DailySession
+	tasks         map[string]app.Task
+	activeTasks   map[string]app.ActiveTask
 }
 
 func (s *memoryThreadStore) GetThreadBinding(_ context.Context, mode string, logicalThreadKey string) (app.ThreadBinding, bool, error) {
@@ -1575,6 +1677,106 @@ func (s *memoryThreadStore) UpsertThreadBinding(_ context.Context, binding app.T
 
 	s.bindings[binding.Mode+":"+binding.LogicalThreadKey] = binding
 	return nil
+}
+
+func (s *memoryThreadStore) GetActiveDailySession(_ context.Context, localDate string) (app.DailySession, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for _, session := range s.dailySessions {
+		if session.LocalDate == localDate && session.IsActive {
+			return session, true, nil
+		}
+	}
+
+	return app.DailySession{}, false, nil
+}
+
+func (s *memoryThreadStore) GetLatestDailySessionBefore(_ context.Context, localDate string) (app.DailySession, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	var latest app.DailySession
+	ok := false
+	for _, session := range s.dailySessions {
+		if !session.IsActive || session.LocalDate >= localDate {
+			continue
+		}
+
+		if !ok || session.LocalDate > latest.LocalDate || (session.LocalDate == latest.LocalDate && session.Generation > latest.Generation) {
+			latest = session
+			ok = true
+		}
+	}
+
+	return latest, ok, nil
+}
+
+func (s *memoryThreadStore) CreateDailySession(_ context.Context, session app.DailySession) (app.DailySession, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for _, existing := range s.dailySessions {
+		if existing.LocalDate == session.LocalDate && existing.IsActive {
+			return existing, nil
+		}
+	}
+
+	if s.dailySessions == nil {
+		s.dailySessions = make(map[string]app.DailySession)
+	}
+
+	if session.CreatedAt.IsZero() {
+		session.CreatedAt = time.Date(2026, time.April, 5, 0, 0, 0, 0, time.UTC)
+	}
+	if session.UpdatedAt.IsZero() {
+		session.UpdatedAt = session.CreatedAt
+	}
+	session.IsActive = true
+	s.dailySessions[session.LocalDate+":"+app.BuildDailyLogicalKey(session.LocalDate, session.Generation)] = session
+	return session, nil
+}
+
+func (s *memoryThreadStore) RotateDailySession(_ context.Context, localDate string, activationReason string) (app.DailySession, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.dailySessions == nil {
+		return app.DailySession{}, sql.ErrNoRows
+	}
+
+	var activeKey string
+	var active app.DailySession
+	ok := false
+	for key, session := range s.dailySessions {
+		if session.LocalDate == localDate && session.IsActive {
+			activeKey = key
+			active = session
+			ok = true
+			break
+		}
+	}
+
+	if !ok {
+		return app.DailySession{}, sql.ErrNoRows
+	}
+
+	active.IsActive = false
+	s.dailySessions[activeKey] = active
+
+	next := app.DailySession{
+		LocalDate:                localDate,
+		Generation:               active.Generation + 1,
+		LogicalThreadKey:         app.BuildDailyLogicalKey(localDate, active.Generation+1),
+		PreviousLogicalThreadKey: active.LogicalThreadKey,
+		ActivationReason:         activationReason,
+		IsActive:                 true,
+		CreatedAt:                time.Date(2026, time.April, 5, 0, 0, 0, 0, time.UTC),
+		UpdatedAt:                time.Date(2026, time.April, 5, 0, 0, 0, 0, time.UTC),
+	}
+	s.dailySessions[next.LocalDate+":"+next.LogicalThreadKey] = next
+
+	return next, nil
 }
 
 func (s *memoryThreadStore) CreateTask(_ context.Context, task app.Task) error {

--- a/internal/app/types.go
+++ b/internal/app/types.go
@@ -35,6 +35,17 @@ type ThreadBinding struct {
 	UpdatedAt        time.Time
 }
 
+type DailySession struct {
+	LocalDate                string
+	Generation               int
+	LogicalThreadKey         string
+	PreviousLogicalThreadKey string
+	ActivationReason         string
+	IsActive                 bool
+	CreatedAt                time.Time
+	UpdatedAt                time.Time
+}
+
 type TaskStatus string
 
 const (
@@ -111,4 +122,9 @@ type QueueAdmission struct {
 	ExecuteNow bool
 	Queued     bool
 	Position   int
+}
+
+type QueueSnapshot struct {
+	InFlight bool
+	Queued   int
 }

--- a/internal/dailymemory/service.go
+++ b/internal/dailymemory/service.go
@@ -15,18 +15,13 @@ import (
 const defaultRefreshTimeout = time.Minute
 
 type Refresher struct {
-	Timezone *time.Location
-	Store    app.ThreadStore
-	Gateway  app.CodexGateway
-	Workdir  string
-	Timeout  time.Duration
+	Store   app.ThreadStore
+	Gateway app.CodexGateway
+	Workdir string
+	Timeout time.Duration
 }
 
-func (r Refresher) RefreshBeforeFirstDailyTurn(ctx context.Context, logicalKey string, _ time.Time) error {
-	if r.Timezone == nil {
-		return errors.New("daily memory refresher timezone must not be nil")
-	}
-
+func (r Refresher) RefreshBeforeFirstDailyTurn(ctx context.Context, session app.DailySession) error {
 	if r.Store == nil {
 		return errors.New("daily memory refresher store must not be nil")
 	}
@@ -40,19 +35,25 @@ func (r Refresher) RefreshBeforeFirstDailyTurn(ctx context.Context, logicalKey s
 		return errors.New("daily memory refresher workdir must not be empty")
 	}
 
-	currentDate, err := time.ParseInLocation(time.DateOnly, logicalKey, r.Timezone)
-	if err != nil {
-		return fmt.Errorf("parse current daily logical key: %w", err)
+	if strings.TrimSpace(session.LogicalThreadKey) == "" {
+		return errors.New("daily memory refresher logical thread key must not be empty")
 	}
 
-	if _, ok, err := r.Store.GetThreadBinding(ctx, "daily", logicalKey); err != nil {
+	if strings.TrimSpace(session.LocalDate) == "" || session.Generation < 1 {
+		return errors.New("daily memory refresher session metadata is incomplete")
+	}
+
+	if _, ok, err := r.Store.GetThreadBinding(ctx, "daily", session.LogicalThreadKey); err != nil {
 		return fmt.Errorf("load current daily thread binding: %w", err)
 	} else if ok {
 		return nil
 	}
 
-	previousDate := currentDate.AddDate(0, 0, -1).Format(time.DateOnly)
-	previousBinding, ok, err := r.Store.GetThreadBinding(ctx, "daily", previousDate)
+	if strings.TrimSpace(session.PreviousLogicalThreadKey) == "" {
+		return nil
+	}
+
+	previousBinding, ok, err := r.Store.GetThreadBinding(ctx, "daily", session.PreviousLogicalThreadKey)
 	if err != nil {
 		return fmt.Errorf("load previous daily thread binding: %w", err)
 	}
@@ -71,8 +72,14 @@ func (r Refresher) RefreshBeforeFirstDailyTurn(ctx context.Context, logicalKey s
 	}
 
 	memoryPath := filepath.Join(memoryDir, memoryFileName)
-	bridgePath := filepath.Join(memoryDir, logicalKey+".md")
-	if err := ensureBridgeNote(bridgePath, previousBinding.CodexThreadID, previousDate, logicalKey); err != nil {
+	bridgeFilename := fmt.Sprintf("%s.%d.md", session.LocalDate, session.Generation)
+	bridgePath := filepath.Join(memoryDir, bridgeFilename)
+	if err := ensureBridgeNote(
+		bridgePath,
+		previousBinding.CodexThreadID,
+		session.PreviousLogicalThreadKey,
+		session.LogicalThreadKey,
+	); err != nil {
 		return err
 	}
 
@@ -84,7 +91,7 @@ func (r Refresher) RefreshBeforeFirstDailyTurn(ctx context.Context, logicalKey s
 	defer cancel()
 
 	result, err := r.Gateway.RunTurn(refreshCtx, previousBinding.CodexThreadID, app.CodexTurnInput{
-		Prompt:           buildRefreshPrompt(previousDate, logicalKey),
+		Prompt:           buildRefreshPrompt(session.PreviousLogicalThreadKey, session.LogicalThreadKey, bridgeFilename),
 		WorkingDirectory: workdir,
 	})
 	if err != nil {
@@ -106,16 +113,16 @@ func (r Refresher) effectiveTimeout() time.Duration {
 	return defaultRefreshTimeout
 }
 
-func ensureBridgeNote(path string, previousThreadID string, previousDate string, currentDate string) error {
+func ensureBridgeNote(path string, previousThreadID string, previousLogicalKey string, currentLogicalKey string) error {
 	if _, err := os.Stat(path); err == nil {
 		return nil
 	} else if !errors.Is(err, os.ErrNotExist) {
 		return fmt.Errorf("stat bridge note: %w", err)
 	}
 
-	content := strings.ReplaceAll(initialBridgeNoteTemplate, "YYYY-MM-DD", currentDate)
+	content := strings.ReplaceAll(initialBridgeNoteTemplate, "CURRENT-LOGICAL-KEY", currentLogicalKey)
 	content = strings.ReplaceAll(content, "<previous-thread-id>", previousThreadID)
-	content = strings.ReplaceAll(content, "<source-day>", previousDate)
+	content = strings.ReplaceAll(content, "<source-logical-key>", previousLogicalKey)
 
 	if err := os.WriteFile(path, []byte(content), fileMode); err != nil {
 		return fmt.Errorf("write bridge note: %w", err)
@@ -124,12 +131,12 @@ func ensureBridgeNote(path string, previousThreadID string, previousDate string,
 	return nil
 }
 
-func buildRefreshPrompt(previousDate string, currentDate string) string {
+func buildRefreshPrompt(previousLogicalKey string, currentLogicalKey string, bridgeFilename string) string {
 	return fmt.Sprintf(
-		"Before handling the first visible user message of the new daily thread, read `.agents/skills/39claw-daily-memory-refresh/SKILL.md` and follow it now.\n\nUse the resumed previous daily thread as the source of truth.\n\nToday's bridge note path is:\n- AGENT_MEMORY/%s.md\n\nThe primary durable memory file is:\n- AGENT_MEMORY/MEMORY.md\n\nThe previous local date is %s.\nThe new local date is %s.\n\nReturn the required completion format after the refresh is complete.",
-		currentDate,
-		previousDate,
-		currentDate,
+		"Before handling the first visible user message of the new daily generation, read `.agents/skills/39claw-daily-memory-refresh/SKILL.md` and follow it now.\n\nUse the resumed previous daily generation as the source of truth.\n\nToday's bridge note path is:\n- AGENT_MEMORY/%s\n\nThe primary durable memory file is:\n- AGENT_MEMORY/MEMORY.md\n\nThe previous logical key is %s.\nThe new logical key is %s.\n\nReturn the required completion format after the refresh is complete.",
+		bridgeFilename,
+		previousLogicalKey,
+		currentLogicalKey,
 	)
 }
 
@@ -143,10 +150,10 @@ func validateRefreshResponse(responseText string, memoryPath string, bridgePath 
 	return nil
 }
 
-const initialBridgeNoteTemplate = "# Daily Memory Bridge for YYYY-MM-DD\n\n" +
+const initialBridgeNoteTemplate = "# Daily Memory Bridge for CURRENT-LOGICAL-KEY\n\n" +
 	"## Source\n\n" +
 	"- Previous thread id: `<previous-thread-id>`\n" +
-	"- Source day: `<source-day>`\n\n" +
+	"- Source logical key: `<source-logical-key>`\n\n" +
 	"## Durable Facts Promoted\n\n" +
 	"- None yet.\n\n" +
 	"## MEMORY.md Updates Applied\n\n" +
@@ -154,4 +161,4 @@ const initialBridgeNoteTemplate = "# Daily Memory Bridge for YYYY-MM-DD\n\n" +
 	"## Rejected Candidates\n\n" +
 	"- None yet.\n\n" +
 	"## Notes\n\n" +
-	"- Created by the 39claw daily memory preflight before the first visible turn of the new day.\n"
+	"- Created by the 39claw daily memory preflight before the first visible turn of the new generation.\n"

--- a/internal/dailymemory/service_test.go
+++ b/internal/dailymemory/service_test.go
@@ -19,19 +19,18 @@ func TestRefresherRefreshBeforeFirstDailyTurnUsesPreviousBinding(t *testing.T) {
 		t.Fatalf("Ensure() error = %v", err)
 	}
 
-	tokyo := mustLoadLocation(t, "Asia/Tokyo")
 	store := &stubThreadStore{
 		bindings: map[string]app.ThreadBinding{
-			"daily:2026-04-05": {
+			"daily:2026-04-05#1": {
 				Mode:             "daily",
-				LogicalThreadKey: "2026-04-05",
+				LogicalThreadKey: "2026-04-05#1",
 				CodexThreadID:    "thread-previous",
 			},
 		},
 	}
 
 	memoryPath := filepath.Join(workdir, memoryDirName, memoryFileName)
-	bridgePath := filepath.Join(workdir, memoryDirName, "2026-04-06.md")
+	bridgePath := filepath.Join(workdir, memoryDirName, "2026-04-06.1.md")
 	gateway := &stubCodexGateway{
 		result: app.RunTurnResult{
 			ThreadID:     "thread-previous",
@@ -40,17 +39,20 @@ func TestRefresherRefreshBeforeFirstDailyTurnUsesPreviousBinding(t *testing.T) {
 	}
 
 	refresher := Refresher{
-		Timezone: tokyo,
-		Store:    store,
-		Gateway:  gateway,
-		Workdir:  workdir,
-		Timeout:  time.Second,
+		Store:   store,
+		Gateway: gateway,
+		Workdir: workdir,
+		Timeout: time.Second,
 	}
 
 	err := refresher.RefreshBeforeFirstDailyTurn(
 		context.Background(),
-		"2026-04-06",
-		time.Date(2026, time.April, 6, 9, 0, 0, 0, tokyo),
+		app.DailySession{
+			LocalDate:                "2026-04-06",
+			Generation:               1,
+			LogicalThreadKey:         "2026-04-06#1",
+			PreviousLogicalThreadKey: "2026-04-05#1",
+		},
 	)
 	if err != nil {
 		t.Fatalf("RefreshBeforeFirstDailyTurn() error = %v", err)
@@ -69,8 +71,8 @@ func TestRefresherRefreshBeforeFirstDailyTurnUsesPreviousBinding(t *testing.T) {
 		t.Fatalf("WorkingDirectory = %q, want %q", call.input.WorkingDirectory, workdir)
 	}
 
-	if call.input.Prompt != buildRefreshPrompt("2026-04-05", "2026-04-06") {
-		t.Fatalf("prompt = %q, want %q", call.input.Prompt, buildRefreshPrompt("2026-04-05", "2026-04-06"))
+	if call.input.Prompt != buildRefreshPrompt("2026-04-05#1", "2026-04-06#1", "2026-04-06.1.md") {
+		t.Fatalf("prompt = %q, want %q", call.input.Prompt, buildRefreshPrompt("2026-04-05#1", "2026-04-06#1", "2026-04-06.1.md"))
 	}
 
 	bridgeContents, err := os.ReadFile(bridgePath)
@@ -78,10 +80,10 @@ func TestRefresherRefreshBeforeFirstDailyTurnUsesPreviousBinding(t *testing.T) {
 		t.Fatalf("ReadFile(bridge note) error = %v", err)
 	}
 
-	expectedBridge := "# Daily Memory Bridge for 2026-04-06\n\n" +
+	expectedBridge := "# Daily Memory Bridge for 2026-04-06#1\n\n" +
 		"## Source\n\n" +
 		"- Previous thread id: `thread-previous`\n" +
-		"- Source day: `2026-04-05`\n\n" +
+		"- Source logical key: `2026-04-05#1`\n\n" +
 		"## Durable Facts Promoted\n\n" +
 		"- None yet.\n\n" +
 		"## MEMORY.md Updates Applied\n\n" +
@@ -89,7 +91,7 @@ func TestRefresherRefreshBeforeFirstDailyTurnUsesPreviousBinding(t *testing.T) {
 		"## Rejected Candidates\n\n" +
 		"- None yet.\n\n" +
 		"## Notes\n\n" +
-		"- Created by the 39claw daily memory preflight before the first visible turn of the new day.\n"
+		"- Created by the 39claw daily memory preflight before the first visible turn of the new generation.\n"
 	if string(bridgeContents) != expectedBridge {
 		t.Fatalf("bridge note contents = %q, want %q", string(bridgeContents), expectedBridge)
 	}
@@ -99,12 +101,11 @@ func TestRefresherSkipsWhenCurrentBindingExists(t *testing.T) {
 	t.Parallel()
 
 	refresher := Refresher{
-		Timezone: mustLoadLocation(t, "Asia/Tokyo"),
 		Store: &stubThreadStore{
 			bindings: map[string]app.ThreadBinding{
-				"daily:2026-04-06": {
+				"daily:2026-04-06#1": {
 					Mode:             "daily",
-					LogicalThreadKey: "2026-04-06",
+					LogicalThreadKey: "2026-04-06#1",
 					CodexThreadID:    "thread-current",
 				},
 			},
@@ -113,7 +114,12 @@ func TestRefresherSkipsWhenCurrentBindingExists(t *testing.T) {
 		Workdir: t.TempDir(),
 	}
 
-	if err := refresher.RefreshBeforeFirstDailyTurn(context.Background(), "2026-04-06", time.Time{}); err != nil {
+	if err := refresher.RefreshBeforeFirstDailyTurn(context.Background(), app.DailySession{
+		LocalDate:                "2026-04-06",
+		Generation:               1,
+		LogicalThreadKey:         "2026-04-06#1",
+		PreviousLogicalThreadKey: "2026-04-05#1",
+	}); err != nil {
 		t.Fatalf("RefreshBeforeFirstDailyTurn() error = %v", err)
 	}
 }
@@ -123,13 +129,16 @@ func TestRefresherSkipsWhenPreviousBindingIsMissing(t *testing.T) {
 
 	gateway := &stubCodexGateway{}
 	refresher := Refresher{
-		Timezone: mustLoadLocation(t, "Asia/Tokyo"),
-		Store:    &stubThreadStore{},
-		Gateway:  gateway,
-		Workdir:  t.TempDir(),
+		Store:   &stubThreadStore{},
+		Gateway: gateway,
+		Workdir: t.TempDir(),
 	}
 
-	if err := refresher.RefreshBeforeFirstDailyTurn(context.Background(), "2026-04-06", time.Time{}); err != nil {
+	if err := refresher.RefreshBeforeFirstDailyTurn(context.Background(), app.DailySession{
+		LocalDate:        "2026-04-06",
+		Generation:       1,
+		LogicalThreadKey: "2026-04-06#1",
+	}); err != nil {
 		t.Fatalf("RefreshBeforeFirstDailyTurn() error = %v", err)
 	}
 
@@ -143,12 +152,11 @@ func TestRefresherReturnsErrorWhenCompletionFormatIsUnexpected(t *testing.T) {
 
 	workdir := t.TempDir()
 	refresher := Refresher{
-		Timezone: mustLoadLocation(t, "Asia/Tokyo"),
 		Store: &stubThreadStore{
 			bindings: map[string]app.ThreadBinding{
-				"daily:2026-04-05": {
+				"daily:2026-04-05#1": {
 					Mode:             "daily",
-					LogicalThreadKey: "2026-04-05",
+					LogicalThreadKey: "2026-04-05#1",
 					CodexThreadID:    "thread-previous",
 				},
 			},
@@ -162,7 +170,12 @@ func TestRefresherReturnsErrorWhenCompletionFormatIsUnexpected(t *testing.T) {
 		Workdir: workdir,
 	}
 
-	err := refresher.RefreshBeforeFirstDailyTurn(context.Background(), "2026-04-06", time.Time{})
+	err := refresher.RefreshBeforeFirstDailyTurn(context.Background(), app.DailySession{
+		LocalDate:                "2026-04-06",
+		Generation:               1,
+		LogicalThreadKey:         "2026-04-06#1",
+		PreviousLogicalThreadKey: "2026-04-05#1",
+	})
 	if err == nil {
 		t.Fatal("RefreshBeforeFirstDailyTurn() error = nil, want non-nil")
 	}
@@ -173,12 +186,11 @@ func TestRefresherReturnsTimeout(t *testing.T) {
 
 	workdir := t.TempDir()
 	refresher := Refresher{
-		Timezone: mustLoadLocation(t, "Asia/Tokyo"),
 		Store: &stubThreadStore{
 			bindings: map[string]app.ThreadBinding{
-				"daily:2026-04-05": {
+				"daily:2026-04-05#1": {
 					Mode:             "daily",
-					LogicalThreadKey: "2026-04-05",
+					LogicalThreadKey: "2026-04-05#1",
 					CodexThreadID:    "thread-previous",
 				},
 			},
@@ -188,7 +200,12 @@ func TestRefresherReturnsTimeout(t *testing.T) {
 		Timeout: 10 * time.Millisecond,
 	}
 
-	err := refresher.RefreshBeforeFirstDailyTurn(context.Background(), "2026-04-06", time.Time{})
+	err := refresher.RefreshBeforeFirstDailyTurn(context.Background(), app.DailySession{
+		LocalDate:                "2026-04-06",
+		Generation:               1,
+		LogicalThreadKey:         "2026-04-06#1",
+		PreviousLogicalThreadKey: "2026-04-05#1",
+	})
 	if !errors.Is(err, context.DeadlineExceeded) {
 		t.Fatalf("RefreshBeforeFirstDailyTurn() error = %v, want deadline exceeded", err)
 	}
@@ -209,6 +226,22 @@ func (s *stubThreadStore) GetThreadBinding(_ context.Context, mode string, logic
 
 func (s *stubThreadStore) UpsertThreadBinding(context.Context, app.ThreadBinding) error {
 	return nil
+}
+
+func (s *stubThreadStore) GetActiveDailySession(context.Context, string) (app.DailySession, bool, error) {
+	return app.DailySession{}, false, nil
+}
+
+func (s *stubThreadStore) GetLatestDailySessionBefore(context.Context, string) (app.DailySession, bool, error) {
+	return app.DailySession{}, false, nil
+}
+
+func (s *stubThreadStore) CreateDailySession(context.Context, app.DailySession) (app.DailySession, error) {
+	return app.DailySession{}, nil
+}
+
+func (s *stubThreadStore) RotateDailySession(context.Context, string, string) (app.DailySession, error) {
+	return app.DailySession{}, nil
 }
 
 func (s *stubThreadStore) CreateTask(context.Context, app.Task) error {

--- a/internal/runtime/discord/commands.go
+++ b/internal/runtime/discord/commands.go
@@ -22,6 +22,13 @@ func registeredCommands(cfg config.Config) []*discordgo.ApplicationCommand {
 		},
 	}
 
+	if cfg.Mode == config.ModeDaily {
+		actionChoices = append(
+			actionChoices,
+			&discordgo.ApplicationCommandOptionChoice{Name: actionClear, Value: actionClear},
+		)
+	}
+
 	if cfg.Mode == config.ModeTask {
 		actionChoices = append(
 			actionChoices,
@@ -79,6 +86,12 @@ func helpResponse(commandName string, mode config.Mode) app.MessageResponse {
 		fmt.Sprintf("- `/%s action:%s` shows this help message.", commandName, actionHelp),
 	}
 
+	if mode == config.ModeDaily {
+		lines = append(lines,
+			fmt.Sprintf("- `/%s action:%s` starts a fresh shared daily generation for today when the current one is idle.", commandName, actionClear),
+		)
+	}
+
 	if mode == config.ModeTask {
 		lines = append(lines,
 			fmt.Sprintf("- `/%s action:%s` shows the active task.", commandName, actionTaskCurrent),
@@ -104,7 +117,7 @@ func taskUnavailableDailyMode(commandName string) string {
 
 func unsupportedActionText(commandName string, mode config.Mode) string {
 	if mode != config.ModeTask {
-		return fmt.Sprintf("Unsupported action. Use `/%s action:%s`.", commandName, actionHelp)
+		return fmt.Sprintf("Unsupported action. Use `/%s action:%s` or `/%s action:%s`.", commandName, actionHelp, commandName, actionClear)
 	}
 
 	return fmt.Sprintf(

--- a/internal/runtime/discord/interaction_mapper.go
+++ b/internal/runtime/discord/interaction_mapper.go
@@ -12,6 +12,7 @@ const (
 	optionTaskID   = "task_id"
 
 	actionHelp        = "help"
+	actionClear       = "clear"
 	actionTaskCurrent = "task-current"
 	actionTaskList    = "task-list"
 	actionTaskNew     = "task-new"

--- a/internal/runtime/discord/runtime.go
+++ b/internal/runtime/discord/runtime.go
@@ -24,6 +24,7 @@ type Dependencies struct {
 	Config               config.Config
 	Logger               *slog.Logger
 	Message              app.MessageService
+	DailyCommand         app.DailyCommandService
 	TaskCommand          app.TaskCommandService
 	SessionFactory       sessionFactory
 	HTTPClient           attachmentHTTPClient
@@ -31,10 +32,11 @@ type Dependencies struct {
 }
 
 type Runtime struct {
-	config      config.Config
-	logger      *slog.Logger
-	message     app.MessageService
-	taskCommand app.TaskCommandService
+	config       config.Config
+	logger       *slog.Logger
+	message      app.MessageService
+	dailyCommand app.DailyCommandService
+	taskCommand  app.TaskCommandService
 
 	sessionFactory sessionFactory
 	httpClient     attachmentHTTPClient
@@ -58,8 +60,12 @@ func NewRuntime(deps Dependencies) (*Runtime, error) {
 		return nil, errors.New("message service must not be nil")
 	}
 
-	if deps.TaskCommand == nil {
-		return nil, errors.New("task command service must not be nil")
+	if deps.Config.Mode == config.ModeDaily && deps.DailyCommand == nil {
+		return nil, errors.New("daily command service must not be nil in daily mode")
+	}
+
+	if deps.Config.Mode == config.ModeTask && deps.TaskCommand == nil {
+		return nil, errors.New("task command service must not be nil in task mode")
 	}
 
 	if deps.Config.DiscordToken == "" {
@@ -85,6 +91,7 @@ func NewRuntime(deps Dependencies) (*Runtime, error) {
 		config:               deps.Config,
 		logger:               deps.Logger,
 		message:              deps.Message,
+		dailyCommand:         deps.DailyCommand,
 		taskCommand:          deps.TaskCommand,
 		sessionFactory:       factory,
 		httpClient:           httpClient,
@@ -473,6 +480,15 @@ func (r *Runtime) routeCommand(ctx context.Context, request commandRequest) (app
 	switch request.Action {
 	case actionHelp:
 		return helpResponse(r.config.DiscordCommandName, r.config.Mode), nil
+	case actionClear:
+		if r.config.Mode != config.ModeDaily {
+			return app.MessageResponse{
+				Text:      unsupportedActionText(r.config.DiscordCommandName, r.config.Mode),
+				Ephemeral: true,
+			}, nil
+		}
+
+		return r.dailyCommand.Clear(ctx, request.UserID, time.Now())
 	case actionTaskCurrent, actionTaskList, actionTaskNew, actionTaskSwitch, actionTaskClose:
 		if r.config.Mode != config.ModeTask {
 			return app.MessageResponse{

--- a/internal/runtime/discord/runtime_test.go
+++ b/internal/runtime/discord/runtime_test.go
@@ -61,12 +61,16 @@ func TestRuntimeStartRegistersCommands(t *testing.T) {
 		t.Fatalf("action option name = %q, want %q", actionOption.Name, optionAction)
 	}
 
-	if len(actionOption.Choices) != 1 {
-		t.Fatalf("action choice count = %d, want %d", len(actionOption.Choices), 1)
+	if len(actionOption.Choices) != 2 {
+		t.Fatalf("action choice count = %d, want %d", len(actionOption.Choices), 2)
 	}
 
 	if actionOption.Choices[0].Value != actionHelp {
 		t.Fatalf("action choice value = %v, want %q", actionOption.Choices[0].Value, actionHelp)
+	}
+
+	if actionOption.Choices[1].Value != actionClear {
+		t.Fatalf("second action choice value = %v, want %q", actionOption.Choices[1].Value, actionClear)
 	}
 }
 
@@ -374,10 +378,11 @@ func TestRuntimeDeferredReplyDeliveryLogsStructuredSuccess(t *testing.T) {
 			DiscordToken:       "discord-token",
 			DiscordCommandName: "release",
 		},
-		Logger:      logger,
-		Message:     messageService,
-		TaskCommand: &fakeTaskCommandService{},
-		HTTPClient:  http.DefaultClient,
+		Logger:       logger,
+		Message:      messageService,
+		DailyCommand: &fakeDailyCommandService{},
+		TaskCommand:  &fakeTaskCommandService{},
+		HTTPClient:   http.DefaultClient,
 		SessionFactory: func(token string) (session, error) {
 			return fakeSession, nil
 		},
@@ -458,7 +463,16 @@ func TestRuntimeCloseWaitsForDeferredQueuedReplyDrain(t *testing.T) {
 	}
 
 	fakeSession := newFakeSession("bot-user")
-	runtime := newTestRuntimeWithTimeout(t, config.ModeDaily, fakeSession, messageService, &fakeTaskCommandService{}, http.DefaultClient, time.Second)
+	runtime := newTestRuntimeWithTimeout(
+		t,
+		config.ModeDaily,
+		fakeSession,
+		messageService,
+		&fakeDailyCommandService{},
+		&fakeTaskCommandService{},
+		http.DefaultClient,
+		time.Second,
+	)
 
 	if err := runtime.Start(context.Background()); err != nil {
 		t.Fatalf("Start() error = %v", err)
@@ -540,7 +554,16 @@ func TestRuntimeCloseCancelsDeferredDrainWhenTimeoutExpires(t *testing.T) {
 	}
 
 	fakeSession := newFakeSession("bot-user")
-	runtime := newTestRuntimeWithTimeout(t, config.ModeDaily, fakeSession, messageService, &fakeTaskCommandService{}, http.DefaultClient, 20*time.Millisecond)
+	runtime := newTestRuntimeWithTimeout(
+		t,
+		config.ModeDaily,
+		fakeSession,
+		messageService,
+		&fakeDailyCommandService{},
+		&fakeTaskCommandService{},
+		http.DefaultClient,
+		20*time.Millisecond,
+	)
 
 	if err := runtime.Start(context.Background()); err != nil {
 		t.Fatalf("Start() error = %v", err)
@@ -843,6 +866,10 @@ func TestRuntimeHelpActionReturnsConfiguredCommandInfo(t *testing.T) {
 	if !strings.Contains(response.Data.Content, "Mode: daily") {
 		t.Fatalf("response content = %q, want mode guidance", response.Data.Content)
 	}
+
+	if !strings.Contains(response.Data.Content, "action:clear") {
+		t.Fatalf("response content = %q, want clear action guidance", response.Data.Content)
+	}
 }
 
 func TestRuntimeTaskCommandInDailyModeIsEphemeral(t *testing.T) {
@@ -875,6 +902,125 @@ func TestRuntimeTaskCommandInDailyModeIsEphemeral(t *testing.T) {
 
 	if !strings.Contains(response.Data.Content, "not available") {
 		t.Fatalf("response content = %q, want task unavailable guidance", response.Data.Content)
+	}
+}
+
+func TestRuntimeDailyClearActionRoutesIdleSuccess(t *testing.T) {
+	t.Parallel()
+
+	tokyo, err := time.LoadLocation("Asia/Tokyo")
+	if err != nil {
+		t.Fatalf("time.LoadLocation() error = %v", err)
+	}
+
+	store := &memoryThreadStore{}
+	dailyService, err := app.NewDailyCommandService(app.DailyCommandServiceDependencies{
+		CommandName: "release",
+		Timezone:    tokyo,
+		Store:       store,
+		Coordinator: &stubQueueCoordinator{},
+	})
+	if err != nil {
+		t.Fatalf("NewDailyCommandService() error = %v", err)
+	}
+
+	fakeSession := newFakeSession("bot-user")
+	runtime := newTestRuntimeWithTimeout(
+		t,
+		config.ModeDaily,
+		fakeSession,
+		&fakeMessageService{},
+		dailyService,
+		&fakeTaskCommandService{},
+		http.DefaultClient,
+		0,
+	)
+
+	if err := runtime.Start(context.Background()); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	t.Cleanup(func() {
+		_ = runtime.Close()
+	})
+
+	fakeSession.dispatchInteraction(commandInteractionEvent("release", "user-1", actionClear, "", ""))
+
+	if len(fakeSession.interactionResponses) != 1 {
+		t.Fatalf("interaction response count = %d, want %d", len(fakeSession.interactionResponses), 1)
+	}
+
+	response := fakeSession.interactionResponses[0]
+	if response.Data == nil || response.Data.Flags != discordgo.MessageFlagsEphemeral {
+		t.Fatalf("response flags = %v, want ephemeral", response.Data.Flags)
+	}
+
+	if !strings.Contains(response.Data.Content, "#2") {
+		t.Fatalf("response content = %q, want rotated generation confirmation", response.Data.Content)
+	}
+}
+
+func TestRuntimeDailyClearActionRejectsBusyGenerationEphemerally(t *testing.T) {
+	t.Parallel()
+
+	tokyo, err := time.LoadLocation("Asia/Tokyo")
+	if err != nil {
+		t.Fatalf("time.LoadLocation() error = %v", err)
+	}
+
+	store := &memoryThreadStore{}
+	localDate := time.Now().In(tokyo).Format(time.DateOnly)
+	if _, err := store.CreateDailySession(context.Background(), app.DailySession{
+		LocalDate:        localDate,
+		Generation:       1,
+		LogicalThreadKey: localDate + "#1",
+		ActivationReason: app.DailySessionActivationAutomatic,
+		IsActive:         true,
+	}); err != nil {
+		t.Fatalf("CreateDailySession() error = %v", err)
+	}
+
+	dailyService, err := app.NewDailyCommandService(app.DailyCommandServiceDependencies{
+		CommandName: "release",
+		Timezone:    tokyo,
+		Store:       store,
+		Coordinator: &stubQueueCoordinator{snapshot: app.QueueSnapshot{InFlight: true, Queued: 1}},
+	})
+	if err != nil {
+		t.Fatalf("NewDailyCommandService() error = %v", err)
+	}
+
+	fakeSession := newFakeSession("bot-user")
+	runtime := newTestRuntimeWithTimeout(
+		t,
+		config.ModeDaily,
+		fakeSession,
+		&fakeMessageService{},
+		dailyService,
+		&fakeTaskCommandService{},
+		http.DefaultClient,
+		0,
+	)
+
+	if err := runtime.Start(context.Background()); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	t.Cleanup(func() {
+		_ = runtime.Close()
+	})
+
+	fakeSession.dispatchInteraction(commandInteractionEvent("release", "user-1", actionClear, "", ""))
+
+	if len(fakeSession.interactionResponses) != 1 {
+		t.Fatalf("interaction response count = %d, want %d", len(fakeSession.interactionResponses), 1)
+	}
+
+	response := fakeSession.interactionResponses[0]
+	if response.Data == nil || response.Data.Flags != discordgo.MessageFlagsEphemeral {
+		t.Fatalf("response flags = %v, want ephemeral", response.Data.Flags)
+	}
+
+	if !strings.Contains(response.Data.Content, "still busy") {
+		t.Fatalf("response content = %q, want busy rejection", response.Data.Content)
 	}
 }
 

--- a/internal/runtime/discord/runtime_test_helpers_test.go
+++ b/internal/runtime/discord/runtime_test_helpers_test.go
@@ -21,7 +21,16 @@ import (
 
 func newTestRuntime(t *testing.T, mode config.Mode, fakeSession *fakeSession) *Runtime {
 	t.Helper()
-	return newTestRuntimeWithTimeout(t, mode, fakeSession, &fakeMessageService{}, &fakeTaskCommandService{}, http.DefaultClient, 0)
+	return newTestRuntimeWithTimeout(
+		t,
+		mode,
+		fakeSession,
+		&fakeMessageService{},
+		&fakeDailyCommandService{},
+		&fakeTaskCommandService{},
+		http.DefaultClient,
+		0,
+	)
 }
 
 func newTestRuntimeWithServices(
@@ -32,7 +41,16 @@ func newTestRuntimeWithServices(
 	taskService app.TaskCommandService,
 ) *Runtime {
 	t.Helper()
-	return newTestRuntimeWithTimeout(t, mode, fakeSession, messageService, taskService, http.DefaultClient, 0)
+	return newTestRuntimeWithTimeout(
+		t,
+		mode,
+		fakeSession,
+		messageService,
+		&fakeDailyCommandService{},
+		taskService,
+		http.DefaultClient,
+		0,
+	)
 }
 
 func newTestRuntimeWithServicesAndClient(
@@ -44,7 +62,16 @@ func newTestRuntimeWithServicesAndClient(
 	httpClient attachmentHTTPClient,
 ) *Runtime {
 	t.Helper()
-	return newTestRuntimeWithTimeout(t, mode, fakeSession, messageService, taskService, httpClient, 0)
+	return newTestRuntimeWithTimeout(
+		t,
+		mode,
+		fakeSession,
+		messageService,
+		&fakeDailyCommandService{},
+		taskService,
+		httpClient,
+		0,
+	)
 }
 
 func newTestRuntimeWithTimeout(
@@ -52,6 +79,7 @@ func newTestRuntimeWithTimeout(
 	mode config.Mode,
 	fakeSession *fakeSession,
 	messageService app.MessageService,
+	dailyService app.DailyCommandService,
 	taskService app.TaskCommandService,
 	httpClient attachmentHTTPClient,
 	shutdownDrainTimeout time.Duration,
@@ -67,6 +95,7 @@ func newTestRuntimeWithTimeout(
 		},
 		Logger:               slog.New(slog.NewTextHandler(io.Discard, nil)),
 		Message:              messageService,
+		DailyCommand:         dailyService,
 		TaskCommand:          taskService,
 		HTTPClient:           httpClient,
 		ShutdownDrainTimeout: shutdownDrainTimeout,
@@ -515,17 +544,59 @@ func (s *fakeTaskCommandService) CloseTask(ctx context.Context, userID string, t
 	return s.closeResponse, nil
 }
 
+type fakeDailyCommandService struct {
+	clearCalls []struct {
+		userID     string
+		receivedAt time.Time
+	}
+	clearResponse app.MessageResponse
+	clearErr      error
+}
+
+func (s *fakeDailyCommandService) Clear(ctx context.Context, userID string, receivedAt time.Time) (app.MessageResponse, error) {
+	s.clearCalls = append(s.clearCalls, struct {
+		userID     string
+		receivedAt time.Time
+	}{
+		userID:     userID,
+		receivedAt: receivedAt,
+	})
+
+	if s.clearErr != nil {
+		return app.MessageResponse{}, s.clearErr
+	}
+
+	return s.clearResponse, nil
+}
+
+type stubQueueCoordinator struct {
+	snapshot app.QueueSnapshot
+}
+
+func (c *stubQueueCoordinator) Admit(string, func()) (app.QueueAdmission, error) {
+	return app.QueueAdmission{ExecuteNow: true}, nil
+}
+
+func (c *stubQueueCoordinator) Complete(string) (func(), bool) {
+	return nil, false
+}
+
+func (c *stubQueueCoordinator) Snapshot(string) app.QueueSnapshot {
+	return c.snapshot
+}
+
 type noopDailyMemoryRefresher struct{}
 
-func (noopDailyMemoryRefresher) RefreshBeforeFirstDailyTurn(context.Context, string, time.Time) error {
+func (noopDailyMemoryRefresher) RefreshBeforeFirstDailyTurn(context.Context, app.DailySession) error {
 	return nil
 }
 
 type memoryThreadStore struct {
-	mu          sync.Mutex
-	bindings    map[string]app.ThreadBinding
-	tasks       map[string]app.Task
-	activeTasks map[string]app.ActiveTask
+	mu            sync.Mutex
+	bindings      map[string]app.ThreadBinding
+	dailySessions map[string]app.DailySession
+	tasks         map[string]app.Task
+	activeTasks   map[string]app.ActiveTask
 }
 
 func (s *memoryThreadStore) GetThreadBinding(_ context.Context, mode string, logicalThreadKey string) (app.ThreadBinding, bool, error) {
@@ -550,6 +621,105 @@ func (s *memoryThreadStore) UpsertThreadBinding(_ context.Context, binding app.T
 
 	s.bindings[binding.Mode+":"+binding.LogicalThreadKey] = binding
 	return nil
+}
+
+func (s *memoryThreadStore) GetActiveDailySession(_ context.Context, localDate string) (app.DailySession, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for _, session := range s.dailySessions {
+		if session.LocalDate == localDate && session.IsActive {
+			return session, true, nil
+		}
+	}
+
+	return app.DailySession{}, false, nil
+}
+
+func (s *memoryThreadStore) GetLatestDailySessionBefore(_ context.Context, localDate string) (app.DailySession, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	var latest app.DailySession
+	ok := false
+	for _, session := range s.dailySessions {
+		if !session.IsActive || session.LocalDate >= localDate {
+			continue
+		}
+
+		if !ok || session.LocalDate > latest.LocalDate || (session.LocalDate == latest.LocalDate && session.Generation > latest.Generation) {
+			latest = session
+			ok = true
+		}
+	}
+
+	return latest, ok, nil
+}
+
+func (s *memoryThreadStore) CreateDailySession(_ context.Context, session app.DailySession) (app.DailySession, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for _, existing := range s.dailySessions {
+		if existing.LocalDate == session.LocalDate && existing.IsActive {
+			return existing, nil
+		}
+	}
+
+	if s.dailySessions == nil {
+		s.dailySessions = make(map[string]app.DailySession)
+	}
+
+	if session.CreatedAt.IsZero() {
+		session.CreatedAt = time.Date(2026, time.April, 5, 0, 0, 0, 0, time.UTC)
+	}
+	if session.UpdatedAt.IsZero() {
+		session.UpdatedAt = session.CreatedAt
+	}
+	session.IsActive = true
+	s.dailySessions[session.LocalDate+":"+session.LogicalThreadKey] = session
+	return session, nil
+}
+
+func (s *memoryThreadStore) RotateDailySession(_ context.Context, localDate string, activationReason string) (app.DailySession, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.dailySessions == nil {
+		return app.DailySession{}, sql.ErrNoRows
+	}
+
+	var activeKey string
+	var active app.DailySession
+	ok := false
+	for key, session := range s.dailySessions {
+		if session.LocalDate == localDate && session.IsActive {
+			activeKey = key
+			active = session
+			ok = true
+			break
+		}
+	}
+
+	if !ok {
+		return app.DailySession{}, sql.ErrNoRows
+	}
+
+	active.IsActive = false
+	s.dailySessions[activeKey] = active
+
+	next := app.DailySession{
+		LocalDate:                localDate,
+		Generation:               active.Generation + 1,
+		LogicalThreadKey:         app.BuildDailyLogicalKey(localDate, active.Generation+1),
+		PreviousLogicalThreadKey: active.LogicalThreadKey,
+		ActivationReason:         activationReason,
+		IsActive:                 true,
+		CreatedAt:                time.Date(2026, time.April, 5, 0, 0, 0, 0, time.UTC),
+		UpdatedAt:                time.Date(2026, time.April, 5, 0, 0, 0, 0, time.UTC),
+	}
+	s.dailySessions[next.LocalDate+":"+next.LogicalThreadKey] = next
+	return next, nil
 }
 
 func (s *memoryThreadStore) CreateTask(_ context.Context, task app.Task) error {

--- a/internal/store/sqlite/daily_sessions.go
+++ b/internal/store/sqlite/daily_sessions.go
@@ -1,0 +1,226 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/HatsuneMiku3939/39claw/internal/app"
+)
+
+func (s *Store) GetActiveDailySession(ctx context.Context, localDate string) (app.DailySession, bool, error) {
+	row := s.db.QueryRowContext(
+		ctx,
+		`SELECT local_date, generation, logical_thread_key, COALESCE(previous_logical_thread_key, ''),
+			activation_reason, is_active, created_at, updated_at
+		FROM daily_sessions
+		WHERE local_date = ? AND is_active = 1`,
+		localDate,
+	)
+
+	return scanDailySession(row)
+}
+
+func (s *Store) GetLatestDailySessionBefore(ctx context.Context, localDate string) (app.DailySession, bool, error) {
+	row := s.db.QueryRowContext(
+		ctx,
+		`SELECT local_date, generation, logical_thread_key, COALESCE(previous_logical_thread_key, ''),
+			activation_reason, is_active, created_at, updated_at
+		FROM daily_sessions
+		WHERE local_date < ? AND is_active = 1
+		ORDER BY local_date DESC, generation DESC
+		LIMIT 1`,
+		localDate,
+	)
+
+	return scanDailySession(row)
+}
+
+func (s *Store) CreateDailySession(ctx context.Context, session app.DailySession) (app.DailySession, error) {
+	now := s.clock()
+	if session.CreatedAt.IsZero() {
+		session.CreatedAt = now
+	}
+	if session.UpdatedAt.IsZero() {
+		session.UpdatedAt = session.CreatedAt
+	}
+	session.IsActive = true
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return app.DailySession{}, fmt.Errorf("begin create daily session transaction: %w", err)
+	}
+	defer func() {
+		rollbackErr := tx.Rollback()
+		if rollbackErr != nil && !errors.Is(rollbackErr, sql.ErrTxDone) {
+			return
+		}
+	}()
+
+	active, ok, err := getActiveDailySessionTx(ctx, tx, session.LocalDate)
+	if err != nil {
+		return app.DailySession{}, fmt.Errorf("load active daily session in transaction: %w", err)
+	}
+
+	if ok {
+		return active, nil
+	}
+
+	_, err = tx.ExecContext(
+		ctx,
+		`INSERT INTO daily_sessions (
+			local_date, generation, logical_thread_key, previous_logical_thread_key,
+			activation_reason, is_active, created_at, updated_at
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+		session.LocalDate,
+		session.Generation,
+		session.LogicalThreadKey,
+		nullableString(session.PreviousLogicalThreadKey),
+		session.ActivationReason,
+		boolToSQLiteInt(session.IsActive),
+		session.CreatedAt.Format(time.RFC3339Nano),
+		session.UpdatedAt.Format(time.RFC3339Nano),
+	)
+	if err != nil {
+		return app.DailySession{}, fmt.Errorf("insert daily session: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return app.DailySession{}, fmt.Errorf("commit create daily session transaction: %w", err)
+	}
+
+	return session, nil
+}
+
+func (s *Store) RotateDailySession(ctx context.Context, localDate string, activationReason string) (app.DailySession, error) {
+	now := s.clock()
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return app.DailySession{}, fmt.Errorf("begin rotate daily session transaction: %w", err)
+	}
+	defer func() {
+		rollbackErr := tx.Rollback()
+		if rollbackErr != nil && !errors.Is(rollbackErr, sql.ErrTxDone) {
+			return
+		}
+	}()
+
+	active, ok, err := getActiveDailySessionTx(ctx, tx, localDate)
+	if err != nil {
+		return app.DailySession{}, fmt.Errorf("load active daily session in transaction: %w", err)
+	}
+	if !ok {
+		return app.DailySession{}, sql.ErrNoRows
+	}
+
+	if _, err := tx.ExecContext(
+		ctx,
+		`UPDATE daily_sessions
+		SET is_active = 0, updated_at = ?
+		WHERE local_date = ? AND generation = ?`,
+		now.Format(time.RFC3339Nano),
+		active.LocalDate,
+		active.Generation,
+	); err != nil {
+		return app.DailySession{}, fmt.Errorf("deactivate current daily session: %w", err)
+	}
+
+	next := app.DailySession{
+		LocalDate:                localDate,
+		Generation:               active.Generation + 1,
+		LogicalThreadKey:         app.BuildDailyLogicalKey(localDate, active.Generation+1),
+		PreviousLogicalThreadKey: active.LogicalThreadKey,
+		ActivationReason:         activationReason,
+		IsActive:                 true,
+		CreatedAt:                now,
+		UpdatedAt:                now,
+	}
+
+	if _, err := tx.ExecContext(
+		ctx,
+		`INSERT INTO daily_sessions (
+			local_date, generation, logical_thread_key, previous_logical_thread_key,
+			activation_reason, is_active, created_at, updated_at
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+		next.LocalDate,
+		next.Generation,
+		next.LogicalThreadKey,
+		next.PreviousLogicalThreadKey,
+		next.ActivationReason,
+		boolToSQLiteInt(next.IsActive),
+		next.CreatedAt.Format(time.RFC3339Nano),
+		next.UpdatedAt.Format(time.RFC3339Nano),
+	); err != nil {
+		return app.DailySession{}, fmt.Errorf("insert rotated daily session: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return app.DailySession{}, fmt.Errorf("commit rotate daily session transaction: %w", err)
+	}
+
+	return next, nil
+}
+
+func getActiveDailySessionTx(ctx context.Context, tx *sql.Tx, localDate string) (app.DailySession, bool, error) {
+	row := tx.QueryRowContext(
+		ctx,
+		`SELECT local_date, generation, logical_thread_key, COALESCE(previous_logical_thread_key, ''),
+			activation_reason, is_active, created_at, updated_at
+		FROM daily_sessions
+		WHERE local_date = ? AND is_active = 1`,
+		localDate,
+	)
+
+	return scanDailySession(row)
+}
+
+func scanDailySession(scanner interface{ Scan(dest ...any) error }) (app.DailySession, bool, error) {
+	var session app.DailySession
+	var previousLogicalThreadKey string
+	var isActive int
+	var createdAt string
+	var updatedAt string
+
+	err := scanner.Scan(
+		&session.LocalDate,
+		&session.Generation,
+		&session.LogicalThreadKey,
+		&previousLogicalThreadKey,
+		&session.ActivationReason,
+		&isActive,
+		&createdAt,
+		&updatedAt,
+	)
+	if errors.Is(err, sql.ErrNoRows) {
+		return app.DailySession{}, false, nil
+	}
+	if err != nil {
+		return app.DailySession{}, false, fmt.Errorf("scan daily session: %w", err)
+	}
+
+	session.PreviousLogicalThreadKey = previousLogicalThreadKey
+	session.IsActive = isActive != 0
+
+	session.CreatedAt, err = time.Parse(time.RFC3339Nano, createdAt)
+	if err != nil {
+		return app.DailySession{}, false, fmt.Errorf("parse daily session created_at: %w", err)
+	}
+
+	session.UpdatedAt, err = time.Parse(time.RFC3339Nano, updatedAt)
+	if err != nil {
+		return app.DailySession{}, false, fmt.Errorf("parse daily session updated_at: %w", err)
+	}
+
+	return session, true, nil
+}
+
+func boolToSQLiteInt(value bool) int {
+	if value {
+		return 1
+	}
+
+	return 0
+}

--- a/internal/store/sqlite/migrate_test.go
+++ b/internal/store/sqlite/migrate_test.go
@@ -27,11 +27,11 @@ func TestMigrateFreshDatabase(t *testing.T) {
 	}
 
 	versions := appliedVersionsForTest(t, db)
-	if !slices.Equal(versions, []int{1, 2}) {
-		t.Fatalf("applied migration versions = %v, want %v", versions, []int{1, 2})
+	if !slices.Equal(versions, []int{1, 2, 3}) {
+		t.Fatalf("applied migration versions = %v, want %v", versions, []int{1, 2, 3})
 	}
 
-	for _, tableName := range []string{"schema_migrations", "thread_bindings", "tasks", "active_tasks"} {
+	for _, tableName := range []string{"schema_migrations", "thread_bindings", "tasks", "active_tasks", "daily_sessions"} {
 		exists, err := tableExists(context.Background(), db, tableName)
 		if err != nil {
 			t.Fatalf("tableExists(%q) error = %v", tableName, err)
@@ -137,8 +137,8 @@ func TestMigrateLegacyDatabaseBootstrapRecognizesLatestSchema(t *testing.T) {
 	}
 
 	versions := appliedVersionsForTest(t, reopened)
-	if !slices.Equal(versions, []int{1, 2}) {
-		t.Fatalf("applied migration versions = %v, want %v", versions, []int{1, 2})
+	if !slices.Equal(versions, []int{1, 2, 3}) {
+		t.Fatalf("applied migration versions = %v, want %v", versions, []int{1, 2, 3})
 	}
 
 	store := New(reopened)
@@ -151,6 +151,113 @@ func TestMigrateLegacyDatabaseBootstrapRecognizesLatestSchema(t *testing.T) {
 	}
 	if task.BranchName != "task/task-1" {
 		t.Fatalf("BranchName = %q, want %q", task.BranchName, "task/task-1")
+	}
+}
+
+func TestMigrateLegacyDailyBindingsBackfillGenerationOne(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "39claw.db")
+	db, err := sql.Open(driverName, path)
+	if err != nil {
+		t.Fatalf("sql.Open() error = %v", err)
+	}
+
+	ctx := context.Background()
+	for _, stmt := range []string{
+		`CREATE TABLE thread_bindings (
+			mode TEXT NOT NULL,
+			logical_thread_key TEXT NOT NULL,
+			codex_thread_id TEXT NOT NULL,
+			task_id TEXT NULL,
+			created_at TEXT NOT NULL,
+			updated_at TEXT NOT NULL,
+			PRIMARY KEY (mode, logical_thread_key)
+		);`,
+		`CREATE TABLE tasks (
+			task_id TEXT PRIMARY KEY,
+			discord_user_id TEXT NOT NULL,
+			task_name TEXT NOT NULL,
+			status TEXT NOT NULL,
+			branch_name TEXT NOT NULL DEFAULT '',
+			base_ref TEXT NULL,
+			worktree_path TEXT NULL,
+			worktree_status TEXT NOT NULL DEFAULT 'pending',
+			created_at TEXT NOT NULL,
+			updated_at TEXT NOT NULL,
+			closed_at TEXT NULL,
+			worktree_created_at TEXT NULL,
+			worktree_pruned_at TEXT NULL,
+			last_used_at TEXT NULL
+		);`,
+		`CREATE TABLE active_tasks (
+			discord_user_id TEXT PRIMARY KEY,
+			task_id TEXT NOT NULL,
+			updated_at TEXT NOT NULL
+		);`,
+	} {
+		if _, err := db.ExecContext(ctx, stmt); err != nil {
+			t.Fatalf("exec schema statement error = %v", err)
+		}
+	}
+
+	if _, err := db.ExecContext(
+		ctx,
+		`INSERT INTO thread_bindings (
+			mode, logical_thread_key, codex_thread_id, task_id, created_at, updated_at
+		) VALUES (?, ?, ?, NULL, ?, ?)`,
+		"daily",
+		"2026-04-05",
+		"thread-legacy",
+		"2026-04-05T00:00:00Z",
+		"2026-04-05T00:00:00Z",
+	); err != nil {
+		t.Fatalf("insert legacy daily binding error = %v", err)
+	}
+
+	if err := db.Close(); err != nil {
+		t.Fatalf("db.Close() error = %v", err)
+	}
+
+	reopened, err := OpenDB(context.Background(), path)
+	if err != nil {
+		t.Fatalf("OpenDB() reopen error = %v", err)
+	}
+	defer func() {
+		if closeErr := reopened.Close(); closeErr != nil {
+			t.Fatalf("reopened.Close() error = %v", closeErr)
+		}
+	}()
+
+	if err := Migrate(ctx, reopened); err != nil {
+		t.Fatalf("Migrate() error = %v", err)
+	}
+
+	store := New(reopened)
+	if _, ok, err := store.GetThreadBinding(ctx, "daily", "2026-04-05"); err != nil || ok {
+		t.Fatalf("legacy key lookup = ok:%v err:%v, want ok:false err:nil", ok, err)
+	}
+
+	binding, ok, err := store.GetThreadBinding(ctx, "daily", "2026-04-05#1")
+	if err != nil {
+		t.Fatalf("GetThreadBinding() migrated key error = %v", err)
+	}
+	if !ok {
+		t.Fatal("GetThreadBinding() migrated key ok = false, want true")
+	}
+	if binding.CodexThreadID != "thread-legacy" {
+		t.Fatalf("CodexThreadID = %q, want %q", binding.CodexThreadID, "thread-legacy")
+	}
+
+	session, ok, err := store.GetActiveDailySession(ctx, "2026-04-05")
+	if err != nil {
+		t.Fatalf("GetActiveDailySession() error = %v", err)
+	}
+	if !ok {
+		t.Fatal("GetActiveDailySession() ok = false, want true")
+	}
+	if session.LogicalThreadKey != "2026-04-05#1" {
+		t.Fatalf("LogicalThreadKey = %q, want %q", session.LogicalThreadKey, "2026-04-05#1")
 	}
 }
 

--- a/internal/store/sqlite/store_test.go
+++ b/internal/store/sqlite/store_test.go
@@ -35,8 +35,120 @@ func TestMigrateIsIdempotent(t *testing.T) {
 		t.Fatalf("query schema_migrations count error = %v", err)
 	}
 
-	if count != 2 {
-		t.Fatalf("schema_migrations count = %d, want %d", count, 2)
+	if count != 3 {
+		t.Fatalf("schema_migrations count = %d, want %d", count, 3)
+	}
+}
+
+func TestStoreCreateDailySessionCreatesGenerationOne(t *testing.T) {
+	t.Parallel()
+
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	session, err := store.CreateDailySession(ctx, app.DailySession{
+		LocalDate:        "2026-04-05",
+		Generation:       1,
+		LogicalThreadKey: "2026-04-05#1",
+		ActivationReason: app.DailySessionActivationAutomatic,
+		IsActive:         true,
+	})
+	if err != nil {
+		t.Fatalf("CreateDailySession() error = %v", err)
+	}
+
+	if session.LogicalThreadKey != "2026-04-05#1" {
+		t.Fatalf("LogicalThreadKey = %q, want %q", session.LogicalThreadKey, "2026-04-05#1")
+	}
+
+	active, ok, err := store.GetActiveDailySession(ctx, "2026-04-05")
+	if err != nil {
+		t.Fatalf("GetActiveDailySession() error = %v", err)
+	}
+	if !ok {
+		t.Fatal("GetActiveDailySession() ok = false, want true")
+	}
+	if active.Generation != 1 {
+		t.Fatalf("Generation = %d, want %d", active.Generation, 1)
+	}
+}
+
+func TestStoreRotateDailySessionCreatesNextGeneration(t *testing.T) {
+	t.Parallel()
+
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	if _, err := store.CreateDailySession(ctx, app.DailySession{
+		LocalDate:        "2026-04-05",
+		Generation:       1,
+		LogicalThreadKey: "2026-04-05#1",
+		ActivationReason: app.DailySessionActivationAutomatic,
+		IsActive:         true,
+	}); err != nil {
+		t.Fatalf("CreateDailySession() error = %v", err)
+	}
+
+	next, err := store.RotateDailySession(ctx, "2026-04-05", app.DailySessionActivationClear)
+	if err != nil {
+		t.Fatalf("RotateDailySession() error = %v", err)
+	}
+
+	if next.Generation != 2 {
+		t.Fatalf("Generation = %d, want %d", next.Generation, 2)
+	}
+	if next.PreviousLogicalThreadKey != "2026-04-05#1" {
+		t.Fatalf("PreviousLogicalThreadKey = %q, want %q", next.PreviousLogicalThreadKey, "2026-04-05#1")
+	}
+
+	active, ok, err := store.GetActiveDailySession(ctx, "2026-04-05")
+	if err != nil {
+		t.Fatalf("GetActiveDailySession() error = %v", err)
+	}
+	if !ok {
+		t.Fatal("GetActiveDailySession() ok = false, want true")
+	}
+	if active.LogicalThreadKey != "2026-04-05#2" {
+		t.Fatalf("active logical key = %q, want %q", active.LogicalThreadKey, "2026-04-05#2")
+	}
+}
+
+func TestStoreGetLatestDailySessionBefore(t *testing.T) {
+	t.Parallel()
+
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	for _, session := range []app.DailySession{
+		{
+			LocalDate:        "2026-04-05",
+			Generation:       1,
+			LogicalThreadKey: "2026-04-05#1",
+			ActivationReason: app.DailySessionActivationAutomatic,
+			IsActive:         true,
+		},
+		{
+			LocalDate:        "2026-04-06",
+			Generation:       1,
+			LogicalThreadKey: "2026-04-06#1",
+			ActivationReason: app.DailySessionActivationAutomatic,
+			IsActive:         true,
+		},
+	} {
+		if _, err := store.CreateDailySession(ctx, session); err != nil {
+			t.Fatalf("CreateDailySession(%s) error = %v", session.LogicalThreadKey, err)
+		}
+	}
+
+	latest, ok, err := store.GetLatestDailySessionBefore(ctx, "2026-04-07")
+	if err != nil {
+		t.Fatalf("GetLatestDailySessionBefore() error = %v", err)
+	}
+	if !ok {
+		t.Fatal("GetLatestDailySessionBefore() ok = false, want true")
+	}
+	if latest.LogicalThreadKey != "2026-04-06#1" {
+		t.Fatalf("LogicalThreadKey = %q, want %q", latest.LogicalThreadKey, "2026-04-06#1")
 	}
 }
 

--- a/internal/thread/policy_test.go
+++ b/internal/thread/policy_test.go
@@ -186,6 +186,45 @@ func TestQueueCoordinatorAdmitAndComplete(t *testing.T) {
 	}
 }
 
+func TestQueueCoordinatorSnapshot(t *testing.T) {
+	t.Parallel()
+
+	coordinator := NewQueueCoordinator()
+	key := "daily:2026-04-05#1"
+
+	if snapshot := coordinator.Snapshot(key); snapshot != (app.QueueSnapshot{}) {
+		t.Fatalf("initial snapshot = %+v, want zero value", snapshot)
+	}
+
+	if _, err := coordinator.Admit(key, func() {}); err != nil {
+		t.Fatalf("Admit() first error = %v", err)
+	}
+
+	if _, err := coordinator.Admit(key, func() {}); err != nil {
+		t.Fatalf("Admit() second error = %v", err)
+	}
+
+	if snapshot := coordinator.Snapshot(key); !snapshot.InFlight || snapshot.Queued != 1 {
+		t.Fatalf("queued snapshot = %+v, want in_flight:true queued:1", snapshot)
+	}
+
+	if work, ok := coordinator.Complete(key); !ok || work == nil {
+		t.Fatalf("Complete() = ok:%v nil-work:%v, want ok:true nil-work:false", ok, work == nil)
+	}
+
+	if snapshot := coordinator.Snapshot(key); !snapshot.InFlight || snapshot.Queued != 0 {
+		t.Fatalf("running snapshot = %+v, want in_flight:true queued:0", snapshot)
+	}
+
+	if work, ok := coordinator.Complete(key); ok || work != nil {
+		t.Fatalf("final Complete() = ok:%v nil-work:%v, want ok:false nil-work:true", ok, work == nil)
+	}
+
+	if snapshot := coordinator.Snapshot(key); snapshot != (app.QueueSnapshot{}) {
+		t.Fatalf("final snapshot = %+v, want zero value", snapshot)
+	}
+}
+
 type stubThreadStore struct {
 	activeTask   app.ActiveTask
 	activeTaskOK bool
@@ -197,6 +236,22 @@ func (s stubThreadStore) GetThreadBinding(context.Context, string, string) (app.
 
 func (s stubThreadStore) UpsertThreadBinding(context.Context, app.ThreadBinding) error {
 	return nil
+}
+
+func (s stubThreadStore) GetActiveDailySession(context.Context, string) (app.DailySession, bool, error) {
+	return app.DailySession{}, false, nil
+}
+
+func (s stubThreadStore) GetLatestDailySessionBefore(context.Context, string) (app.DailySession, bool, error) {
+	return app.DailySession{}, false, nil
+}
+
+func (s stubThreadStore) CreateDailySession(context.Context, app.DailySession) (app.DailySession, error) {
+	return app.DailySession{}, nil
+}
+
+func (s stubThreadStore) RotateDailySession(context.Context, string, string) (app.DailySession, error) {
+	return app.DailySession{}, nil
 }
 
 func (s stubThreadStore) CreateTask(context.Context, app.Task) error {

--- a/internal/thread/queue.go
+++ b/internal/thread/queue.go
@@ -65,3 +65,18 @@ func (c *QueueCoordinator) Complete(key string) (func(), bool) {
 	entry.waiting = entry.waiting[1:]
 	return next, true
 }
+
+func (c *QueueCoordinator) Snapshot(key string) app.QueueSnapshot {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	entry, ok := c.entries[key]
+	if !ok {
+		return app.QueueSnapshot{}
+	}
+
+	return app.QueueSnapshot{
+		InFlight: entry.running,
+		Queued:   len(entry.waiting),
+	}
+}

--- a/migrations/sqlite/0003_daily_sessions.sql
+++ b/migrations/sqlite/0003_daily_sessions.sql
@@ -1,0 +1,49 @@
+CREATE TABLE daily_sessions (
+    local_date TEXT NOT NULL,
+    generation INTEGER NOT NULL,
+    logical_thread_key TEXT NOT NULL,
+    previous_logical_thread_key TEXT NULL,
+    activation_reason TEXT NOT NULL,
+    is_active INTEGER NOT NULL DEFAULT 1,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    PRIMARY KEY (local_date, generation),
+    UNIQUE (logical_thread_key)
+);
+
+CREATE UNIQUE INDEX daily_sessions_active_local_date_idx
+    ON daily_sessions (local_date)
+    WHERE is_active = 1;
+
+UPDATE thread_bindings
+SET logical_thread_key = logical_thread_key || '#1'
+WHERE mode = 'daily'
+  AND instr(logical_thread_key, '#') = 0
+  AND length(logical_thread_key) = 10
+  AND substr(logical_thread_key, 5, 1) = '-'
+  AND substr(logical_thread_key, 8, 1) = '-';
+
+INSERT OR IGNORE INTO daily_sessions (
+    local_date,
+    generation,
+    logical_thread_key,
+    previous_logical_thread_key,
+    activation_reason,
+    is_active,
+    created_at,
+    updated_at
+)
+SELECT
+    substr(logical_thread_key, 1, 10) AS local_date,
+    1 AS generation,
+    logical_thread_key,
+    NULL,
+    'legacy-migration',
+    1,
+    created_at,
+    updated_at
+FROM thread_bindings
+WHERE mode = 'daily'
+  AND instr(logical_thread_key, '#') > 0
+  AND substr(logical_thread_key, length(logical_thread_key), 1) = '1'
+  AND length(logical_thread_key) > 11;


### PR DESCRIPTION
## Summary

- add explicit `daily_sessions` persistence and migrate legacy bare-date daily bindings to generation keys
- route `daily` messages through the active generation and add `action:clear` for same-day rotation
- make daily memory preflight generation-aware and close ExecPlan 12

## Background

`daily` mode previously bound one shared Codex thread directly to the local date. That made same-day resets awkward, prevented explicit shared rotation, and forced the durable-memory preflight to assume that the previous source was always the previous calendar day.

## Related issue(s)

- None.

## Implementation details

- added `migrations/sqlite/0003_daily_sessions.sql` and SQLite store methods for active-session lookup, prior-day lookup, generation creation, same-day rotation, and legacy key backfill
- added app-level `DailySession` helpers plus `DailyCommandService` for `action:clear`
- updated message handling so `daily` traffic resolves the active generation before preflight and thread binding lookup
- changed daily memory refresh to use generation metadata and generation-scoped bridge notes such as `AGENT_MEMORY/YYYY-MM-DD.<generation>.md`
- extended the queue coordinator with snapshots so clear requests reject rotation while a generation is in flight or queued
- updated Discord command registration, interaction routing, and runtime tests for `action:clear`
- moved ExecPlan 12 to `docs/exec-plans/completed`

## Test coverage

- `go test ./internal/store/sqlite`
- `go test ./internal/app`
- `go test ./internal/dailymemory`
- `go test ./internal/runtime/discord`
- `go test ./internal/thread`
- `go test ./...`
- `./scripts/lint -c .golangci.yml`

## Breaking changes

- legacy `daily` thread-binding keys are normalized from `YYYY-MM-DD` to `YYYY-MM-DD#1` during migration
- same-day `daily` thread bindings now persist against generation keys instead of bare dates

## Notes

- `action:clear` is rejected when the active same-day generation is busy or has queued work
- `make` is not installed in this environment, so equivalent direct validation commands were used

Created by Codex