### PR TITLE
[codex] Enable direct-message turns without mentions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ It is built for teams or individuals who want to work with Codex from inside Dis
 - two conversation modes for different workflows
 - one instance-specific slash command with explicit action choices
 - SQLite-backed continuity across restarts
-- image attachment support for mention-triggered turns
+- image attachment support for guild mentions and direct messages
 - queued acknowledgments when the same conversation is already busy
 
 ## Installation
@@ -153,9 +153,9 @@ Use `task` mode when you want durable work streams that continue across multiple
 
 ### Normal conversation
 
-- 39claw responds only when the bot is mentioned
+- 39claw responds to direct messages without a mention, and to guild messages only when the bot is mentioned
 - a qualifying message may contain text, images, or both
-- if the mention includes no text and no usable image, the bot stays silent
+- if the qualifying trigger includes no text and no usable image, the bot stays silent
 - replies are posted in the same channel as replies to the triggering message
 
 ### Commands
@@ -286,7 +286,7 @@ If this is your first time running a Discord bot, do this before the quick start
 
 In the bot settings, enable **Message Content Intent**.
 
-39claw reads the content of mention-triggered messages, so this intent is required for normal conversation in guild channels.
+39claw reads the content of guild mention-triggered messages and direct messages, so this intent is required for normal conversation in guild channels.
 
 ### 3. Generate an invite URL
 
@@ -326,7 +326,7 @@ If you set `CLAW_DISCORD_GUILD_ID`, 39claw registers slash commands in that guil
 
 ### 7. Know what to expect in the channel
 
-- normal conversation is mention-only
+- normal conversation is mention-only in guild channels and works without a mention in DMs
 - slash commands are explicit and do not require a mention
 - in `task` mode, users must create or switch to a task before normal conversation will run
 
@@ -494,7 +494,7 @@ go test ./internal/runtime/discord -run 'TestRuntimeContract' -v
 
 These suites exercise the real Discord runtime startup path with a fake session and verify observable behavior such as:
 
-- reply targeting for qualifying mentions
+- reply targeting for qualifying guild mentions and direct messages
 - streamed in-place reply edits for immediate turns
 - queued acknowledgments followed by deferred replies
 - command-style interaction presentation
@@ -505,7 +505,8 @@ These suites exercise the real Discord runtime startup path with a fake session 
 Use this checklist when you want optional live Discord hardening beyond the normal automated suites.
 It is most useful for real-platform behaviors such as hosted attachments, command registration, permissions, and final reply delivery:
 
-- mention the bot and confirm the reply targets the original message
+- mention the bot in a guild channel and confirm the reply targets the original message
+- send the bot a direct message without a mention and confirm it answers
 - mention the bot with text plus an image and confirm the request is handled
 - mention the bot with only an image and confirm the bot still answers
 - send unrelated chatter without a mention and confirm the bot stays silent
@@ -552,8 +553,8 @@ For the complete release candidate checklist, tagging steps, and post-release ve
 
 39claw is still early-stage software, but the current build already supports:
 
-- mention-only normal conversation
-- mention-triggered image attachment intake
+- guild mention and direct-message normal conversation
+- guild-mention and direct-message image attachment intake
 - `daily` and `task` conversation modes
 - one instance-specific root slash command
 - `action:help`, `action:task-current`, `action:task-list`, `action:task-new`, `action:task-switch`, and `action:task-close`

--- a/docs/design-docs/implementation-spec.md
+++ b/docs/design-docs/implementation-spec.md
@@ -113,9 +113,9 @@ When the bot runs in `daily` mode, 39claw also manages a durable memory projecti
 
 ## Discord Behavior Defaults
 
-Normal conversation is mention-only in v1.
+Normal conversation is mention-only in guild channels and direct-message-triggered in DMs in v1.
 When a qualifying normal message is handled, the bot replies in the same channel and targets the triggering message as the reply root.
-Qualifying normal messages may include text, image attachments, or both as long as the bot mention is present and at least one usable input remains after attachment filtering.
+Qualifying normal messages may include text, image attachments, or both as long as the guild-channel bot mention is present or the message arrived in a direct message, and at least one usable input remains after attachment filtering.
 
 Each bot instance should expose one slash-command surface whose root name comes from `CLAW_DISCORD_COMMAND_NAME`.
 That root command should always expose `action:help`.
@@ -136,8 +136,8 @@ If the source repository has an `origin` remote, 39claw should try `git fetch or
 Once the task worktree is ready, Codex runs with the task-specific `worktree_path` as the effective working directory for that turn.
 Closed tasks keep their task branches, but only the fifteen most recently closed ready tasks keep their worktrees; older closed ready worktrees are force-pruned.
 
-Unsupported non-mention chatter is ignored.
-Mention-only posts that contain no text and no usable image attachments are also ignored.
+Unsupported guild-channel non-mention chatter is ignored.
+Qualifying posts that contain no text and no usable image attachments are also ignored.
 Long responses are chunked into Discord-safe messages while preserving code fences when practical.
 Before a response is sent to Discord, local workspace file references should be rewritten so the absolute `CLAW_CODEX_WORKDIR` path is not exposed, and percent-encoded path segments should be decoded for display.
 Only one Codex turn may run at a time for a given logical thread key.
@@ -224,8 +224,8 @@ Most of these outcomes should be proven through automated contract coverage plus
 - In `daily` mode, the first qualifying mention creates generation `#1`, a second same-day mention reuses the active generation, and the first mention on the next local date creates a fresh `#1` generation after the durable-memory preflight refreshes `AGENT_MEMORY` from the last active prior-day generation when that previous binding exists.
 - In `daily` mode, `/<instance-command> action:clear` rotates the shared same-day generation only when the current generation is idle, and the next mention creates or resumes a fresh same-day binding after the durable-memory preflight refreshes `AGENT_MEMORY` from the previous recorded generation when that previous binding exists.
 - In `daily` mode, startup does not create or rewrite `AGENTS.md`.
-- A mention-triggered message with text plus image attachments reaches Codex as multipart input.
-- A mention-triggered message with only one or more usable image attachments is accepted and answered.
+- A guild mention or direct message with text plus image attachments reaches Codex as multipart input.
+- A guild mention or direct message with only one or more usable image attachments is accepted and answered.
 - In `task` mode, a normal mention without an active task returns guidance instead of routing to Codex.
 - `/<instance-command> action:task-current` shows the active task for the requesting user.
 - `/<instance-command> action:task-new task_name:<name>` creates a task and sets it active for the requesting user.
@@ -234,7 +234,7 @@ Most of these outcomes should be proven through automated contract coverage plus
 - `/<instance-command> action:task-close task_id:<id>` closes the task and clears active state when the closed task was active.
 - Closed-task worktree retention keeps only the fifteen most recently closed ready worktrees and never deletes the task branches.
 - Existing `daily` and `task` bindings survive process restart through SQLite-backed state.
-- Non-mention chatter is ignored, unsupported non-image-only mention posts stay silent, supported slash commands respond correctly, and long replies are chunked cleanly.
+- Guild non-mention chatter is ignored, unsupported non-image-only qualifying posts stay silent, supported slash commands respond correctly, and long replies are chunked cleanly.
 - Simultaneous requests for the same logical thread do not execute overlapping Codex turns.
 - Simultaneous requests for the same logical thread receive queued acknowledgments and later deferred replies until the waiting queue reaches five items.
 

--- a/docs/product-specs/discord-command-behavior.md
+++ b/docs/product-specs/discord-command-behavior.md
@@ -78,11 +78,14 @@ If the bot responds to normal conversation, the conditions should be easy for us
 
 Examples:
 
-- explicit mention required
+- explicit mention required in guild channels
+- direct messages may be treated as explicit user turns without an extra mention
 
-v1 should use mention-only triggering for normal-message interaction.
-When the bot is mentioned, a normal message may contain typed text, one or more image attachments, or both.
-If the mention is present but the message contains neither text nor a usable image attachment, the bot should stay silent.
+v1 should use a small, channel-aware trigger contract for normal-message interaction.
+In guild channels, normal-message interaction remains mention-only.
+In direct messages, normal-message interaction should work without an extra bot mention.
+When a qualifying normal message is accepted, it may contain typed text, one or more image attachments, or both.
+If a qualifying trigger is present but the message contains neither text nor a usable image attachment, the bot should stay silent.
 If the turn starts immediately, the bot may first post a short placeholder reply and then edit that same reply as Codex streams progress or partial assistant output.
 If another turn for the same logical conversation is already running, the bot should acknowledge queued acceptance immediately and post the real answer later as a reply to the original triggering message.
 If five waiting messages are already queued for that logical conversation, the bot should return a clear retry-later response instead of queueing more work.
@@ -263,7 +266,7 @@ This command behavior layer is not intended to:
 
 ## Decisions
 
-- v1 normal-message triggering should be mention-only.
+- v1 normal-message triggering should be mention-only in guild channels and direct-message-triggered in DMs.
 - each bot instance should register exactly one slash command whose name identifies that instance in Discord search.
 - `action:help` should stay structurally simple in v1, but it should only describe commands that are actually available in the current bot instance.
 - `daily` mode may expose `action:clear` on that same root command so users can intentionally rotate the shared same-day generation.

--- a/internal/runtime/discord/message_mapper.go
+++ b/internal/runtime/discord/message_mapper.go
@@ -17,7 +17,7 @@ func mapMessageCreate(selfUserID string, event *discordgo.MessageCreate) (app.Me
 		return app.MessageRequest{}, false
 	}
 
-	if !mentionsUser(event.Mentions, selfUserID) {
+	if !isDirectMessage(event) && !mentionsUser(event.Mentions, selfUserID) {
 		return app.MessageRequest{}, false
 	}
 
@@ -36,6 +36,10 @@ func mapMessageCreate(selfUserID string, event *discordgo.MessageCreate) (app.Me
 		Mentioned:  true,
 		ReceivedAt: receivedAt,
 	}, true
+}
+
+func isDirectMessage(event *discordgo.MessageCreate) bool {
+	return event != nil && strings.TrimSpace(event.GuildID) == ""
 }
 
 func mentionsUser(users []*discordgo.User, userID string) bool {

--- a/internal/runtime/discord/message_mapper_test.go
+++ b/internal/runtime/discord/message_mapper_test.go
@@ -1,0 +1,96 @@
+package discord
+
+import (
+	"testing"
+	"time"
+
+	"github.com/bwmarrin/discordgo"
+)
+
+func TestMapMessageCreate(t *testing.T) {
+	t.Parallel()
+
+	timestamp := time.Date(2026, time.April, 10, 9, 30, 0, 0, time.UTC)
+
+	tests := []struct {
+		name        string
+		event       *discordgo.MessageCreate
+		wantOK      bool
+		wantContent string
+	}{
+		{
+			name: "guild mention maps request",
+			event: &discordgo.MessageCreate{
+				Message: &discordgo.Message{
+					ID:        "message-1",
+					ChannelID: "channel-1",
+					GuildID:   "guild-1",
+					Content:   "<@bot-user> hello there",
+					Author:    &discordgo.User{ID: "user-1"},
+					Mentions: []*discordgo.User{
+						{ID: "bot-user"},
+					},
+					Timestamp: timestamp,
+				},
+			},
+			wantOK:      true,
+			wantContent: "hello there",
+		},
+		{
+			name: "direct message maps request without mention",
+			event: &discordgo.MessageCreate{
+				Message: &discordgo.Message{
+					ID:        "message-2",
+					ChannelID: "dm-channel-1",
+					Content:   "hello from dm",
+					Author:    &discordgo.User{ID: "user-1"},
+					Timestamp: timestamp,
+				},
+			},
+			wantOK:      true,
+			wantContent: "hello from dm",
+		},
+		{
+			name: "guild chatter without mention is ignored",
+			event: &discordgo.MessageCreate{
+				Message: &discordgo.Message{
+					ID:        "message-3",
+					ChannelID: "channel-1",
+					GuildID:   "guild-1",
+					Content:   "just chatting",
+					Author:    &discordgo.User{ID: "user-1"},
+					Timestamp: timestamp,
+				},
+			},
+			wantOK: false,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			request, ok := mapMessageCreate("bot-user", tt.event)
+			if ok != tt.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tt.wantOK)
+			}
+
+			if !tt.wantOK {
+				return
+			}
+
+			if request.Content != tt.wantContent {
+				t.Fatalf("content = %q, want %q", request.Content, tt.wantContent)
+			}
+
+			if !request.Mentioned {
+				t.Fatal("Mentioned = false, want true")
+			}
+
+			if !request.ReceivedAt.Equal(timestamp) {
+				t.Fatalf("received at = %v, want %v", request.ReceivedAt, timestamp)
+			}
+		})
+	}
+}

--- a/internal/runtime/discord/runtime_test.go
+++ b/internal/runtime/discord/runtime_test.go
@@ -158,6 +158,55 @@ func TestRuntimeMentionHandlingRepliesToTriggerMessage(t *testing.T) {
 	}
 }
 
+func TestRuntimeDirectMessageHandlingRepliesWithoutMention(t *testing.T) {
+	t.Parallel()
+
+	messageService := &fakeMessageService{
+		response: app.MessageResponse{
+			Text:      "Hello from DM",
+			ReplyToID: "message-1",
+		},
+	}
+	fakeSession := newFakeSession("bot-user")
+	runtime := newTestRuntimeWithServices(t, config.ModeDaily, fakeSession, messageService, &fakeTaskCommandService{})
+
+	if err := runtime.Start(context.Background()); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	t.Cleanup(func() {
+		_ = runtime.Close()
+	})
+
+	fakeSession.dispatchMessage(&discordgo.MessageCreate{
+		Message: &discordgo.Message{
+			ID:        "message-1",
+			ChannelID: "dm-channel-1",
+			Content:   "hello from dm",
+			Author:    &discordgo.User{ID: "user-1"},
+		},
+	})
+
+	if len(messageService.requests) != 1 {
+		t.Fatalf("message request count = %d, want %d", len(messageService.requests), 1)
+	}
+
+	if messageService.requests[0].Content != "hello from dm" {
+		t.Fatalf("mapped content = %q, want %q", messageService.requests[0].Content, "hello from dm")
+	}
+
+	if !messageService.requests[0].Mentioned {
+		t.Fatal("Mentioned = false, want true")
+	}
+
+	if len(fakeSession.sentMessages) != 1 {
+		t.Fatalf("sent message count = %d, want %d", len(fakeSession.sentMessages), 1)
+	}
+
+	if fakeSession.sentMessages[0].Reference == nil || fakeSession.sentMessages[0].Reference.MessageID != "message-1" {
+		t.Fatal("first sent message missing reply reference")
+	}
+}
+
 func TestRuntimeMentionHandlingStreamsProgressByEditingReply(t *testing.T) {
 	t.Parallel()
 
@@ -821,6 +870,7 @@ func TestRuntimeIgnoresUnsupportedChatter(t *testing.T) {
 		Message: &discordgo.Message{
 			ID:        "message-1",
 			ChannelID: "channel-1",
+			GuildID:   "guild-1",
 			Content:   "just chatting",
 			Author:    &discordgo.User{ID: "user-1"},
 		},


### PR DESCRIPTION
## Summary

- allow direct messages to reach the normal message flow without requiring a bot mention
- keep guild-channel behavior mention-only
- add mapper and runtime coverage for the DM trigger path
- update user-facing and implementation documentation to describe the guild-vs-DM contract

## Background

39claw previously accepted normal conversation only when the Discord message explicitly mentioned the bot. That made direct-message conversations feel broken because a DM is already an explicit conversation boundary and should not require an additional mention.

## Related issue(s)

- None

## Implementation details

- treat Discord messages with an empty `GuildID` as direct messages during runtime mapping
- preserve the existing mention requirement for guild-channel messages
- add table-driven mapper tests for guild mentions, DM messages, and ignored guild chatter
- add runtime coverage proving a DM without a mention reaches the message service and replies to the trigger message
- update README and Discord behavior specs so the product contract is consistent with the runtime

## Test coverage

- `go test ./internal/runtime/discord/...`
- `./scripts/lint -c .golangci.yml`
- `go test ./...`

## Breaking changes

- None

## Notes

- `make` was unavailable in the local environment, so the equivalent commands from `Makefile` were run directly.

Created by Codex
