### PR TITLE
[codex] Prefer task names for task-switch and task-close

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,8 +182,8 @@ In `task` mode, the same root command also supports:
   - list open tasks and mark the active one
 - `/<instance-command> action:task-new task_name:<name>`
   - create a task and make it active
-- `/<instance-command> action:task-switch task_id:<id>`
-  - switch the active task
+- `/<instance-command> action:task-switch task_name:<name>`
+  - switch the active task by name; use `task_id` only when the name is ambiguous
 - `/<instance-command> action:task-close task_id:<id>`
   - close a task
 

--- a/README.md
+++ b/README.md
@@ -184,8 +184,8 @@ In `task` mode, the same root command also supports:
   - create a task and make it active
 - `/<instance-command> action:task-switch task_name:<name>`
   - switch the active task by name; use `task_id` only when the name is ambiguous
-- `/<instance-command> action:task-close task_id:<id>`
-  - close a task
+- `/<instance-command> action:task-close task_name:<name>`
+  - close a task by name; use `task_id` only when the name is ambiguous
 
 ### Busy conversations
 

--- a/docs/design-docs/implementation-spec.md
+++ b/docs/design-docs/implementation-spec.md
@@ -233,7 +233,7 @@ Most of these outcomes should be proven through automated contract coverage plus
 - `/<instance-command> action:task-new task_name:<name>` creates a task and sets it active for the requesting user.
 - The first normal message for a new task creates a task worktree lazily under `${CLAW_DATADIR}/worktrees/<task_id>` and then runs Codex inside that worktree.
 - `/<instance-command> action:task-switch task_name:<name>` changes the routing target for subsequent normal messages, with `task_id` reserved for ambiguity fallback.
-- `/<instance-command> action:task-close task_id:<id>` closes the task and clears active state when the closed task was active.
+- `/<instance-command> action:task-close task_name:<name>` closes the task and clears active state when the closed task was active, with `task_id` reserved for ambiguity fallback.
 - Closed-task worktree retention keeps only the fifteen most recently closed ready worktrees and never deletes the task branches.
 - Existing `daily` and `task` bindings survive process restart through SQLite-backed state.
 - Guild non-mention chatter is ignored, unsupported non-image-only qualifying posts stay silent, supported slash commands respond correctly, and long replies are chunked cleanly.

--- a/docs/design-docs/implementation-spec.md
+++ b/docs/design-docs/implementation-spec.md
@@ -232,7 +232,7 @@ Most of these outcomes should be proven through automated contract coverage plus
 - `/<instance-command> action:task-current` shows the active task for the requesting user.
 - `/<instance-command> action:task-new task_name:<name>` creates a task and sets it active for the requesting user.
 - The first normal message for a new task creates a task worktree lazily under `${CLAW_DATADIR}/worktrees/<task_id>` and then runs Codex inside that worktree.
-- `/<instance-command> action:task-switch task_id:<id>` changes the routing target for subsequent normal messages.
+- `/<instance-command> action:task-switch task_name:<name>` changes the routing target for subsequent normal messages, with `task_id` reserved for ambiguity fallback.
 - `/<instance-command> action:task-close task_id:<id>` closes the task and clears active state when the closed task was active.
 - Closed-task worktree retention keeps only the fifteen most recently closed ready worktrees and never deletes the task branches.
 - Existing `daily` and `task` bindings survive process restart through SQLite-backed state.

--- a/docs/design-docs/task-mode-worktrees.md
+++ b/docs/design-docs/task-mode-worktrees.md
@@ -101,7 +101,7 @@ If any step fails, Codex must not run for that turn.
 
 Task switching remains intentionally small.
 
-`/<instance-command> action:task-switch task_id:<id>` changes only the active task pointer for the requesting user.
+`/<instance-command> action:task-switch task_name:<name>` changes only the active task pointer for the requesting user, with `task_id` used only as an ambiguity fallback.
 It does not:
 
 - run Git checkout in the current shell

--- a/docs/product-specs/discord-command-behavior.md
+++ b/docs/product-specs/discord-command-behavior.md
@@ -127,8 +127,8 @@ The root command should support user-facing actions for:
   - create a new task and switch the active task to it
 - `/<instance-command> action:task-switch task_name:<name>`
   - switch the active task to the uniquely named open task, with `task_id` available only when the name is ambiguous
-- `/<instance-command> action:task-close task_id:<id>`
-  - close the specified task
+- `/<instance-command> action:task-close task_name:<name>`
+  - close the uniquely named open task, with `task_id` available only when the name is ambiguous
 
 Every instance should also support:
 

--- a/docs/product-specs/discord-command-behavior.md
+++ b/docs/product-specs/discord-command-behavior.md
@@ -125,8 +125,8 @@ The root command should support user-facing actions for:
   - show task names and IDs
 - `/<instance-command> action:task-new task_name:<name>`
   - create a new task and switch the active task to it
-- `/<instance-command> action:task-switch task_id:<id>`
-  - switch the active task to the specified task
+- `/<instance-command> action:task-switch task_name:<name>`
+  - switch the active task to the uniquely named open task, with `task_id` available only when the name is ambiguous
 - `/<instance-command> action:task-close task_id:<id>`
   - close the specified task
 

--- a/docs/product-specs/task-mode-user-flow.md
+++ b/docs/product-specs/task-mode-user-flow.md
@@ -151,8 +151,8 @@ For `task` mode to feel usable, v1 should support at least:
   - create a new task and switch the active task to it
 - `/<instance-command> action:task-switch task_name:<name>`
   - switch the active task to the uniquely named open task, with `task_id` used only when the name is ambiguous
-- `/<instance-command> action:task-close task_id:<id>`
-  - close the specified task
+- `/<instance-command> action:task-close task_name:<name>`
+  - close the uniquely named open task, with `task_id` used only when the name is ambiguous
 
 The root-command action surface should stay explicit and stable enough that users can learn it as the standard task-control surface for `task` mode.
 

--- a/docs/product-specs/task-mode-user-flow.md
+++ b/docs/product-specs/task-mode-user-flow.md
@@ -67,7 +67,7 @@ Expected user perception:
 
 Expected flow:
 
-1. The user uses `/<instance-command> action:task-new task_name:<name>`, `/<instance-command> action:task-switch task_id:<id>`, or `/<instance-command> action:task-current` plus other task actions to establish the desired task context.
+1. The user uses `/<instance-command> action:task-new task_name:<name>`, `/<instance-command> action:task-switch task_name:<name>`, or `/<instance-command> action:task-current` plus other task actions to establish the desired task context.
 2. 39claw records that task as the active context for the user within the current bot instance.
 3. A newly created task reserves its own task branch identity even before worktree creation.
 4. The next normal message routes to the thread associated with that task.
@@ -149,8 +149,8 @@ For `task` mode to feel usable, v1 should support at least:
   - show task names and IDs
 - `/<instance-command> action:task-new task_name:<name>`
   - create a new task and switch the active task to it
-- `/<instance-command> action:task-switch task_id:<id>`
-  - switch the active task to the specified task
+- `/<instance-command> action:task-switch task_name:<name>`
+  - switch the active task to the uniquely named open task, with `task_id` used only when the name is ambiguous
 - `/<instance-command> action:task-close task_id:<id>`
   - close the specified task
 
@@ -190,7 +190,7 @@ When no active task exists, the bot should:
 
 - say that an active task is required
 - explain the next action clearly
-- direct the user toward `/<instance-command> action:task-new task_name:<name>`, `/<instance-command> action:task-switch task_id:<id>`, or `/<instance-command> action:task-list` as appropriate
+- direct the user toward `/<instance-command> action:task-new task_name:<name>`, `/<instance-command> action:task-switch task_name:<name>`, or `/<instance-command> action:task-list` as appropriate
 - avoid pretending the user message was processed normally
 
 If a user closes a task and then immediately sends a normal message, the bot should treat that as a missing-active-task case.

--- a/internal/app/command_surface.go
+++ b/internal/app/command_surface.go
@@ -22,10 +22,10 @@ func (s commandSurface) taskSwitchPlaceholder() string {
 	return fmt.Sprintf("`/%s action:task-switch task_name:<name>`", s.commandName)
 }
 
-func (s commandSurface) taskSwitchIDPlaceholder() string {
-	return fmt.Sprintf("`/%s action:task-switch task_id:<id>`", s.commandName)
-}
-
 func (s commandSurface) taskClose(taskID string) string {
 	return fmt.Sprintf("`/%s action:task-close task_id:%s`", s.commandName, taskID)
+}
+
+func (s commandSurface) taskIDPlaceholder(action string) string {
+	return fmt.Sprintf("`/%s action:%s task_id:<id>`", s.commandName, action)
 }

--- a/internal/app/command_surface.go
+++ b/internal/app/command_surface.go
@@ -19,6 +19,10 @@ func (s commandSurface) taskNewPlaceholder() string {
 }
 
 func (s commandSurface) taskSwitchPlaceholder() string {
+	return fmt.Sprintf("`/%s action:task-switch task_name:<name>`", s.commandName)
+}
+
+func (s commandSurface) taskSwitchIDPlaceholder() string {
 	return fmt.Sprintf("`/%s action:task-switch task_id:<id>`", s.commandName)
 }
 

--- a/internal/app/message_service_test.go
+++ b/internal/app/message_service_test.go
@@ -432,7 +432,7 @@ func TestMessageServiceHandleMessageReturnsTaskGuidance(t *testing.T) {
 		t.Fatalf("HandleMessage() error = %v", err)
 	}
 
-	if response.Text != "No active task is selected. Use `/release action:task-new task_name:<name>`, `/release action:task-list`, or `/release action:task-switch task_id:<id>` first." {
+	if response.Text != "No active task is selected. Use `/release action:task-new task_name:<name>`, `/release action:task-list`, or `/release action:task-switch task_name:<name>` first." {
 		t.Fatalf("guidance text = %q", response.Text)
 	}
 }

--- a/internal/app/task_service.go
+++ b/internal/app/task_service.go
@@ -16,7 +16,7 @@ type TaskCommandService interface {
 	ListTasks(ctx context.Context, userID string) (MessageResponse, error)
 	CreateTask(ctx context.Context, userID string, taskName string) (MessageResponse, error)
 	SwitchTask(ctx context.Context, userID string, taskID string, taskName string) (MessageResponse, error)
-	CloseTask(ctx context.Context, userID string, taskID string) (MessageResponse, error)
+	CloseTask(ctx context.Context, userID string, taskID string, taskName string) (MessageResponse, error)
 }
 
 type TaskCommandServiceDependencies struct {
@@ -165,7 +165,7 @@ func (s *DefaultTaskCommandService) SwitchTask(ctx context.Context, userID strin
 		return taskCommandResponse(s.taskSelectorRequiredMessage()), nil
 	}
 
-	task, ok, err := s.loadTaskForSwitch(ctx, userID, taskID, taskName)
+	task, ok, err := s.loadOpenTaskBySelector(ctx, userID, taskID, taskName, "task-switch")
 	if err != nil {
 		var commandErr taskCommandError
 		if errors.As(err, &commandErr) {
@@ -210,20 +210,32 @@ func (s *DefaultTaskCommandService) SwitchTask(ctx context.Context, userID strin
 	), nil
 }
 
-func (s *DefaultTaskCommandService) CloseTask(ctx context.Context, userID string, taskID string) (MessageResponse, error) {
+func (s *DefaultTaskCommandService) CloseTask(ctx context.Context, userID string, taskID string, taskName string) (MessageResponse, error) {
 	taskID = strings.TrimSpace(taskID)
-	if taskID == "" {
-		return taskCommandResponse(s.taskIDRequiredMessage()), nil
+	taskName = strings.TrimSpace(taskName)
+	if taskID == "" && taskName == "" {
+		return taskCommandResponse(s.taskSelectorRequiredMessage()), nil
 	}
 
-	task, ok, err := s.store.GetTask(ctx, userID, taskID)
+	task, ok, err := s.loadOpenTaskBySelector(ctx, userID, taskID, taskName, "task-close")
 	if err != nil {
-		return MessageResponse{}, fmt.Errorf("load task: %w", err)
+		var commandErr taskCommandError
+		if errors.As(err, &commandErr) {
+			return taskCommandResponse(commandErr.Error()), nil
+		}
+
+		return MessageResponse{}, err
 	}
 
 	if !ok {
+		if taskID != "" {
+			return taskCommandResponse(
+				fmt.Sprintf("Task `%s` was not found. Use %s to find an open task.", taskID, s.commands.taskList()),
+			), nil
+		}
+
 		return taskCommandResponse(
-			fmt.Sprintf("Task `%s` was not found. Use %s to find an open task.", taskID, s.commands.taskList()),
+			fmt.Sprintf("No open task named `%s` was found. Use %s to find an open task.", taskName, s.commands.taskList()),
 		), nil
 	}
 
@@ -289,10 +301,6 @@ func (s *DefaultTaskCommandService) taskSelectorRequiredMessage() string {
 	return fmt.Sprintf("A task name or task ID is required. Use %s to find an open task.", s.commands.taskList())
 }
 
-func (s *DefaultTaskCommandService) taskIDRequiredMessage() string {
-	return fmt.Sprintf("A task ID is required. Use %s to find an open task.", s.commands.taskList())
-}
-
 func (s *DefaultTaskCommandService) taskNameRequiredMessage() string {
 	return fmt.Sprintf("A task name is required. Use %s to create one.", s.commands.taskNewPlaceholder())
 }
@@ -330,11 +338,12 @@ func taskCommandResponse(text string) MessageResponse {
 	}
 }
 
-func (s *DefaultTaskCommandService) loadTaskForSwitch(
+func (s *DefaultTaskCommandService) loadOpenTaskBySelector(
 	ctx context.Context,
 	userID string,
 	taskID string,
 	taskName string,
+	action string,
 ) (Task, bool, error) {
 	if taskID != "" {
 		task, ok, err := s.store.GetTask(ctx, userID, taskID)
@@ -369,7 +378,7 @@ func (s *DefaultTaskCommandService) loadTaskForSwitch(
 		for _, task := range matches {
 			lines = append(lines, "- "+renderTask(task))
 		}
-		lines = append(lines, fmt.Sprintf("Use %s when the task name is ambiguous.", s.commands.taskSwitchIDPlaceholder()))
+		lines = append(lines, fmt.Sprintf("Use %s when the task name is ambiguous.", s.commands.taskIDPlaceholder(action)))
 		return Task{}, false, taskCommandError(strings.Join(lines, "\n"))
 	}
 }

--- a/internal/app/task_service.go
+++ b/internal/app/task_service.go
@@ -15,7 +15,7 @@ type TaskCommandService interface {
 	ShowCurrentTask(ctx context.Context, userID string) (MessageResponse, error)
 	ListTasks(ctx context.Context, userID string) (MessageResponse, error)
 	CreateTask(ctx context.Context, userID string, taskName string) (MessageResponse, error)
-	SwitchTask(ctx context.Context, userID string, taskID string) (MessageResponse, error)
+	SwitchTask(ctx context.Context, userID string, taskID string, taskName string) (MessageResponse, error)
 	CloseTask(ctx context.Context, userID string, taskID string) (MessageResponse, error)
 }
 
@@ -158,20 +158,32 @@ func (s *DefaultTaskCommandService) CreateTask(ctx context.Context, userID strin
 	), nil
 }
 
-func (s *DefaultTaskCommandService) SwitchTask(ctx context.Context, userID string, taskID string) (MessageResponse, error) {
+func (s *DefaultTaskCommandService) SwitchTask(ctx context.Context, userID string, taskID string, taskName string) (MessageResponse, error) {
 	taskID = strings.TrimSpace(taskID)
-	if taskID == "" {
-		return taskCommandResponse(s.taskIDRequiredMessage()), nil
+	taskName = strings.TrimSpace(taskName)
+	if taskID == "" && taskName == "" {
+		return taskCommandResponse(s.taskSelectorRequiredMessage()), nil
 	}
 
-	task, ok, err := s.store.GetTask(ctx, userID, taskID)
+	task, ok, err := s.loadTaskForSwitch(ctx, userID, taskID, taskName)
 	if err != nil {
-		return MessageResponse{}, fmt.Errorf("load task: %w", err)
+		var commandErr taskCommandError
+		if errors.As(err, &commandErr) {
+			return taskCommandResponse(commandErr.Error()), nil
+		}
+
+		return MessageResponse{}, err
 	}
 
 	if !ok {
+		if taskID != "" {
+			return taskCommandResponse(
+				fmt.Sprintf("Task `%s` was not found. Use %s to find an open task.", taskID, s.commands.taskList()),
+			), nil
+		}
+
 		return taskCommandResponse(
-			fmt.Sprintf("Task `%s` was not found. Use %s to find an open task.", taskID, s.commands.taskList()),
+			fmt.Sprintf("No open task named `%s` was found. Use %s to find an open task.", taskName, s.commands.taskList()),
 		), nil
 	}
 
@@ -273,6 +285,10 @@ func (s *DefaultTaskCommandService) noOpenTasksMessage() string {
 	return fmt.Sprintf("No open tasks yet. Use %s to create one.", s.commands.taskNewPlaceholder())
 }
 
+func (s *DefaultTaskCommandService) taskSelectorRequiredMessage() string {
+	return fmt.Sprintf("A task name or task ID is required. Use %s to find an open task.", s.commands.taskList())
+}
+
 func (s *DefaultTaskCommandService) taskIDRequiredMessage() string {
 	return fmt.Sprintf("A task ID is required. Use %s to find an open task.", s.commands.taskList())
 }
@@ -312,6 +328,56 @@ func taskCommandResponse(text string) MessageResponse {
 		Text:      text,
 		Ephemeral: true,
 	}
+}
+
+func (s *DefaultTaskCommandService) loadTaskForSwitch(
+	ctx context.Context,
+	userID string,
+	taskID string,
+	taskName string,
+) (Task, bool, error) {
+	if taskID != "" {
+		task, ok, err := s.store.GetTask(ctx, userID, taskID)
+		if err != nil {
+			return Task{}, false, fmt.Errorf("load task: %w", err)
+		}
+
+		return task, ok, nil
+	}
+
+	tasks, err := s.store.ListOpenTasks(ctx, userID)
+	if err != nil {
+		return Task{}, false, fmt.Errorf("list open tasks for switch: %w", err)
+	}
+
+	matches := make([]Task, 0, len(tasks))
+	for _, task := range tasks {
+		if strings.EqualFold(task.TaskName, taskName) {
+			matches = append(matches, task)
+		}
+	}
+
+	switch len(matches) {
+	case 0:
+		return Task{}, false, nil
+	case 1:
+		return matches[0], true, nil
+	default:
+		lines := []string{
+			fmt.Sprintf("Multiple open tasks are named `%s`. Retry with a task ID:", taskName),
+		}
+		for _, task := range matches {
+			lines = append(lines, "- "+renderTask(task))
+		}
+		lines = append(lines, fmt.Sprintf("Use %s when the task name is ambiguous.", s.commands.taskSwitchIDPlaceholder()))
+		return Task{}, false, taskCommandError(strings.Join(lines, "\n"))
+	}
+}
+
+type taskCommandError string
+
+func (e taskCommandError) Error() string {
+	return string(e)
 }
 
 func (s *DefaultTaskCommandService) pruneClosedTaskWorktrees(ctx context.Context) {

--- a/internal/app/task_service_test.go
+++ b/internal/app/task_service_test.go
@@ -54,7 +54,7 @@ func TestTaskCommandServiceShowCurrentTaskWithoutActiveTaskReturnsGuidance(t *te
 		t.Fatalf("ShowCurrentTask() error = %v", err)
 	}
 
-	want := "No active task is selected. Use `/release action:task-new task_name:<name>`, `/release action:task-list`, or `/release action:task-switch task_id:<id>` first."
+	want := "No active task is selected. Use `/release action:task-new task_name:<name>`, `/release action:task-list`, or `/release action:task-switch task_name:<name>` first."
 	if response.Text != want {
 		t.Fatalf("Text = %q, want %q", response.Text, want)
 	}
@@ -153,13 +153,13 @@ func TestTaskCommandServiceListTasksMarksActiveTask(t *testing.T) {
 		t.Fatalf("ListTasks() error = %v", err)
 	}
 
-	want := "Open tasks:\n- `Release work` (`task-1`)\n- `Docs update` (`task-2`) [active]\nUse `/release action:task-switch task_id:<id>` to change the active task."
+	want := "Open tasks:\n- `Release work` (`task-1`)\n- `Docs update` (`task-2`) [active]\nUse `/release action:task-switch task_name:<name>` to change the active task."
 	if response.Text != want {
 		t.Fatalf("Text = %q, want %q", response.Text, want)
 	}
 }
 
-func TestTaskCommandServiceSwitchTaskRequiresOpenTask(t *testing.T) {
+func TestTaskCommandServiceSwitchTaskByIDRequiresOpenTask(t *testing.T) {
 	t.Parallel()
 
 	service := newTaskCommandService(t, &memoryThreadStore{
@@ -174,12 +174,85 @@ func TestTaskCommandServiceSwitchTaskRequiresOpenTask(t *testing.T) {
 		},
 	})
 
-	response, err := service.SwitchTask(context.Background(), "user-1", "task-1")
+	response, err := service.SwitchTask(context.Background(), "user-1", "task-1", "")
 	if err != nil {
 		t.Fatalf("SwitchTask() error = %v", err)
 	}
 
 	want := "Task `task-1` is closed. Use `/release action:task-list` to find an open task or `/release action:task-new task_name:<name>` to create another one."
+	if response.Text != want {
+		t.Fatalf("Text = %q, want %q", response.Text, want)
+	}
+}
+
+func TestTaskCommandServiceSwitchTaskByUniqueName(t *testing.T) {
+	t.Parallel()
+
+	store := &memoryThreadStore{
+		tasks: map[string]app.Task{
+			"user-1:task-1": {
+				TaskID:        "task-1",
+				DiscordUserID: "user-1",
+				TaskName:      "Release work",
+				Status:        app.TaskStatusOpen,
+				CreatedAt:     time.Date(2026, time.April, 5, 0, 0, 0, 0, time.UTC),
+			},
+		},
+	}
+	service := newTaskCommandService(t, store)
+
+	response, err := service.SwitchTask(context.Background(), "user-1", "", "release work")
+	if err != nil {
+		t.Fatalf("SwitchTask() error = %v", err)
+	}
+
+	want := "Active task is now `Release work` (`task-1`). Your next message will continue this task."
+	if response.Text != want {
+		t.Fatalf("Text = %q, want %q", response.Text, want)
+	}
+
+	activeTask, ok, err := store.GetActiveTask(context.Background(), "user-1")
+	if err != nil {
+		t.Fatalf("GetActiveTask() error = %v", err)
+	}
+
+	if !ok {
+		t.Fatal("GetActiveTask() ok = false, want true")
+	}
+
+	if activeTask.TaskID != "task-1" {
+		t.Fatalf("TaskID = %q, want %q", activeTask.TaskID, "task-1")
+	}
+}
+
+func TestTaskCommandServiceSwitchTaskByNameRequiresIDWhenAmbiguous(t *testing.T) {
+	t.Parallel()
+
+	service := newTaskCommandService(t, &memoryThreadStore{
+		tasks: map[string]app.Task{
+			"user-1:task-1": {
+				TaskID:        "task-1",
+				DiscordUserID: "user-1",
+				TaskName:      "Release work",
+				Status:        app.TaskStatusOpen,
+				CreatedAt:     time.Date(2026, time.April, 5, 0, 0, 0, 0, time.UTC),
+			},
+			"user-1:task-2": {
+				TaskID:        "task-2",
+				DiscordUserID: "user-1",
+				TaskName:      "Release work",
+				Status:        app.TaskStatusOpen,
+				CreatedAt:     time.Date(2026, time.April, 5, 1, 0, 0, 0, time.UTC),
+			},
+		},
+	})
+
+	response, err := service.SwitchTask(context.Background(), "user-1", "", "Release work")
+	if err != nil {
+		t.Fatalf("SwitchTask() error = %v", err)
+	}
+
+	want := "Multiple open tasks are named `Release work`. Retry with a task ID:\n- `Release work` (`task-1`)\n- `Release work` (`task-2`)\nUse `/release action:task-switch task_id:<id>` when the task name is ambiguous."
 	if response.Text != want {
 		t.Fatalf("Text = %q, want %q", response.Text, want)
 	}

--- a/internal/app/task_service_test.go
+++ b/internal/app/task_service_test.go
@@ -280,7 +280,7 @@ func TestTaskCommandServiceCloseTaskClearsActiveTaskWhenClosingCurrentTask(t *te
 	}
 	service := newTaskCommandService(t, store)
 
-	response, err := service.CloseTask(context.Background(), "user-1", "task-1")
+	response, err := service.CloseTask(context.Background(), "user-1", "task-1", "")
 	if err != nil {
 		t.Fatalf("CloseTask() error = %v", err)
 	}
@@ -324,7 +324,7 @@ func TestTaskCommandServiceCloseTaskKeepsDifferentActiveTask(t *testing.T) {
 	}
 	service := newTaskCommandService(t, store)
 
-	response, err := service.CloseTask(context.Background(), "user-1", "task-1")
+	response, err := service.CloseTask(context.Background(), "user-1", "task-1", "")
 	if err != nil {
 		t.Fatalf("CloseTask() error = %v", err)
 	}
@@ -354,12 +354,78 @@ func TestTaskCommandServiceCloseTaskTriggersPruning(t *testing.T) {
 	worktrees := &countingTaskWorkspaceManager{}
 	service := newTaskCommandServiceWithWorkspace(t, store, nil, worktrees)
 
-	if _, err := service.CloseTask(context.Background(), "user-1", "task-1"); err != nil {
+	if _, err := service.CloseTask(context.Background(), "user-1", "task-1", ""); err != nil {
 		t.Fatalf("CloseTask() error = %v", err)
 	}
 
 	if worktrees.pruneCalls != 1 {
 		t.Fatalf("PruneClosed() call count = %d, want %d", worktrees.pruneCalls, 1)
+	}
+}
+
+func TestTaskCommandServiceCloseTaskByUniqueName(t *testing.T) {
+	t.Parallel()
+
+	store := &memoryThreadStore{
+		tasks: map[string]app.Task{
+			"user-1:task-1": {
+				TaskID:        "task-1",
+				DiscordUserID: "user-1",
+				TaskName:      "Release work",
+				Status:        app.TaskStatusOpen,
+				CreatedAt:     time.Date(2026, time.April, 5, 0, 0, 0, 0, time.UTC),
+			},
+		},
+		activeTasks: map[string]app.ActiveTask{
+			"user-1": {
+				DiscordUserID: "user-1",
+				TaskID:        "task-1",
+			},
+		},
+	}
+	service := newTaskCommandService(t, store)
+
+	response, err := service.CloseTask(context.Background(), "user-1", "", "Release work")
+	if err != nil {
+		t.Fatalf("CloseTask() error = %v", err)
+	}
+
+	want := "Closed task `Release work` (`task-1`). No active task is selected now."
+	if response.Text != want {
+		t.Fatalf("Text = %q, want %q", response.Text, want)
+	}
+}
+
+func TestTaskCommandServiceCloseTaskByNameRequiresIDWhenAmbiguous(t *testing.T) {
+	t.Parallel()
+
+	service := newTaskCommandService(t, &memoryThreadStore{
+		tasks: map[string]app.Task{
+			"user-1:task-1": {
+				TaskID:        "task-1",
+				DiscordUserID: "user-1",
+				TaskName:      "Release work",
+				Status:        app.TaskStatusOpen,
+				CreatedAt:     time.Date(2026, time.April, 5, 0, 0, 0, 0, time.UTC),
+			},
+			"user-1:task-2": {
+				TaskID:        "task-2",
+				DiscordUserID: "user-1",
+				TaskName:      "Release work",
+				Status:        app.TaskStatusOpen,
+				CreatedAt:     time.Date(2026, time.April, 5, 1, 0, 0, 0, time.UTC),
+			},
+		},
+	})
+
+	response, err := service.CloseTask(context.Background(), "user-1", "", "Release work")
+	if err != nil {
+		t.Fatalf("CloseTask() error = %v", err)
+	}
+
+	want := "Multiple open tasks are named `Release work`. Retry with a task ID:\n- `Release work` (`task-1`)\n- `Release work` (`task-2`)\nUse `/release action:task-close task_id:<id>` when the task name is ambiguous."
+	if response.Text != want {
+		t.Fatalf("Text = %q, want %q", response.Text, want)
 	}
 }
 

--- a/internal/runtime/discord/commands.go
+++ b/internal/runtime/discord/commands.go
@@ -56,13 +56,13 @@ func registeredCommands(cfg config.Config) []*discordgo.ApplicationCommand {
 			&discordgo.ApplicationCommandOption{
 				Type:        discordgo.ApplicationCommandOptionString,
 				Name:        optionTaskName,
-				Description: "Task name for task-new.",
+				Description: "Task name for task-new or task-switch.",
 				Required:    false,
 			},
 			&discordgo.ApplicationCommandOption{
 				Type:        discordgo.ApplicationCommandOptionString,
 				Name:        optionTaskID,
-				Description: "Task ID for task-switch or task-close.",
+				Description: "Task ID for task-switch when a name is ambiguous, or for task-close.",
 				Required:    false,
 			},
 		)
@@ -97,7 +97,7 @@ func helpResponse(commandName string, mode config.Mode) app.MessageResponse {
 			fmt.Sprintf("- `/%s action:%s` shows the active task.", commandName, actionTaskCurrent),
 			fmt.Sprintf("- `/%s action:%s` lists open tasks.", commandName, actionTaskList),
 			fmt.Sprintf("- `/%s action:%s task_name:<name>` creates and activates a task.", commandName, actionTaskNew),
-			fmt.Sprintf("- `/%s action:%s task_id:<id>` changes the active task.", commandName, actionTaskSwitch),
+			fmt.Sprintf("- `/%s action:%s task_name:<name>` changes the active task and falls back to `task_id` when the name is ambiguous.", commandName, actionTaskSwitch),
 			fmt.Sprintf("- `/%s action:%s task_id:<id>` closes a task.", commandName, actionTaskClose),
 		)
 	}
@@ -121,7 +121,7 @@ func unsupportedActionText(commandName string, mode config.Mode) string {
 	}
 
 	return fmt.Sprintf(
-		"Unsupported action. Use `/%s action:%s`, `/%s action:%s`, `/%s action:%s`, `/%s action:%s task_name:<name>`, `/%s action:%s task_id:<id>`, or `/%s action:%s task_id:<id>`.",
+		"Unsupported action. Use `/%s action:%s`, `/%s action:%s`, `/%s action:%s`, `/%s action:%s task_name:<name>`, `/%s action:%s task_name:<name>`, or `/%s action:%s task_id:<id>`.",
 		commandName,
 		actionHelp,
 		commandName,

--- a/internal/runtime/discord/commands.go
+++ b/internal/runtime/discord/commands.go
@@ -56,13 +56,13 @@ func registeredCommands(cfg config.Config) []*discordgo.ApplicationCommand {
 			&discordgo.ApplicationCommandOption{
 				Type:        discordgo.ApplicationCommandOptionString,
 				Name:        optionTaskName,
-				Description: "Task name for task-new or task-switch.",
+				Description: "Task name for task-new, task-switch, or task-close.",
 				Required:    false,
 			},
 			&discordgo.ApplicationCommandOption{
 				Type:        discordgo.ApplicationCommandOptionString,
 				Name:        optionTaskID,
-				Description: "Task ID for task-switch when a name is ambiguous, or for task-close.",
+				Description: "Task ID for task-switch or task-close when a name is ambiguous.",
 				Required:    false,
 			},
 		)
@@ -98,7 +98,7 @@ func helpResponse(commandName string, mode config.Mode) app.MessageResponse {
 			fmt.Sprintf("- `/%s action:%s` lists open tasks.", commandName, actionTaskList),
 			fmt.Sprintf("- `/%s action:%s task_name:<name>` creates and activates a task.", commandName, actionTaskNew),
 			fmt.Sprintf("- `/%s action:%s task_name:<name>` changes the active task and falls back to `task_id` when the name is ambiguous.", commandName, actionTaskSwitch),
-			fmt.Sprintf("- `/%s action:%s task_id:<id>` closes a task.", commandName, actionTaskClose),
+			fmt.Sprintf("- `/%s action:%s task_name:<name>` closes a task and falls back to `task_id` when the name is ambiguous.", commandName, actionTaskClose),
 		)
 	}
 
@@ -121,7 +121,7 @@ func unsupportedActionText(commandName string, mode config.Mode) string {
 	}
 
 	return fmt.Sprintf(
-		"Unsupported action. Use `/%s action:%s`, `/%s action:%s`, `/%s action:%s`, `/%s action:%s task_name:<name>`, `/%s action:%s task_name:<name>`, or `/%s action:%s task_id:<id>`.",
+		"Unsupported action. Use `/%s action:%s`, `/%s action:%s`, `/%s action:%s`, `/%s action:%s task_name:<name>`, `/%s action:%s task_name:<name>`, or `/%s action:%s task_name:<name>`.",
 		commandName,
 		actionHelp,
 		commandName,

--- a/internal/runtime/discord/runtime.go
+++ b/internal/runtime/discord/runtime.go
@@ -540,7 +540,7 @@ func (r *Runtime) routeCommand(ctx context.Context, request commandRequest) (app
 		case actionTaskSwitch:
 			return r.taskCommand.SwitchTask(ctx, request.UserID, request.TaskID, request.TaskName)
 		case actionTaskClose:
-			return r.taskCommand.CloseTask(ctx, request.UserID, request.TaskID)
+			return r.taskCommand.CloseTask(ctx, request.UserID, request.TaskID, request.TaskName)
 		}
 
 		return app.MessageResponse{

--- a/internal/runtime/discord/runtime.go
+++ b/internal/runtime/discord/runtime.go
@@ -538,7 +538,7 @@ func (r *Runtime) routeCommand(ctx context.Context, request commandRequest) (app
 		case actionTaskNew:
 			return r.taskCommand.CreateTask(ctx, request.UserID, request.TaskName)
 		case actionTaskSwitch:
-			return r.taskCommand.SwitchTask(ctx, request.UserID, request.TaskID)
+			return r.taskCommand.SwitchTask(ctx, request.UserID, request.TaskID, request.TaskName)
 		case actionTaskClose:
 			return r.taskCommand.CloseTask(ctx, request.UserID, request.TaskID)
 		}

--- a/internal/runtime/discord/runtime_test.go
+++ b/internal/runtime/discord/runtime_test.go
@@ -1122,6 +1122,10 @@ func TestRuntimeTaskCommandRoutesTaskModeActions(t *testing.T) {
 			Text:      "Created task `Release work` (`task-1`) and made it active. Your next message will continue this task.",
 			Ephemeral: true,
 		},
+		switchResponse: app.MessageResponse{
+			Text:      "Active task is now `Release work` (`task-1`). Your next message will continue this task.",
+			Ephemeral: true,
+		},
 	}
 	fakeSession := newFakeSession("bot-user")
 	runtime := newTestRuntimeWithServices(t, config.ModeTask, fakeSession, &fakeMessageService{}, taskService)
@@ -1135,6 +1139,7 @@ func TestRuntimeTaskCommandRoutesTaskModeActions(t *testing.T) {
 
 	fakeSession.dispatchInteraction(commandInteractionEvent("release", "user-1", actionTaskCurrent, "", ""))
 	fakeSession.dispatchInteraction(commandInteractionEvent("release", "user-1", actionTaskNew, "Release work", ""))
+	fakeSession.dispatchInteraction(commandInteractionEvent("release", "user-1", actionTaskSwitch, "Release work", ""))
 
 	if len(taskService.currentCalls) != 1 {
 		t.Fatalf("current call count = %d, want %d", len(taskService.currentCalls), 1)
@@ -1148,11 +1153,23 @@ func TestRuntimeTaskCommandRoutesTaskModeActions(t *testing.T) {
 		t.Fatalf("create task name = %q, want %q", taskService.createCalls[0].taskName, "Release work")
 	}
 
-	if len(fakeSession.interactionResponses) != 2 {
-		t.Fatalf("interaction response count = %d, want %d", len(fakeSession.interactionResponses), 2)
+	if len(taskService.switchCalls) != 1 {
+		t.Fatalf("switch call count = %d, want %d", len(taskService.switchCalls), 1)
 	}
 
-	response := fakeSession.interactionResponses[1]
+	if taskService.switchCalls[0].taskName != "Release work" {
+		t.Fatalf("switch task name = %q, want %q", taskService.switchCalls[0].taskName, "Release work")
+	}
+
+	if taskService.switchCalls[0].taskID != "" {
+		t.Fatalf("switch task id = %q, want empty", taskService.switchCalls[0].taskID)
+	}
+
+	if len(fakeSession.interactionResponses) != 3 {
+		t.Fatalf("interaction response count = %d, want %d", len(fakeSession.interactionResponses), 3)
+	}
+
+	response := fakeSession.interactionResponses[2]
 	if response.Data == nil || response.Data.Flags != discordgo.MessageFlagsEphemeral {
 		t.Fatal("task response should be ephemeral")
 	}

--- a/internal/runtime/discord/runtime_test.go
+++ b/internal/runtime/discord/runtime_test.go
@@ -1126,6 +1126,10 @@ func TestRuntimeTaskCommandRoutesTaskModeActions(t *testing.T) {
 			Text:      "Active task is now `Release work` (`task-1`). Your next message will continue this task.",
 			Ephemeral: true,
 		},
+		closeResponse: app.MessageResponse{
+			Text:      "Closed task `Release work` (`task-1`). No active task is selected now.",
+			Ephemeral: true,
+		},
 	}
 	fakeSession := newFakeSession("bot-user")
 	runtime := newTestRuntimeWithServices(t, config.ModeTask, fakeSession, &fakeMessageService{}, taskService)
@@ -1140,6 +1144,7 @@ func TestRuntimeTaskCommandRoutesTaskModeActions(t *testing.T) {
 	fakeSession.dispatchInteraction(commandInteractionEvent("release", "user-1", actionTaskCurrent, "", ""))
 	fakeSession.dispatchInteraction(commandInteractionEvent("release", "user-1", actionTaskNew, "Release work", ""))
 	fakeSession.dispatchInteraction(commandInteractionEvent("release", "user-1", actionTaskSwitch, "Release work", ""))
+	fakeSession.dispatchInteraction(commandInteractionEvent("release", "user-1", actionTaskClose, "Release work", ""))
 
 	if len(taskService.currentCalls) != 1 {
 		t.Fatalf("current call count = %d, want %d", len(taskService.currentCalls), 1)
@@ -1165,11 +1170,23 @@ func TestRuntimeTaskCommandRoutesTaskModeActions(t *testing.T) {
 		t.Fatalf("switch task id = %q, want empty", taskService.switchCalls[0].taskID)
 	}
 
-	if len(fakeSession.interactionResponses) != 3 {
-		t.Fatalf("interaction response count = %d, want %d", len(fakeSession.interactionResponses), 3)
+	if len(taskService.closeCalls) != 1 {
+		t.Fatalf("close call count = %d, want %d", len(taskService.closeCalls), 1)
 	}
 
-	response := fakeSession.interactionResponses[2]
+	if taskService.closeCalls[0].taskName != "Release work" {
+		t.Fatalf("close task name = %q, want %q", taskService.closeCalls[0].taskName, "Release work")
+	}
+
+	if taskService.closeCalls[0].taskID != "" {
+		t.Fatalf("close task id = %q, want empty", taskService.closeCalls[0].taskID)
+	}
+
+	if len(fakeSession.interactionResponses) != 4 {
+		t.Fatalf("interaction response count = %d, want %d", len(fakeSession.interactionResponses), 4)
+	}
+
+	response := fakeSession.interactionResponses[3]
 	if response.Data == nil || response.Data.Flags != discordgo.MessageFlagsEphemeral {
 		t.Fatal("task response should be ephemeral")
 	}

--- a/internal/runtime/discord/runtime_test_helpers_test.go
+++ b/internal/runtime/discord/runtime_test_helpers_test.go
@@ -536,6 +536,11 @@ type fakeTaskCommandService struct {
 		userID   string
 		taskName string
 	}
+	switchCalls []struct {
+		userID   string
+		taskID   string
+		taskName string
+	}
 
 	currentResponse app.MessageResponse
 	listResponse    app.MessageResponse
@@ -561,7 +566,12 @@ func (s *fakeTaskCommandService) CreateTask(ctx context.Context, userID string, 
 	return s.createResponse, nil
 }
 
-func (s *fakeTaskCommandService) SwitchTask(ctx context.Context, userID string, taskID string) (app.MessageResponse, error) {
+func (s *fakeTaskCommandService) SwitchTask(ctx context.Context, userID string, taskID string, taskName string) (app.MessageResponse, error) {
+	s.switchCalls = append(s.switchCalls, struct {
+		userID   string
+		taskID   string
+		taskName string
+	}{userID: userID, taskID: taskID, taskName: taskName})
 	return s.switchResponse, nil
 }
 

--- a/internal/runtime/discord/runtime_test_helpers_test.go
+++ b/internal/runtime/discord/runtime_test_helpers_test.go
@@ -541,6 +541,11 @@ type fakeTaskCommandService struct {
 		taskID   string
 		taskName string
 	}
+	closeCalls []struct {
+		userID   string
+		taskID   string
+		taskName string
+	}
 
 	currentResponse app.MessageResponse
 	listResponse    app.MessageResponse
@@ -575,7 +580,12 @@ func (s *fakeTaskCommandService) SwitchTask(ctx context.Context, userID string, 
 	return s.switchResponse, nil
 }
 
-func (s *fakeTaskCommandService) CloseTask(ctx context.Context, userID string, taskID string) (app.MessageResponse, error) {
+func (s *fakeTaskCommandService) CloseTask(ctx context.Context, userID string, taskID string, taskName string) (app.MessageResponse, error) {
+	s.closeCalls = append(s.closeCalls, struct {
+		userID   string
+		taskID   string
+		taskName string
+	}{userID: userID, taskID: taskID, taskName: taskName})
 	return s.closeResponse, nil
 }
 


### PR DESCRIPTION
## Summary

- make `task-switch` and `task-close` prefer `task_name` instead of forcing users to supply a task ID every time
- keep `task_id` available as a fallback only when the requested task name is ambiguous
- update help text, user guidance, and task-mode documentation to reflect the new command contract

## Background

The previous task-mode command surface still required `task_id` for `task-close`, even after `task-switch` moved to a name-first workflow. That left the overall task UX inconsistent and forced users back into `task-list` output whenever they wanted to close a task. Aligning both actions around task names keeps the runtime contract simpler for users today and easier to carry forward into additional runtimes later.

## Related issue(s)

- None

## Implementation details

- update the task command service so both `task-switch` and `task-close` accept either a task name or a task ID
- treat task names as the preferred selector and resolve them against open tasks with case-insensitive exact matching
- fall back to `task_id` only when the task name is ambiguous or when the caller explicitly provides an ID
- reuse the same ambiguity messaging pattern for both switch and close flows
- update runtime command routing and fake test services to pass both `task_name` and `task_id` for close actions too
- add service and runtime tests for unique-name closing, ambiguous-name guidance, and refreshed command help text
- update README, product specs, and design docs so the documented task-mode UX matches the implementation

## Test coverage

- `./scripts/lint -c .golangci.yml`
- `go test ./...`

## Breaking changes

- `task-close` no longer documents `task_id` as the primary selector; `task_name` is now the primary path and `task_id` is the ambiguity fallback.

## Notes

- The name-based switch and close paths currently match open task names case-insensitively and require an exact name match.
- When multiple open tasks share the same name, the bot lists the matching tasks and asks the user to retry with a task ID.

Created by Codex