### PR TITLE
[codex] Use runtime context for daily memory preflight

### DIFF
--- a/internal/dailymemory/service.go
+++ b/internal/dailymemory/service.go
@@ -7,18 +7,14 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"time"
 
 	"github.com/HatsuneMiku3939/39claw/internal/app"
 )
-
-const defaultRefreshTimeout = time.Minute
 
 type Refresher struct {
 	Store   app.ThreadStore
 	Gateway app.CodexGateway
 	Workdir string
-	Timeout time.Duration
 }
 
 func (r Refresher) RefreshBeforeFirstDailyTurn(ctx context.Context, session app.DailySession) error {
@@ -83,14 +79,7 @@ func (r Refresher) RefreshBeforeFirstDailyTurn(ctx context.Context, session app.
 		return err
 	}
 
-	refreshCtx := ctx
-	cancel := func() {}
-	if timeout := r.effectiveTimeout(); timeout > 0 {
-		refreshCtx, cancel = context.WithTimeout(ctx, timeout)
-	}
-	defer cancel()
-
-	result, err := r.Gateway.RunTurn(refreshCtx, previousBinding.CodexThreadID, app.CodexTurnInput{
+	result, err := r.Gateway.RunTurn(ctx, previousBinding.CodexThreadID, app.CodexTurnInput{
 		Prompt:           buildRefreshPrompt(session.PreviousLogicalThreadKey, session.LogicalThreadKey, bridgeFilename),
 		WorkingDirectory: workdir,
 	})
@@ -103,14 +92,6 @@ func (r Refresher) RefreshBeforeFirstDailyTurn(ctx context.Context, session app.
 	}
 
 	return nil
-}
-
-func (r Refresher) effectiveTimeout() time.Duration {
-	if r.Timeout != 0 {
-		return r.Timeout
-	}
-
-	return defaultRefreshTimeout
 }
 
 func ensureBridgeNote(path string, previousThreadID string, previousLogicalKey string, currentLogicalKey string) error {

--- a/internal/dailymemory/service_test.go
+++ b/internal/dailymemory/service_test.go
@@ -42,7 +42,6 @@ func TestRefresherRefreshBeforeFirstDailyTurnUsesPreviousBinding(t *testing.T) {
 		Store:   store,
 		Gateway: gateway,
 		Workdir: workdir,
-		Timeout: time.Second,
 	}
 
 	err := refresher.RefreshBeforeFirstDailyTurn(
@@ -181,7 +180,7 @@ func TestRefresherReturnsErrorWhenCompletionFormatIsUnexpected(t *testing.T) {
 	}
 }
 
-func TestRefresherReturnsTimeout(t *testing.T) {
+func TestRefresherUsesCallerContextDeadline(t *testing.T) {
 	t.Parallel()
 
 	workdir := t.TempDir()
@@ -197,10 +196,12 @@ func TestRefresherReturnsTimeout(t *testing.T) {
 		},
 		Gateway: timeoutCodexGateway{},
 		Workdir: workdir,
-		Timeout: 10 * time.Millisecond,
 	}
 
-	err := refresher.RefreshBeforeFirstDailyTurn(context.Background(), app.DailySession{
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+
+	err := refresher.RefreshBeforeFirstDailyTurn(ctx, app.DailySession{
 		LocalDate:                "2026-04-06",
 		Generation:               1,
 		LogicalThreadKey:         "2026-04-06#1",


### PR DESCRIPTION
## Summary

- remove the dedicated daily-memory preflight timeout and run the hidden refresh turn under the runtime lifecycle context
- keep the preflight cancellation behavior aligned with normal visible Codex turns
- update daily-memory tests to prove the refresher now follows the caller context deadline

## Background

A production log showed `refresh daily memory bridge` failing with `run daily memory refresh turn: context deadline exceeded`. The refresher was wrapping the runtime context in its own one-minute timeout, so the hidden preflight turn could be canceled earlier than a normal visible turn even though both flows share the same runtime lifecycle. That made the preflight behavior inconsistent and caused avoidable daily-memory refresh failures when Codex was briefly slow.

## Related issue(s)

- None

## Implementation details

- remove the `Refresher`-local timeout field and the extra `context.WithTimeout(...)` wrapper
- pass the runtime-provided context straight through to `Gateway.RunTurn(...)` for the hidden preflight refresh
- keep the existing hidden-turn error handling intact so visible replies still continue when refresh fails for other reasons
- replace the timeout-focused unit test with coverage that proves the refresher respects the caller context deadline

## Test coverage

- `./scripts/lint -c .golangci.yml`
- `go test ./...`

## Breaking changes

- None

## Notes

- This change means the first visible daily reply can now wait as long as the runtime context allows when the hidden preflight refresh is slow, which matches normal turn behavior.

Created by Codex