### PR TITLE
[codex] Add completion reactions to Discord replies

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Use `task` mode when you want durable work streams that continue across multiple
 - a qualifying message may contain text, images, or both
 - if the qualifying trigger includes no text and no usable image, the bot stays silent
 - replies are posted in the same channel as replies to the triggering message
+- when a normal-message reply finishes successfully, 39claw adds a `✅` reaction to the primary bot reply when Discord permissions allow it
 
 ### Commands
 
@@ -309,8 +310,11 @@ Recommended permissions:
 
 Useful optional permissions:
 
+- `Add Reactions`
 - `Embed Links`
 - `Attach Files`
+
+`Add Reactions` is required if you want 39claw to mark completed normal-message replies with a `✅` reaction.
 
 ### 5. Invite the bot to a test server
 
@@ -506,6 +510,7 @@ Use this checklist when you want optional live Discord hardening beyond the norm
 It is most useful for real-platform behaviors such as hosted attachments, command registration, permissions, and final reply delivery:
 
 - mention the bot in a guild channel and confirm the reply targets the original message
+- confirm the bot adds a `✅` reaction after the final normal-message reply finishes
 - send the bot a direct message without a mention and confirm it answers
 - mention the bot with text plus an image and confirm the request is handled
 - mention the bot with only an image and confirm the bot still answers

--- a/docs/design-docs/implementation-spec.md
+++ b/docs/design-docs/implementation-spec.md
@@ -116,6 +116,7 @@ When the bot runs in `daily` mode, 39claw also manages a durable memory projecti
 Normal conversation is mention-only in guild channels and direct-message-triggered in DMs in v1.
 When a qualifying normal message is handled, the bot replies in the same channel and targets the triggering message as the reply root.
 Qualifying normal messages may include text, image attachments, or both as long as the guild-channel bot mention is present or the message arrived in a direct message, and at least one usable input remains after attachment filtering.
+When a normal-message reply finishes successfully, 39claw should add a `✅` reaction to the primary bot reply message as a best-effort completion marker when Discord permissions allow it.
 
 Each bot instance should expose one slash-command surface whose root name comes from `CLAW_DISCORD_COMMAND_NAME`.
 That root command should always expose `action:help`.
@@ -140,6 +141,7 @@ Unsupported guild-channel non-mention chatter is ignored.
 Qualifying posts that contain no text and no usable image attachments are also ignored.
 Long responses are chunked into Discord-safe messages while preserving code fences when practical.
 Before a response is sent to Discord, local workspace file references should be rewritten so the absolute `CLAW_CODEX_WORKDIR` path is not exposed, and percent-encoded path segments should be decoded for display.
+Failure to add the completion reaction must not fail or delay reply delivery.
 Only one Codex turn may run at a time for a given logical thread key.
 If another message arrives for the same logical thread while a turn is running, the bot should accept up to five waiting messages in an in-memory FIFO queue.
 Queued messages should receive an immediate acknowledgment and later receive their final answer as a follow-up reply to the original message.

--- a/docs/product-specs/discord-command-behavior.md
+++ b/docs/product-specs/discord-command-behavior.md
@@ -87,6 +87,7 @@ In direct messages, normal-message interaction should work without an extra bot 
 When a qualifying normal message is accepted, it may contain typed text, one or more image attachments, or both.
 If a qualifying trigger is present but the message contains neither text nor a usable image attachment, the bot should stay silent.
 If the turn starts immediately, the bot may first post a short placeholder reply and then edit that same reply as Codex streams progress or partial assistant output.
+When a normal-message reply finishes successfully, the bot may add a small completion marker such as a `✅` reaction to its reply message when Discord permissions allow it.
 If another turn for the same logical conversation is already running, the bot should acknowledge queued acceptance immediately and post the real answer later as a reply to the original triggering message.
 If five waiting messages are already queued for that logical conversation, the bot should return a clear retry-later response instead of queueing more work.
 

--- a/internal/app/message_service_impl.go
+++ b/internal/app/message_service_impl.go
@@ -163,6 +163,7 @@ func (s *DefaultMessageService) HandleMessage(ctx context.Context, request Messa
 		return MessageResponse{
 			Text:      queuedAcknowledgementMessage(admission.Position),
 			ReplyToID: request.MessageID,
+			Deferred:  true,
 		}, nil
 	}
 

--- a/internal/app/types.go
+++ b/internal/app/types.go
@@ -24,6 +24,7 @@ type MessageResponse struct {
 	ReplyToID string
 	Ephemeral bool
 	Ignore    bool
+	Deferred  bool
 }
 
 type ThreadBinding struct {

--- a/internal/runtime/discord/live_message.go
+++ b/internal/runtime/discord/live_message.go
@@ -40,6 +40,17 @@ func (p *liveMessagePresenter) Active() bool {
 	return len(p.messageIDs) > 0
 }
 
+func (p *liveMessagePresenter) PrimaryMessageID() string {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if len(p.messageIDs) == 0 {
+		return ""
+	}
+
+	return p.messageIDs[0]
+}
+
 func (p *liveMessagePresenter) Update(text string) error {
 	return p.syncText(text)
 }

--- a/internal/runtime/discord/presenter.go
+++ b/internal/runtime/discord/presenter.go
@@ -7,15 +7,17 @@ import (
 	"github.com/bwmarrin/discordgo"
 )
 
-func presentMessage(discordSession session, channelID string, response app.MessageResponse) error {
+func presentMessage(discordSession session, channelID string, response app.MessageResponse) (string, error) {
 	if response.Ignore {
-		return nil
+		return "", nil
 	}
 
 	chunks := chunkText(response.Text)
 	if len(chunks) == 0 {
-		return nil
+		return "", nil
 	}
+
+	primaryMessageID := ""
 
 	for index, chunk := range chunks {
 		payload := &discordgo.MessageSend{
@@ -26,12 +28,17 @@ func presentMessage(discordSession session, channelID string, response app.Messa
 			payload.Reference = replyReference(channelID, response.ReplyToID)
 		}
 
-		if _, err := discordSession.ChannelMessageSendComplex(channelID, payload); err != nil {
-			return fmt.Errorf("send channel message: %w", err)
+		message, err := discordSession.ChannelMessageSendComplex(channelID, payload)
+		if err != nil {
+			return "", fmt.Errorf("send channel message: %w", err)
+		}
+
+		if index == 0 && message != nil {
+			primaryMessageID = message.ID
 		}
 	}
 
-	return nil
+	return primaryMessageID, nil
 }
 
 func presentInteraction(discordSession session, interaction *discordgo.Interaction, response app.MessageResponse) error {

--- a/internal/runtime/discord/runtime.go
+++ b/internal/runtime/discord/runtime.go
@@ -18,6 +18,7 @@ import (
 const (
 	defaultShutdownDrainTimeout = 5 * time.Second
 	forcedShutdownWaitTimeout   = time.Second
+	completionReactionEmoji     = "✅"
 )
 
 type Dependencies struct {
@@ -255,7 +256,7 @@ func (r *Runtime) handleMessageCreate(_ *discordgo.Session, event *discordgo.Mes
 		}
 
 		r.logger.Error("prepare image attachments", "error", err, "channel_id", request.ChannelID, "message_id", request.MessageID)
-		if err := r.presentMessageResponse(discordSession, request.ChannelID, app.MessageResponse{
+		if _, err := r.presentMessageResponse(discordSession, request.ChannelID, app.MessageResponse{
 			Text:      imageDownloadErrorMessage,
 			ReplyToID: request.MessageID,
 		}); err != nil {
@@ -312,13 +313,16 @@ func (r *Runtime) handleMessageCreate(_ *discordgo.Session, event *discordgo.Mes
 			return err
 		}
 
-		if err := r.presentMessageResponse(currentSession, request.ChannelID, response); err != nil {
+		messageID, err := r.presentMessageResponse(currentSession, request.ChannelID, response)
+		if err != nil {
 			r.logger.Error(
 				"deferred reply delivery failed",
 				append(logAttrs, "outcome", "failure", "error", err)...,
 			)
 			return err
 		}
+
+		r.addCompletionReaction(currentSession, request.ChannelID, messageID)
 
 		r.logger.Info(
 			"deferred reply delivery succeeded",
@@ -336,15 +340,24 @@ func (r *Runtime) handleMessageCreate(_ *discordgo.Session, event *discordgo.Mes
 		}
 	}
 
+	reactionTargetID := ""
 	var presentErr error
 	if livePresenter.Active() {
 		presentErr = livePresenter.Update(response.Text)
+		if presentErr == nil {
+			reactionTargetID = livePresenter.PrimaryMessageID()
+		}
 	} else {
-		presentErr = r.presentMessageResponse(discordSession, request.ChannelID, response)
+		reactionTargetID, presentErr = r.presentMessageResponse(discordSession, request.ChannelID, response)
 	}
 
 	if presentErr != nil {
 		r.logger.Error("present message response", "error", presentErr, "channel_id", request.ChannelID, "message_id", request.MessageID)
+		return
+	}
+
+	if err == nil && !response.Ignore && !response.Deferred {
+		r.addCompletionReaction(discordSession, request.ChannelID, reactionTargetID)
 	}
 }
 
@@ -455,9 +468,29 @@ func (c *lifecycleContext) Cancel() {
 	})
 }
 
-func (r *Runtime) presentMessageResponse(discordSession session, channelID string, response app.MessageResponse) error {
+func (r *Runtime) presentMessageResponse(discordSession session, channelID string, response app.MessageResponse) (string, error) {
 	response.Text = formatDiscordResponseText(response.Text, r.config.CodexWorkdir)
 	return presentMessage(discordSession, channelID, response)
+}
+
+func (r *Runtime) addCompletionReaction(discordSession session, channelID string, messageID string) {
+	if strings.TrimSpace(channelID) == "" || strings.TrimSpace(messageID) == "" {
+		return
+	}
+
+	if err := discordSession.MessageReactionAdd(channelID, messageID, completionReactionEmoji); err != nil {
+		r.logger.Warn(
+			"add completion reaction",
+			"error",
+			err,
+			"channel_id",
+			channelID,
+			"message_id",
+			messageID,
+			"emoji",
+			completionReactionEmoji,
+		)
+	}
 }
 
 func (r *Runtime) presentInteractionResponse(

--- a/internal/runtime/discord/runtime_test.go
+++ b/internal/runtime/discord/runtime_test.go
@@ -156,6 +156,18 @@ func TestRuntimeMentionHandlingRepliesToTriggerMessage(t *testing.T) {
 	if fakeSession.sentMessages[0].Reference == nil || fakeSession.sentMessages[0].Reference.MessageID != "message-1" {
 		t.Fatal("first sent message missing reply reference")
 	}
+
+	if len(fakeSession.reactions) != 1 {
+		t.Fatalf("reaction count = %d, want %d", len(fakeSession.reactions), 1)
+	}
+
+	if fakeSession.reactions[0].messageID != "sent-message-1" {
+		t.Fatalf("reaction message id = %q, want %q", fakeSession.reactions[0].messageID, "sent-message-1")
+	}
+
+	if fakeSession.reactions[0].emoji != completionReactionEmoji {
+		t.Fatalf("reaction emoji = %q, want %q", fakeSession.reactions[0].emoji, completionReactionEmoji)
+	}
 }
 
 func TestRuntimeDirectMessageHandlingRepliesWithoutMention(t *testing.T) {
@@ -275,6 +287,14 @@ func TestRuntimeMentionHandlingStreamsProgressByEditingReply(t *testing.T) {
 	if got := stringPointerValue(fakeSession.editedMessages[1].Content); got != "Final streamed response" {
 		t.Fatalf("second edit content = %q, want %q", got, "Final streamed response")
 	}
+
+	if len(fakeSession.reactions) != 1 {
+		t.Fatalf("reaction count = %d, want %d", len(fakeSession.reactions), 1)
+	}
+
+	if fakeSession.reactions[0].messageID != "sent-message-1" {
+		t.Fatalf("reaction message id = %q, want %q", fakeSession.reactions[0].messageID, "sent-message-1")
+	}
 }
 
 func TestRuntimeMentionHandlingSanitizesWorkspacePathsForDiscord(t *testing.T) {
@@ -343,6 +363,7 @@ func TestRuntimeMentionHandlingPresentsQueuedAcknowledgementAndDeferredReply(t *
 			return app.MessageResponse{
 				Text:      "A response is already running for this conversation. Your message has been queued at position 1.",
 				ReplyToID: request.MessageID,
+				Deferred:  true,
 			}, nil
 		},
 	}
@@ -376,6 +397,10 @@ func TestRuntimeMentionHandlingPresentsQueuedAcknowledgementAndDeferredReply(t *
 		t.Fatalf("queued ack content = %q", fakeSession.sentMessages[0].Content)
 	}
 
+	if len(fakeSession.reactions) != 0 {
+		t.Fatalf("reaction count after ack = %d, want %d", len(fakeSession.reactions), 0)
+	}
+
 	close(deliverQueuedResponse)
 
 	select {
@@ -394,6 +419,14 @@ func TestRuntimeMentionHandlingPresentsQueuedAcknowledgementAndDeferredReply(t *
 
 	if fakeSession.sentMessages[1].Reference == nil || fakeSession.sentMessages[1].Reference.MessageID != "message-1" {
 		t.Fatal("deferred sent message missing reply reference")
+	}
+
+	if len(fakeSession.reactions) != 1 {
+		t.Fatalf("reaction count after deferred delivery = %d, want %d", len(fakeSession.reactions), 1)
+	}
+
+	if fakeSession.reactions[0].messageID != "sent-message-2" {
+		t.Fatalf("reaction message id = %q, want %q", fakeSession.reactions[0].messageID, "sent-message-2")
 	}
 }
 
@@ -415,6 +448,7 @@ func TestRuntimeDeferredReplyDeliveryLogsStructuredSuccess(t *testing.T) {
 			return app.MessageResponse{
 				Text:      "A response is already running for this conversation. Your message has been queued at position 1.",
 				ReplyToID: request.MessageID,
+				Deferred:  true,
 			}, nil
 		},
 	}
@@ -499,6 +533,7 @@ func TestRuntimeCloseWaitsForDeferredQueuedReplyDrain(t *testing.T) {
 			return app.MessageResponse{
 				Text:      "A response is already running for this conversation. Your message has been queued at position 1.",
 				ReplyToID: request.MessageID,
+				Deferred:  true,
 			}, nil
 		},
 		waitForDrain: func(ctx context.Context) error {
@@ -590,6 +625,7 @@ func TestRuntimeCloseCancelsDeferredDrainWhenTimeoutExpires(t *testing.T) {
 			return app.MessageResponse{
 				Text:      "A response is already running for this conversation. Your message has been queued at position 1.",
 				ReplyToID: request.MessageID,
+				Deferred:  true,
 			}, nil
 		},
 		waitForDrain: func(ctx context.Context) error {

--- a/internal/runtime/discord/runtime_test_helpers_test.go
+++ b/internal/runtime/discord/runtime_test_helpers_test.go
@@ -189,10 +189,17 @@ type fakeSession struct {
 	sentMessages         []*discordgo.MessageSend
 	editedMessages       []*discordgo.MessageEdit
 	deletedMessageIDs    []string
+	reactions            []addedReaction
 	interactionResponses []*discordgo.InteractionResponse
 	interactionEdits     []*discordgo.WebhookEdit
 	followups            []*discordgo.WebhookParams
 	deliveries           []runtimeharness.Delivery
+}
+
+type addedReaction struct {
+	channelID string
+	messageID string
+	emoji     string
 }
 
 func newFakeSession(selfUserID string) *fakeSession {
@@ -305,6 +312,24 @@ func (s *fakeSession) ChannelMessageDelete(
 		Kind:      runtimeharness.DeliveryKindChannelDelete,
 		ChannelID: channelID,
 		MessageID: messageID,
+	})
+	s.mu.Unlock()
+
+	s.signal()
+	return nil
+}
+
+func (s *fakeSession) MessageReactionAdd(
+	channelID string,
+	messageID string,
+	emojiID string,
+	options ...discordgo.RequestOption,
+) error {
+	s.mu.Lock()
+	s.reactions = append(s.reactions, addedReaction{
+		channelID: channelID,
+		messageID: messageID,
+		emoji:     emojiID,
 	})
 	s.mu.Unlock()
 

--- a/internal/runtime/discord/session.go
+++ b/internal/runtime/discord/session.go
@@ -28,6 +28,12 @@ type session interface {
 		messageID string,
 		options ...discordgo.RequestOption,
 	) error
+	MessageReactionAdd(
+		channelID string,
+		messageID string,
+		emojiID string,
+		options ...discordgo.RequestOption,
+	) error
 	InteractionRespond(
 		interaction *discordgo.Interaction,
 		resp *discordgo.InteractionResponse,


### PR DESCRIPTION
## Summary

- add a `✅` completion reaction after successful Discord normal-message replies finish
- avoid marking queued acknowledgements as complete before their deferred final reply arrives
- document the new completion marker behavior and the optional `Add Reactions` permission

## Background

39claw currently streams progress by editing Discord replies in place, but the final transition from in-progress output to completed output is easy to miss. A lightweight completion reaction makes the end of a successful reply clearer without polluting the message body with a mechanical footer.

## Related issue(s)

- None

## Implementation details

- add Discord reaction support to the runtime session abstraction
- track the primary bot reply message so the runtime can add a `✅` reaction after the final successful render
- add a small response hint so queued acknowledgements are not treated as final completed replies
- keep reaction failures best-effort so missing Discord permissions do not block or delay reply delivery
- update runtime tests to cover normal replies, streamed replies, and queued/deferred reply flows
- update README and Discord behavior docs to describe the completion marker and the `Add Reactions` permission requirement

## Test coverage

- `./scripts/lint -c .golangci.yml`
- `go test ./...`

## Breaking changes

- None

## Notes

- The `✅` reaction is only added for successful normal-message replies.
- Queued acknowledgements do not receive the reaction; the deferred final reply does.

Created by Codex
