### PR TITLE
[codex] Manage task worktrees from bare parent repos

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -55,7 +55,7 @@ Instead, it routes Discord interactions into Codex threads that operate against 
 The distinction between `daily` mode and `task` mode is therefore not a different execution engine.
 It is a difference in the role of the repository that Codex is operating against.
 
-- In `task` mode, the configured workdir must be a Git repository that serves as the source repository for task-isolated worktrees, allowing Codex to help perform operational tasks such as code changes, pull request handling, and release workflows.
+- In `task` mode, the configured workdir must be a Git repository with an `origin` remote. It remains the operator-visible source checkout and validation anchor, while 39claw creates task-isolated worktrees from its own managed bare parent repository under `CLAW_DATADIR`.
 - In `daily` mode, the repository is a knowledge-oriented repository that primarily contains instructions and documentation, allowing Codex to answer questions by following local guidance and searching the knowledge base.
 
 Both modes share the same Codex-native foundation.
@@ -270,11 +270,11 @@ thread_key = user + task_id
 
 Behavior:
 
-- `task` mode requires `CLAW_CODEX_WORKDIR` to be a Git repository
+- `task` mode requires `CLAW_CODEX_WORKDIR` to be a Git repository with an `origin` remote
 - normal messages require an active task context
-- each task reserves its own branch identity and eventually its own Git worktree
+- each task reserves its own branch identity in a managed bare parent repository under `${CLAW_DATADIR}/repos`
 - messages route to the thread bound to the active task
-- the first normal message for a task may lazily create the task worktree before Codex runs
+- the first normal message for a task may lazily create the managed bare parent and the task worktree before Codex runs
 - changing the active task changes the target thread
 - each task maps to a distinct Codex conversation thread, so switching tasks also switches execution context and working directory once the task worktree exists
 

--- a/README.md
+++ b/README.md
@@ -350,9 +350,9 @@ Pick one:
 - `CLAW_MODE=daily`
 - `CLAW_MODE=task`
 
-If you choose `task`, `CLAW_CODEX_WORKDIR` must point to a Git repository.
-39claw treats that repository as the source repository for task-specific worktrees stored under `CLAW_DATADIR`.
-If startup finds a missing or non-Git task workdir, the bot exits with a clear configuration error before it connects to Discord.
+If you choose `task`, `CLAW_CODEX_WORKDIR` must point to a Git repository with an `origin` remote.
+39claw treats that checkout as the operator-visible source repository and creates a managed bare parent under `CLAW_DATADIR/repos` plus task-specific worktrees under `CLAW_DATADIR/worktrees`.
+If startup finds a missing, non-Git, or no-`origin` task workdir, the bot exits with a clear configuration error before it connects to Discord.
 
 ### 2. Set the required environment variables
 
@@ -425,9 +425,9 @@ The first normal message for a new task may spend a moment preparing that task's
 - `CLAW_DISCORD_COMMAND_NAME`
   - the unique root slash command name for this bot instance
 - `CLAW_CODEX_WORKDIR`
-  - working directory passed to Codex
+  - in `daily` mode, the working directory passed to Codex; in `task` mode, the operator-visible Git checkout that must have an `origin` remote
 - `CLAW_DATADIR`
-  - directory used for local state; the SQLite database path is fixed to `39claw.sqlite` inside this directory
+  - directory used for local state; `39claw.sqlite`, managed task repositories under `repos/`, and task worktrees under `worktrees/` all live here
 - `CLAW_CODEX_EXECUTABLE`
   - path to the `codex` executable
 

--- a/cmd/39claw/main.go
+++ b/cmd/39claw/main.go
@@ -180,7 +180,7 @@ func run(ctx context.Context, lookupEnv func(string) (string, bool)) error {
 
 	var workspaceManager app.TaskWorkspaceManager
 	if cfg.Mode == config.ModeTask {
-		workspaceManager, err = app.NewTaskWorkspaceManager(app.TaskWorkspaceManagerDependencies{
+		workspaceManager, err = app.NewTaskWorkspaceManager(ctx, app.TaskWorkspaceManagerDependencies{
 			Store:            store,
 			SourceRepository: cfg.CodexWorkdir,
 			DataDir:          cfg.DataDir,

--- a/cmd/39claw/main_test.go
+++ b/cmd/39claw/main_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -227,6 +228,19 @@ func TestRun(t *testing.T) {
 			},
 			wantErr: "task mode requires CLAW_CODEX_WORKDIR to exist",
 		},
+		{
+			name: "rejects git workdir without origin remote in task mode during startup",
+			env: map[string]string{
+				"CLAW_MODE":                 "task",
+				"CLAW_TIMEZONE":             "Asia/Tokyo",
+				"CLAW_DISCORD_TOKEN":        "discord-token",
+				"CLAW_DISCORD_COMMAND_NAME": "release",
+				"CLAW_CODEX_WORKDIR":        "/workspace/repo-without-origin",
+				"CLAW_DATADIR":              "/tmp/39claw-data",
+				"CLAW_CODEX_EXECUTABLE":     "codex",
+			},
+			wantErr: "task mode requires CLAW_CODEX_WORKDIR to have an origin remote",
+		},
 	}
 
 	for _, tt := range tests {
@@ -250,7 +264,7 @@ func TestRun(t *testing.T) {
 			cancel := func() {}
 			if tt.wantErr == "" {
 				var timeoutCtx context.Context
-					timeoutCtx, cancel = context.WithTimeout(context.Background(), 2*time.Second)
+				timeoutCtx, cancel = context.WithTimeout(context.Background(), 2*time.Second)
 				ctx = timeoutCtx
 			}
 			defer cancel()
@@ -274,12 +288,13 @@ func TestRun(t *testing.T) {
 			}
 
 			if env["CLAW_MODE"] == "task" && tt.wantErr == "" {
-				workdir := filepath.Join(t.TempDir(), "repo")
-				if err := os.MkdirAll(filepath.Join(workdir, ".git"), 0o755); err != nil {
-					t.Fatalf("MkdirAll(.git) error = %v", err)
-				}
+				workdir := createTaskModeRemoteBackedRepository(t)
 				env["CLAW_CODEX_WORKDIR"] = workdir
 				tt.wantThreadOptions.WorkingDirectory = workdir
+			}
+
+			if env["CLAW_MODE"] == "task" && strings.Contains(tt.wantErr, "origin remote") {
+				env["CLAW_CODEX_WORKDIR"] = createTaskModeLocalRepository(t)
 			}
 
 			err := run(ctx, func(key string) (string, bool) {
@@ -474,6 +489,66 @@ type stubCodexGateway struct{}
 
 func (stubCodexGateway) RunTurn(ctx context.Context, threadID string, input app.CodexTurnInput) (app.RunTurnResult, error) {
 	return app.RunTurnResult{}, nil
+}
+
+func createTaskModeRemoteBackedRepository(t *testing.T) string {
+	t.Helper()
+
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Fatalf("git is required for task-mode startup tests: %v", err)
+	}
+
+	root := t.TempDir()
+	remote := filepath.Join(root, "remote.git")
+	source := filepath.Join(root, "source")
+
+	runGitTest(t, root, "init", "--bare", "-b", "main", remote)
+	runGitTest(t, root, "clone", remote, source)
+	runGitTest(t, source, "config", "user.email", "codex@example.com")
+	runGitTest(t, source, "config", "user.name", "Codex")
+	assertNoError(t, os.WriteFile(filepath.Join(source, "README.md"), []byte("hello\n"), 0o644))
+	runGitTest(t, source, "add", "README.md")
+	runGitTest(t, source, "commit", "-m", "initial commit")
+	runGitTest(t, source, "push", "-u", "origin", "main")
+
+	return source
+}
+
+func createTaskModeLocalRepository(t *testing.T) string {
+	t.Helper()
+
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Fatalf("git is required for task-mode startup tests: %v", err)
+	}
+
+	repo := filepath.Join(t.TempDir(), "source")
+	assertNoError(t, os.MkdirAll(repo, 0o755))
+	runGitTest(t, repo, "init", "-b", "main")
+	runGitTest(t, repo, "config", "user.email", "codex@example.com")
+	runGitTest(t, repo, "config", "user.name", "Codex")
+	assertNoError(t, os.WriteFile(filepath.Join(repo, "README.md"), []byte("hello\n"), 0o644))
+	runGitTest(t, repo, "add", "README.md")
+	runGitTest(t, repo, "commit", "-m", "initial commit")
+
+	return repo
+}
+
+func runGitTest(t *testing.T, workdir string, args ...string) {
+	t.Helper()
+
+	cmd := exec.Command("git", args...)
+	cmd.Dir = workdir
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v error = %v\n%s", args, err, output)
+	}
+}
+
+func assertNoError(t *testing.T, err error) {
+	t.Helper()
+
+	if err != nil {
+		t.Fatal(err)
+	}
 }
 
 func assertThreadOptionsEqual(t *testing.T, got codex.ThreadOptions, want codex.ThreadOptions) {

--- a/docs/design-docs/architecture-overview.md
+++ b/docs/design-docs/architecture-overview.md
@@ -24,7 +24,7 @@ This leads to two distinct mode families on the same foundation:
 - `daily`
   - knowledge-oriented interaction against repository instructions and documentation, with one active shared generation per local day plus a runtime-managed durable-memory bridge under `AGENT_MEMORY/`
 - `task`
-  - execution-oriented interaction against a Git work repository where each task eventually runs inside its own task-specific worktree
+  - execution-oriented interaction against an operator-visible Git checkout with an `origin` remote, where 39claw manages a separate bare parent repository and each task eventually runs inside its own task-specific worktree
 
 The detailed rationale for these modes lives in `ARCHITECTURE.md` and `thread-modes.md`.
 

--- a/docs/design-docs/implementation-spec.md
+++ b/docs/design-docs/implementation-spec.md
@@ -131,11 +131,11 @@ When a bot instance runs in `daily` mode, the first visible turn of a new daily 
 If that preflight fails or times out, 39claw should log the failure and continue with the visible turn instead of blocking the user.
 If `action:clear` is invoked while the current active daily generation still has in-flight or queued work, 39claw should reject the clear request with an ephemeral retry-later response instead of rotating immediately.
 39claw must not create or modify user-owned instruction files such as `AGENTS.md`; if a deployment wants visible turns to consult `AGENT_MEMORY`, the deployment must express that through its own checked-in instructions.
-When a bot instance runs in `task` mode, `CLAW_CODEX_WORKDIR` must be a Git repository.
-`task-new` creates task metadata only; the first normal message for a pending or failed task creates the task worktree lazily from the remote default branch when possible by trying `origin/HEAD`, then `origin/main`, then `origin/master`, and only then falling back to local `main` or `master`.
-If the source repository has an `origin` remote, 39claw should try `git fetch origin --prune` before detecting that base ref, but a fetch failure should not block task execution by itself.
+When a bot instance runs in `task` mode, `CLAW_CODEX_WORKDIR` must be a Git repository with an `origin` remote.
+`task-new` creates task metadata only; the first normal message for a pending or failed task creates the task worktree lazily from a managed bare parent under `${CLAW_DATADIR}/repos`, preferring the remote default branch by trying `origin/HEAD`, then `origin/main`, then `origin/master`, and only then falling back to local `main` or `master` inside that managed repository.
+Before detecting that base ref, 39claw should synchronize the managed bare parent against the source checkout's `origin` configuration and try `git fetch origin --prune`; a fetch failure should not block task execution by itself when cached remote refs are already available.
 Once the task worktree is ready, Codex runs with the task-specific `worktree_path` as the effective working directory for that turn.
-Closed tasks keep their task branches, but only the fifteen most recently closed ready tasks keep their worktrees; older closed ready worktrees are force-pruned.
+Closed tasks keep their task branches in the managed bare parent, but only the fifteen most recently closed ready tasks keep their worktrees; older closed ready worktrees are force-pruned.
 
 Unsupported guild-channel non-mention chatter is ignored.
 Qualifying posts that contain no text and no usable image attachments are also ignored.
@@ -185,7 +185,8 @@ The expected variables are:
 `CLAW_TIMEZONE` must be set explicitly for each deployment.
 `CLAW_DISCORD_COMMAND_NAME` must be unique per bot instance, normalized to lowercase, and validated conservatively before Discord registration.
 When `CLAW_CODEX_HOME` is set, 39claw must inject it into the spawned Codex CLI process as `CODEX_HOME`.
-When `CLAW_MODE=task`, `CLAW_CODEX_WORKDIR` must point to a Git repository and acts as the source repository root for task worktree creation.
+When `CLAW_MODE=task`, `CLAW_CODEX_WORKDIR` must point to a Git repository with an `origin` remote and acts as the operator-visible source checkout plus validation target for task-mode startup.
+Task-mode startup and first-use preparation must maintain a managed bare parent repository under `${CLAW_DATADIR}/repos`, and task worktrees must be created from that managed parent rather than directly from the visible source checkout.
 When `CLAW_MODE=daily`, startup must materialize the managed durable-memory skill and the `AGENT_MEMORY` directory inside `CLAW_CODEX_WORKDIR`.
 `CLAW_LOG_LEVEL` defaults to `info` when omitted.
 When `CLAW_DISCORD_GUILD_ID` is set, slash commands are overwritten in that guild for faster development feedback.
@@ -231,10 +232,10 @@ Most of these outcomes should be proven through automated contract coverage plus
 - In `task` mode, a normal mention without an active task returns guidance instead of routing to Codex.
 - `/<instance-command> action:task-current` shows the active task for the requesting user.
 - `/<instance-command> action:task-new task_name:<name>` creates a task and sets it active for the requesting user.
-- The first normal message for a new task creates a task worktree lazily under `${CLAW_DATADIR}/worktrees/<task_id>` and then runs Codex inside that worktree.
+- The first normal message for a new task creates or refreshes a managed bare parent under `${CLAW_DATADIR}/repos`, then creates a task worktree lazily under `${CLAW_DATADIR}/worktrees/<task_id>`, and then runs Codex inside that worktree.
 - `/<instance-command> action:task-switch task_name:<name>` changes the routing target for subsequent normal messages, with `task_id` reserved for ambiguity fallback.
 - `/<instance-command> action:task-close task_name:<name>` closes the task and clears active state when the closed task was active, with `task_id` reserved for ambiguity fallback.
-- Closed-task worktree retention keeps only the fifteen most recently closed ready worktrees and never deletes the task branches.
+- Closed-task worktree retention keeps only the fifteen most recently closed ready worktrees and never deletes the task branches held by the managed bare parent.
 - Existing `daily` and `task` bindings survive process restart through SQLite-backed state.
 - Guild non-mention chatter is ignored, unsupported non-image-only qualifying posts stay silent, supported slash commands respond correctly, and long replies are chunked cleanly.
 - Simultaneous requests for the same logical thread do not execute overlapping Codex turns.

--- a/docs/design-docs/state-and-storage.md
+++ b/docs/design-docs/state-and-storage.md
@@ -95,6 +95,13 @@ That includes:
 
 This metadata lets 39claw decide whether a task needs lazy worktree creation, whether a closed task is eligible for pruning, and which working directory Codex should use for the next turn.
 
+Task mode also owns a repository-shaped on-disk artifact outside SQLite:
+
+- `${CLAW_DATADIR}/repos/<repo-id>.git`
+
+That managed bare repository is not a user-facing checkout.
+It exists so 39claw can own task branches and create task worktrees without letting the operator-visible source checkout occupy the default branch for every bot-managed workspace.
+
 ## Storage Direction for v1
 
 SQLite is the preferred v1 storage backend.

--- a/docs/design-docs/task-mode-worktrees.md
+++ b/docs/design-docs/task-mode-worktrees.md
@@ -20,15 +20,16 @@ This turns `task` mode into an execution-oriented workflow instead of a long-liv
 
 ## Core Decisions
 
-- `task` mode is valid only when `CLAW_CODEX_WORKDIR` points to a Git repository.
-- In `task` mode, `CLAW_CODEX_WORKDIR` is the source repository root, not the final Codex working directory for every turn.
+- `task` mode is valid only when `CLAW_CODEX_WORKDIR` points to a Git repository with an `origin` remote.
+- In `task` mode, `CLAW_CODEX_WORKDIR` is the operator-visible source checkout and startup validation target, not the parent repository that directly owns task worktrees.
 - Each task owns one task-specific branch name.
-- Each task may also own one task-specific Git worktree created from that source repository.
+- 39claw maintains one managed bare parent repository under `${CLAW_DATADIR}/repos/<repo-id>.git` for the configured source checkout.
+- Each task may also own one task-specific Git worktree created from that managed bare parent.
 - Worktrees are created lazily on the first normal message that needs to run Codex for the task.
-- The base ref for worktree creation is detected automatically by preferring the remote default branch state.
-- When the source repository has an `origin` remote, worktree preparation should try `git fetch origin --prune` as a best-effort refresh before resolving the base ref.
+- The base ref for worktree creation is detected automatically inside the managed bare parent by preferring the remote default branch state.
+- Worktree preparation synchronizes the managed bare parent to the source checkout's `origin` URL and best-effort `pushurl`, then tries `git fetch origin --prune` plus `git remote set-head origin --auto` before resolving the base ref.
 - Base-ref resolution should prefer `origin/HEAD`, then `origin/main`, then `origin/master`, and only then fall back to local `main` or `master`.
-- Closing a task does not delete its branch.
+- Closing a task does not delete its branch from the managed bare parent.
 - Closed-task worktrees are treated as disposable cache-like workspaces.
 - The system keeps the most recent fifteen closed-task worktrees and prunes older closed-task worktrees with forced removal.
 
@@ -38,11 +39,12 @@ In `daily` mode, the configured Codex working directory remains the directory pa
 
 In `task` mode, the repository model changes:
 
-- source repository root: `CLAW_CODEX_WORKDIR`
+- source checkout root: `CLAW_CODEX_WORKDIR`
+- managed bare parent root: `${CLAW_DATADIR}/repos/<repo-id>.git`
 - task worktree root: `${CLAW_DATADIR}/worktrees/<task_id>`
 - Codex working directory for a task turn: the task's `worktree_path` once the worktree is ready
 
-This means the configured workdir remains globally important, but in `task` mode it acts as the shared Git source from which task worktrees are derived.
+This means the configured workdir remains globally important, but in `task` mode it acts as the human-facing checkout and remote-configuration source. Task branches and task worktrees belong to the managed bare parent instead of to the visible checkout.
 
 ## Task State Model
 
@@ -88,12 +90,14 @@ The first normal message sent to an active task with `worktree_status=pending` o
 The preparation flow is:
 
 1. load the active task record
-2. refresh `origin` metadata with a best-effort `git fetch origin --prune` when the source repository has an `origin` remote
-3. detect the base ref by preferring `origin/HEAD`, then `origin/main`, then `origin/master`, and only then falling back to local `main` or `master`
-4. create the task worktree under `${CLAW_DATADIR}/worktrees/<task_id>`
-5. create or attach the reserved task branch for that worktree
-6. persist `base_ref`, `worktree_path`, `worktree_created_at`, and `worktree_status=ready`
-7. run Codex with the task-specific worktree path as the working directory
+2. create or validate the managed bare parent under `${CLAW_DATADIR}/repos/<repo-id>.git`
+3. synchronize that managed bare parent to the source checkout's `origin` URL and optional `pushurl`
+4. refresh managed-`origin` metadata with a best-effort `git fetch origin --prune`
+5. detect the base ref by preferring `origin/HEAD`, then `origin/main`, then `origin/master`, and only then falling back to local `main` or `master`
+6. create the task worktree under `${CLAW_DATADIR}/worktrees/<task_id>`
+7. create or attach the reserved task branch for that worktree inside the managed bare parent
+8. persist `base_ref`, `worktree_path`, `worktree_created_at`, and `worktree_status=ready`
+9. run Codex with the task-specific worktree path as the working directory
 
 If any step fails, Codex must not run for that turn.
 
@@ -128,7 +132,7 @@ After close succeeds, the system applies closed-task worktree retention:
 - older closed tasks with `worktree_status=ready` are pruned by `git worktree remove --force`
 - when pruning succeeds, the task becomes `worktree_status=pruned` and records `worktree_pruned_at`
 
-The branch is intentionally left behind so repository history and manual recovery options remain available even after workspace cleanup.
+The branch is intentionally left behind in the managed bare parent so repository history and manual recovery options remain available even after workspace cleanup.
 
 ## Failure and Retry Model
 
@@ -143,7 +147,7 @@ Lazy worktree creation failure is handled at normal-message time:
 - the task moves to `worktree_status=failed`
 - the next normal message retries worktree preparation automatically
 
-If the best-effort `git fetch origin --prune` step fails, the system should log the refresh failure but still continue base-ref detection using any already-available remote-tracking refs and then the local fallback branches.
+If the best-effort `git fetch origin --prune` step fails, the system should log the refresh failure but still continue base-ref detection using any already-available remote-tracking refs in the managed bare parent and then the local fallback branches.
 
 Pruning failure must not reopen or invalidate the closed task.
 If pruning fails, the system should keep the task in `closed + ready`, log the failure, and try again during a later cleanup opportunity.
@@ -163,6 +167,9 @@ The `tasks` table now carries task worktree metadata in addition to task identit
 `branch_name` is fixed at task creation.
 `base_ref` and `worktree_path` are populated on first successful worktree creation and remain stable afterward.
 `last_used_at` is updated whenever a normal message successfully uses the task context.
+
+Task branches are intentionally stored in the managed bare parent rather than in the visible source checkout.
+That keeps the operator checkout branch-neutral with respect to bot-owned worktrees while preserving normal `git push origin ...` behavior from inside task worktrees.
 
 ## User Experience Consequences
 

--- a/docs/design-docs/thread-modes.md
+++ b/docs/design-docs/thread-modes.md
@@ -84,10 +84,10 @@ thread_key = user + task_id
 
 ### Behavior
 
-- the configured `CLAW_CODEX_WORKDIR` must be a Git repository
+- the configured `CLAW_CODEX_WORKDIR` must be a Git repository with an `origin` remote
 - a current task must exist before normal messages can be routed
 - `task-new` creates task metadata immediately but defers worktree creation
-- the first normal message for a task creates the task worktree lazily when needed
+- the first normal message for a task creates or refreshes the managed bare parent under `${CLAW_DATADIR}/repos` and then creates the task worktree lazily when needed
 - messages are sent to the Codex thread associated with the active task and use that task's worktree once it exists
 - changing tasks changes the target logical thread
 - closed-task worktrees are retained only for the fifteen most recently closed ready tasks

--- a/docs/exec-plans/active/15-task-managed-bare-parent.md
+++ b/docs/exec-plans/active/15-task-managed-bare-parent.md
@@ -14,11 +14,11 @@ The user-visible proof is practical. In `task` mode with a source repository tha
 
 - [x] (2026-04-10 09:48Z) Reviewed the existing task worktree implementation, the completed worktree-isolation plans, and the current product/design docs to confirm that `CLAW_CODEX_WORKDIR` still acts as both the operator checkout and the worktree parent repository.
 - [x] (2026-04-10 09:48Z) Decided that the managed-bare redesign will require an `origin` remote in `task` mode and will not preserve no-remote support, because the local-only synchronization story is high-complexity and low-value.
-- [ ] Implement startup validation that requires both a Git repository and an `origin` remote when `CLAW_MODE=task`.
-- [ ] Add managed bare repository lifecycle support under `${CLAW_DATADIR}/repos/<repo-id>.git`, cloned from the real `origin` remote and refreshed from that same remote afterward.
-- [ ] Move task worktree creation to the managed bare parent while preserving task branch identity, remote push behavior, and closed-task pruning.
-- [ ] Update architecture, design, product, and operator docs so the new task-mode repository model is fully described.
-- [ ] Add automated coverage for startup validation, managed-bare creation, remote propagation, task worktree branch switching, and regression cases around task pruning.
+- [x] (2026-04-10 11:20Z) Implemented startup validation that requires both a Git repository and an `origin` remote when `CLAW_MODE=task`, by failing `NewTaskWorkspaceManager` during task-mode assembly when `origin` is missing.
+- [x] (2026-04-10 11:20Z) Added managed bare repository lifecycle support under `${CLAW_DATADIR}/repos/<repo-id>.git`, synchronizing it to the real `origin` remote plus optional `pushurl` before each task-worktree preparation.
+- [x] (2026-04-10 11:20Z) Moved task worktree creation and pruning to the managed bare parent while preserving task branch identity, remote push behavior, cached-ref fallback, and closed-task pruning.
+- [x] (2026-04-10 11:20Z) Updated architecture, design, product, operator, and example docs so the new task-mode repository model is fully described.
+- [x] (2026-04-10 11:20Z) Added automated coverage for startup validation, managed-bare creation, remote propagation, task worktree branch switching, cached-remote fallback, and pruning regressions.
 - [ ] Run repository validation (`make test` / `make lint`, or the documented command-level fallback when `make` is unavailable), open the feature PR, merge it, and archive this plan into `docs/exec-plans/completed/`.
 
 ## Surprises & Discoveries
@@ -32,6 +32,9 @@ The user-visible proof is practical. In `task` mode with a source repository tha
 - Observation: A managed bare parent solves the branch-occupancy problem only when the runtime stops treating the visible source checkout as the parent repository; simply detaching task worktrees would not help.
   Evidence: Git worktree branch occupancy is enforced per parent repository, and the current parent repository is the operator checkout at `CLAW_CODEX_WORKDIR`.
 
+- Observation: A literal `git clone --bare <origin-url>` does not populate the managed repository with `origin/main`-style remote-tracking refs, which means later `git worktree add ... origin/main` fails even though the clone succeeded.
+  Evidence: A temporary shell reproduction showed `fatal: invalid reference: origin/main` after a bare clone, while `git init --bare` followed by `remote add origin`, `config remote.origin.fetch +refs/heads/*:refs/remotes/origin/*`, and `fetch origin --prune` produced the remote-tracking refs needed by `git worktree add`.
+
 ## Decision Log
 
 - Decision: The redesign will introduce a managed bare repository under `${CLAW_DATADIR}/repos` and will create all task worktrees from that managed bare parent instead of from `CLAW_CODEX_WORKDIR`.
@@ -42,8 +45,8 @@ The user-visible proof is practical. In `task` mode with a source repository tha
   Rationale: The managed-bare model needs a clear remote synchronization story for fetch, push, and recovery, and no-remote support adds disproportionate complexity for little practical value.
   Date/Author: 2026-04-10 / Codex
 
-- Decision: The managed bare repository will be cloned directly from the real `origin` remote instead of being seeded from the local source checkout path.
-  Rationale: Once no-remote repositories are rejected up front, cloning from `origin` gives the cleanest and most legible source-of-truth model for new task worktrees.
+- Decision: The managed bare repository will be initialized from the real `origin` remote instead of being seeded from the local source checkout path.
+  Rationale: Once no-remote repositories are rejected up front, using `origin` as the source of truth gives the cleanest synchronization model. In practice, the implementation uses `git init --bare` plus explicit `origin` configuration and `fetch` so the managed parent contains remote-tracking refs such as `origin/main`.
   Date/Author: 2026-04-10 / Codex
 
 - Decision: This redesign will not attempt automatic bidirectional synchronization between the visible source checkout and the managed bare repository.
@@ -52,15 +55,15 @@ The user-visible proof is practical. In `task` mode with a source repository tha
 
 ## Outcomes & Retrospective
 
-This plan is not implemented yet. The intended outcome is a simpler and safer task-mode repository model: operators keep using `CLAW_CODEX_WORKDIR` as a normal checkout, while 39claw owns a separate managed bare repository for task worktree lifecycle. The expected benefit is better Git ergonomics inside task worktrees and a clearer operational boundary between human workspace state and bot-managed workspace state.
+The implementation now follows the intended repository split. Operators keep using `CLAW_CODEX_WORKDIR` as a normal checkout, while 39claw owns a separate managed bare repository for task worktree lifecycle under `${CLAW_DATADIR}/repos`. Task branches now live in that managed parent, task worktrees are created from it, and startup fails early when the configured checkout lacks an `origin` remote.
 
-The main risk area is not the worktree command itself; it is the surrounding contract change. Startup validation, remote propagation, branch retention, recovery instructions, and the user/operator documentation all have to describe the same repository model or later contributors will misunderstand which repository owns task branches and remotes.
+The most important retrospective note is that "initialized from origin" mattered more than the exact shell verb. The clean user-facing model still came from `origin`, but the Git plumbing needed explicit remote-tracking refs inside the bare parent, so the final implementation used `git init --bare` plus explicit remote configuration rather than a single `git clone --bare` command.
 
 ## Context and Orientation
 
 39claw is a Go-based Discord bot that routes messages into Codex threads. In `task` mode, each task has a task record, a Codex thread binding, and lazily created Git worktree metadata. Today, `CLAW_CODEX_WORKDIR` is both the operator-visible checkout and the Git repository that directly owns all task worktrees. The task worktree manager lives in `internal/app/task_workspace.go`, and it currently runs `git worktree add` directly against that visible source checkout.
 
-This plan changes the repository model. After implementation, the operator-visible checkout at `CLAW_CODEX_WORKDIR` remains the configuration anchor and validation target, but it will no longer be the repository that owns task worktrees or the source from which the managed parent is cloned. Instead, startup will materialize a managed bare repository under `${CLAW_DATADIR}/repos/<repo-id>.git` by cloning the real `origin` remote. A "bare repository" is a Git repository that stores refs, objects, and configuration but does not itself contain a checked-out working tree. Git can still create linked worktrees from it, which makes it a good parent for bot-managed task worktrees because it does not keep `main` or `master` checked out anywhere.
+This plan changes the repository model. After implementation, the operator-visible checkout at `CLAW_CODEX_WORKDIR` remains the configuration anchor and validation target, but it will no longer be the repository that owns task worktrees or the source from which the managed parent is seeded. Instead, startup and first task preparation materialize a managed bare repository under `${CLAW_DATADIR}/repos/<repo-id>.git` from the real `origin` remote configuration. A "bare repository" is a Git repository that stores refs, objects, and configuration but does not itself contain a checked-out working tree. Git can still create linked worktrees from it, which makes it a good parent for bot-managed task worktrees because it does not keep `main` or `master` checked out anywhere.
 
 The most relevant files are:
 
@@ -96,11 +99,11 @@ Terms used in this plan:
 
 ## Plan of Work
 
-Start by updating the repository contracts before touching code. `ARCHITECTURE.md`, `docs/design-docs/task-mode-worktrees.md`, `docs/design-docs/implementation-spec.md`, `docs/design-docs/architecture-overview.md`, `docs/product-specs/task-mode-user-flow.md`, `docs/product-specs/discord-command-behavior.md`, and `README.md` must all stop describing `CLAW_CODEX_WORKDIR` as the repository that directly owns task worktrees. They must instead describe it as the operator-visible checkout and configuration anchor, while the task worktree parent moves under `${CLAW_DATADIR}` and is cloned from `origin`. The docs must also state clearly that `task` mode now requires an `origin` remote and that no-remote repositories fail fast at startup.
+Start by updating the repository contracts before touching code. `ARCHITECTURE.md`, `docs/design-docs/task-mode-worktrees.md`, `docs/design-docs/implementation-spec.md`, `docs/design-docs/architecture-overview.md`, `docs/product-specs/task-mode-user-flow.md`, `docs/product-specs/discord-command-behavior.md`, and `README.md` must all stop describing `CLAW_CODEX_WORKDIR` as the repository that directly owns task worktrees. They must instead describe it as the operator-visible checkout and configuration anchor, while the task worktree parent moves under `${CLAW_DATADIR}` and is initialized from `origin`. The docs must also state clearly that `task` mode now requires an `origin` remote and that no-remote repositories fail fast at startup.
 
 Next, extend startup validation in `internal/config/config.go` and any startup helpers used from `cmd/39claw/main.go`. The validation must continue rejecting non-Git repositories in `task` mode, and it must now also reject a source checkout that lacks an `origin` remote. The error message must be explicit enough that an operator immediately understands the new product contract, for example by naming `CLAW_CODEX_WORKDIR` and explaining that managed-bare task mode needs an `origin` remote.
 
-Then redesign the task workspace manager in `internal/app/task_workspace.go`. Introduce a small managed-bare lifecycle layer that derives a stable bare-repository path under `${CLAW_DATADIR}/repos`. The stable repo identifier should be based on the source checkout path, the normalized `origin` URL, or another deterministic local identity so repeated startups reuse the same managed bare parent. On first use, clone that bare parent directly from the real `origin` remote. After cloning, copy any additional remote settings that matter for operator workflows from the source checkout into the managed bare parent, especially `remote.origin.pushurl` when present. On later startups and later task preparations, refresh the managed bare parent with `git fetch origin --prune` as a best-effort step before choosing the base ref for a new task worktree.
+Then redesign the task workspace manager in `internal/app/task_workspace.go`. Introduce a small managed-bare lifecycle layer that derives a stable bare-repository path under `${CLAW_DATADIR}/repos`. The stable repo identifier should be based on the source checkout path, the normalized `origin` URL, or another deterministic local identity so repeated startups reuse the same managed bare parent. On first use, initialize that bare parent from the real `origin` remote and configure it to store remote-tracking refs such as `origin/main`. After initialization, copy any additional remote settings that matter for operator workflows from the source checkout into the managed bare parent, especially `remote.origin.pushurl` when present. On later startups and later task preparations, refresh the managed bare parent with `git fetch origin --prune` as a best-effort step before choosing the base ref for a new task worktree.
 
 Keep task branch identity stable. `Task.BranchName` should continue to represent the task branch, but after this redesign that branch will live in the managed bare parent rather than in the operator-visible source checkout. The `EnsureReady` flow should create or attach the task branch inside the managed bare parent and materialize the task worktree under `${CLAW_DATADIR}/worktrees/<task_id>`. Base-ref detection should run against the managed bare parent, still preferring `origin/HEAD`, `origin/main`, and `origin/master` before any local fallback that remains meaningful in the managed-bare repository.
 
@@ -197,7 +200,7 @@ Acceptance is behavioral. A contributor should be able to inspect `${CLAW_DATADI
 
 ## Idempotence and Recovery
 
-The managed bare repository path must be deterministic so repeated startups reuse the same repository instead of cloning a new bare parent every time. Initial clone and remote-propagation steps must be safe to rerun: if the managed bare parent already exists, refresh it instead of recreating it. If startup validation fails because `origin` is missing, exit before mutating `${CLAW_DATADIR}` so operators can fix the checkout safely and retry.
+The managed bare repository path must be deterministic so repeated startups reuse the same repository instead of initializing a new bare parent every time. Initial setup and remote-propagation steps must be safe to rerun: if the managed bare parent already exists, refresh it instead of recreating it. If startup validation fails because `origin` is missing, exit before mutating `${CLAW_DATADIR}` so operators can fix the checkout safely and retry.
 
 Because this design intentionally avoids automatic synchronization back into the source checkout, recovery guidance must be explicit. If an operator wants to inspect task branches, they should look in the managed bare parent or fetch from it intentionally; the implementation must not try to push task-branch state back into the source checkout automatically. Closed-task pruning must continue to be best-effort and must never delete task branches from the managed bare parent.
 

--- a/docs/operations/RELEASE_RUNBOOK.md
+++ b/docs/operations/RELEASE_RUNBOOK.md
@@ -34,9 +34,13 @@ Do not create or push a release tag until all of the following are true:
    - slash-command help or task controls after command-surface changes
    - image attachment handling after attachment-mapping or download changes
    - any other Discord-specific behavior implicated by a recent incident or release risk
-6. `go run ./cmd/39claw version` returns a sensible value locally and the release config still injects `version.Version`.
-7. The `HOMEBREW_TAP_GITHUB_TOKEN` GitHub Actions secret is configured with write access to `HatsuneMiku3939/homebrew-tap`.
-8. No ad hoc release-only edits are waiting outside version control.
+6. When the release touches task-mode repository lifecycle or startup validation, a local task-mode checkout with a real `origin` remote has been exercised far enough to confirm:
+   - startup accepts the configured checkout
+   - a managed bare repository appears under `${CLAW_DATADIR}/repos`
+   - a task worktree can still switch to the default branch inside `${CLAW_DATADIR}/worktrees`
+7. `go run ./cmd/39claw version` returns a sensible value locally and the release config still injects `version.Version`.
+8. The `HOMEBREW_TAP_GITHUB_TOKEN` GitHub Actions secret is configured with write access to `HatsuneMiku3939/homebrew-tap`.
+9. No ad hoc release-only edits are waiting outside version control.
 
 If any gate fails, fix the repository state first and rerun the failed checks before tagging.
 

--- a/docs/product-specs/discord-command-behavior.md
+++ b/docs/product-specs/discord-command-behavior.md
@@ -272,4 +272,4 @@ This command behavior layer is not intended to:
 - `action:help` should stay structurally simple in v1, but it should only describe commands that are actually available in the current bot instance.
 - `daily` mode may expose `action:clear` on that same root command so users can intentionally rotate the shared same-day generation.
 - Unsupported invocation patterns should be ignored rather than acknowledged with lightweight feedback.
-- In `task` mode, the configured workdir is a Git repository source for task worktrees rather than only one shared execution directory.
+- In `task` mode, the configured workdir is an operator-visible Git checkout with an `origin` remote, while task worktrees are owned by a managed bare repository under the bot data directory.

--- a/docs/product-specs/task-mode-user-flow.md
+++ b/docs/product-specs/task-mode-user-flow.md
@@ -115,7 +115,7 @@ Expected flow:
 1. The user creates or switches to a task that has no ready task worktree yet.
 2. The user sends a normal message to continue that task.
 3. 39claw detects that the task worktree is still pending or previously failed.
-4. 39claw refreshes `origin` metadata on a best-effort basis when the source repository has an `origin` remote, then prepares the task-specific Git worktree under the bot data directory from the shared remote default branch when available.
+4. 39claw creates or refreshes the managed bare parent under `${CLAW_DATADIR}/repos`, best-effort fetches `origin`, and then prepares the task-specific Git worktree under the bot data directory from the shared remote default branch when available.
 5. After workspace preparation succeeds, 39claw runs the Codex turn in that task worktree.
 
 Expected user perception:
@@ -229,7 +229,7 @@ The most recent closed task workspaces should remain available longer than older
 - Active task state is always user-scoped within a bot instance in v1.
 - The active task should remain active until the user explicitly closes it or switches to another task.
 - If a task is closed and the user then sends a normal message, the bot should respond with missing-active-task guidance rather than routing the message normally.
-- `task` mode assumes the configured workdir is a Git repository.
+- `task` mode assumes the configured workdir is a Git repository with an `origin` remote.
 - New tasks create metadata first and prepare their task worktree lazily on the first normal message.
 - Closed-task retention keeps only the fifteen most recently closed ready task worktrees.
-- Task branches are retained even when older closed-task worktrees are pruned.
+- Task branches are retained in the managed bare parent even when older closed-task worktrees are pruned.

--- a/example/README.md
+++ b/example/README.md
@@ -37,4 +37,4 @@ Recommended command names:
 1. Run the two instances with separate Discord bot applications and separate tokens if you want them online at the same time.
 2. Each 39claw process bulk-overwrites the slash-command schema for its own Discord application at startup.
 3. `daily` mode needs a writable Codex sandbox because 39claw manages `AGENT_MEMORY/` inside the configured workdir.
-4. `task` mode requires `CLAW_CODEX_WORKDIR` to be the root of a Git repository.
+4. `task` mode requires `CLAW_CODEX_WORKDIR` to be the root of a Git repository with an `origin` remote.

--- a/example/task-repository.md
+++ b/example/task-repository.md
@@ -12,6 +12,7 @@ This example assumes:
 
 - you can clone the source repository locally before starting 39claw
 - `CLAW_CODEX_WORKDIR` points at that repository root
+- that checkout has an `origin` remote configured
 - task worktrees will be created under the 39claw data directory
 - you want a convenience-first autonomous development preset
 - you installed `39claw` already through one of the packaged installation paths in [README.md](../README.md)
@@ -63,10 +64,11 @@ Check that the chosen workdir is the repository root:
 ```bash
 cd /Users/you/src/project-alpha
 git status --short --branch
+git remote get-url origin
 test -e .git && echo "git root ok"
 ```
 
-If `.git` is missing at that exact path, point `CLAW_CODEX_WORKDIR` at the real repository root before continuing.
+If `.git` is missing at that exact path, or `git remote get-url origin` fails, point `CLAW_CODEX_WORKDIR` at the real repository root and configure `origin` before continuing.
 
 ## Step 3: Create the local data directory
 
@@ -77,7 +79,8 @@ mkdir -p /Users/you/.local/share/39claw-dev
 39claw will store:
 
 1. the SQLite database at `/Users/you/.local/share/39claw-dev/39claw.sqlite`
-2. task worktrees under `/Users/you/.local/share/39claw-dev/worktrees/`
+2. a managed bare task repository under `/Users/you/.local/share/39claw-dev/repos/`
+3. task worktrees under `/Users/you/.local/share/39claw-dev/worktrees/`
 
 ## Step 4: Create the environment file
 
@@ -116,9 +119,9 @@ CLAW_LOG_FORMAT=text
 Why these values matter:
 
 1. `CLAW_MODE=task` enables task creation, switching, and task-specific threads.
-2. `CLAW_CODEX_WORKDIR` is the source repository root, not the final execution path for every turn.
+2. `CLAW_CODEX_WORKDIR` is the operator-visible source checkout and must have an `origin` remote.
 3. `CLAW_CODEX_HOME`, when set, tells 39claw which `CODEX_HOME` value to pass to the spawned Codex CLI.
-4. Each new active task can create its own worktree under `CLAW_DATADIR/worktrees/`.
+4. 39claw creates a managed bare parent under `CLAW_DATADIR/repos/` and each new active task can create its own worktree under `CLAW_DATADIR/worktrees/`.
 5. `CLAW_CODEX_SANDBOX_MODE=danger-full-access` gives Codex the widest local write access for autonomous repository work.
 6. `CLAW_CODEX_WEB_SEARCH_MODE=live` lets the bot look up fresh web information when implementation work needs it.
 7. `CLAW_CODEX_NETWORK_ACCESS=true` lets the bot open links and use network-backed tooling during a task.
@@ -184,7 +187,7 @@ On startup, 39claw should:
 
 1. connect to Discord
 2. register the `/dev` command
-3. validate that `/Users/you/src/project-alpha` is a Git repository root
+3. validate that `/Users/you/src/project-alpha` is a Git repository root with an `origin` remote
 
 ## Step 8: Create the first task in Discord
 
@@ -197,15 +200,16 @@ In your Discord test channel:
 
 The first normal message for that task may take a moment longer because 39claw can create the task worktree before Codex starts.
 
-## Step 9: Confirm the worktree was created
+## Step 9: Confirm the managed repository and worktree were created
 
 After the first normal task message, inspect the data directory:
 
 ```bash
+find /Users/you/.local/share/39claw-dev/repos -maxdepth 2 -type d | sort
 find /Users/you/.local/share/39claw-dev/worktrees -maxdepth 2 -type d | sort
 ```
 
-You should see a task-specific directory under `worktrees/`.
+You should see one bare repository under `repos/` and a task-specific directory under `worktrees/`.
 
 ## Step 10: Smoke-test task switching
 
@@ -228,9 +232,10 @@ If startup fails, check these first:
 
 1. `CLAW_CODEX_WORKDIR` must exist and be a directory.
 2. `CLAW_CODEX_WORKDIR` must be the root of a Git repository.
-3. `CLAW_DISCORD_COMMAND_NAME` must contain only lowercase letters, digits, or hyphens.
-4. `CLAW_DISCORD_TOKEN` must belong to the bot application you invited to the server.
-5. `danger-full-access` and network-enabled execution should match your security expectations before you leave the bot running unattended.
+3. `CLAW_CODEX_WORKDIR` must have a working `origin` remote.
+4. `CLAW_DISCORD_COMMAND_NAME` must contain only lowercase letters, digits, or hyphens.
+5. `CLAW_DISCORD_TOKEN` must belong to the bot application you invited to the server.
+6. `danger-full-access` and network-enabled execution should match your security expectations before you leave the bot running unattended.
 
 ## Step 12: Move from test to real use
 

--- a/internal/app/task_workspace.go
+++ b/internal/app/task_workspace.go
@@ -3,6 +3,8 @@ package app
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -14,10 +16,13 @@ import (
 )
 
 const (
-	defaultGitExecutablePath   = "git"
-	defaultClosedTaskRetention = 15
-	worktreesDirectoryName     = "worktrees"
-	worktreeDirectoryPerms     = 0o755
+	defaultGitExecutablePath      = "git"
+	defaultClosedTaskRetention    = 15
+	worktreesDirectoryName        = "worktrees"
+	managedRepositoriesDirectory  = "repos"
+	worktreeDirectoryPerms        = 0o755
+	managedOriginFetchRefspec     = "+refs/heads/*:refs/remotes/origin/*"
+	managedRepositoryHashByteSize = 6
 )
 
 type TaskWorkspaceManagerDependencies struct {
@@ -40,7 +45,12 @@ type GitTaskWorkspaceManager struct {
 	clock            func() time.Time
 }
 
-func NewTaskWorkspaceManager(deps TaskWorkspaceManagerDependencies) (*GitTaskWorkspaceManager, error) {
+type gitRemoteConfig struct {
+	url     string
+	pushURL string
+}
+
+func NewTaskWorkspaceManager(ctx context.Context, deps TaskWorkspaceManagerDependencies) (*GitTaskWorkspaceManager, error) {
 	if deps.Store == nil {
 		return nil, errors.New("thread store must not be nil")
 	}
@@ -75,7 +85,7 @@ func NewTaskWorkspaceManager(deps TaskWorkspaceManagerDependencies) (*GitTaskWor
 		clock = time.Now().UTC
 	}
 
-	return &GitTaskWorkspaceManager{
+	manager := &GitTaskWorkspaceManager{
 		store:            deps.Store,
 		sourceRepository: sourceRepository,
 		dataDir:          dataDir,
@@ -83,7 +93,13 @@ func NewTaskWorkspaceManager(deps TaskWorkspaceManagerDependencies) (*GitTaskWor
 		closedRetention:  closedRetention,
 		logger:           logger,
 		clock:            clock,
-	}, nil
+	}
+
+	if _, err := manager.sourceOriginConfig(ctx); err != nil {
+		return nil, err
+	}
+
+	return manager, nil
 }
 
 func DefaultTaskBranchName(taskID string) string {
@@ -107,10 +123,14 @@ func (m *GitTaskWorkspaceManager) EnsureReady(ctx context.Context, task Task) (T
 		return task, nil
 	}
 
+	managedRepositoryPath, err := m.ensureManagedRepository(ctx)
+	if err != nil {
+		return Task{}, m.markTaskWorktreeFailed(ctx, task, "", err)
+	}
+
 	baseRef := task.BaseRef
 	if baseRef == "" {
-		m.refreshOrigin(ctx)
-		detectedBaseRef, err := m.detectBaseRef(ctx)
+		detectedBaseRef, err := m.detectBaseRef(ctx, managedRepositoryPath)
 		if err != nil {
 			return Task{}, m.markTaskWorktreeFailed(ctx, task, "", err)
 		}
@@ -122,11 +142,11 @@ func (m *GitTaskWorkspaceManager) EnsureReady(ctx context.Context, task Task) (T
 		worktreePath = m.worktreePath(task.TaskID)
 	}
 
-	if err := m.prepareWorktreePath(ctx, worktreePath); err != nil {
+	if err := m.prepareWorktreePath(ctx, managedRepositoryPath, worktreePath); err != nil {
 		return Task{}, m.markTaskWorktreeFailed(ctx, task, worktreePath, err)
 	}
 
-	branchExists, err := m.branchExists(ctx, task.BranchName)
+	branchExists, err := m.branchExists(ctx, managedRepositoryPath, task.BranchName)
 	if err != nil {
 		return Task{}, m.markTaskWorktreeFailed(ctx, task, worktreePath, err)
 	}
@@ -142,7 +162,7 @@ func (m *GitTaskWorkspaceManager) EnsureReady(ctx context.Context, task Task) (T
 		args = append(args, baseRef)
 	}
 
-	if _, err := m.runGit(ctx, args...); err != nil {
+	if _, err := m.runGitIn(ctx, managedRepositoryPath, args...); err != nil {
 		return Task{}, m.markTaskWorktreeFailed(ctx, task, worktreePath, err)
 	}
 
@@ -173,13 +193,18 @@ func (m *GitTaskWorkspaceManager) PruneClosed(ctx context.Context) error {
 		return nil
 	}
 
+	managedRepositoryPath, err := m.ensureManagedRepository(ctx)
+	if err != nil {
+		return fmt.Errorf("ensure managed task repository: %w", err)
+	}
+
 	var errs []error
 	for _, task := range tasks[m.closedRetention:] {
 		if strings.TrimSpace(task.WorktreePath) == "" {
 			continue
 		}
 
-		if _, err := m.runGit(ctx, "worktree", "remove", "--force", task.WorktreePath); err != nil {
+		if _, err := m.runGitIn(ctx, managedRepositoryPath, "worktree", "remove", "--force", task.WorktreePath); err != nil {
 			m.logger.Error(
 				"prune closed task worktree",
 				"task_id", task.TaskID,
@@ -208,13 +233,13 @@ func (m *GitTaskWorkspaceManager) PruneClosed(ctx context.Context) error {
 	return errors.Join(errs...)
 }
 
-func (m *GitTaskWorkspaceManager) detectBaseRef(ctx context.Context) (string, error) {
-	if ref, ok := m.originHeadRef(ctx); ok {
+func (m *GitTaskWorkspaceManager) detectBaseRef(ctx context.Context, repositoryPath string) (string, error) {
+	if ref, ok := m.originHeadRef(ctx, repositoryPath); ok {
 		return ref, nil
 	}
 
 	for _, ref := range []string{"origin/main", "origin/master", "main", "master"} {
-		exists, err := m.refExists(ctx, ref)
+		exists, err := m.refExists(ctx, repositoryPath, ref)
 		if err != nil {
 			return "", err
 		}
@@ -226,8 +251,8 @@ func (m *GitTaskWorkspaceManager) detectBaseRef(ctx context.Context) (string, er
 	return "", errors.New("detect task worktree base ref: expected origin/HEAD, origin/main, origin/master, main, or master")
 }
 
-func (m *GitTaskWorkspaceManager) branchExists(ctx context.Context, branchName string) (bool, error) {
-	_, err := m.runGit(ctx, "show-ref", "--verify", "--quiet", "refs/heads/"+branchName)
+func (m *GitTaskWorkspaceManager) branchExists(ctx context.Context, repositoryPath string, branchName string) (bool, error) {
+	_, err := m.runGitIn(ctx, repositoryPath, "show-ref", "--verify", "--quiet", "refs/heads/"+branchName)
 	if err == nil {
 		return true, nil
 	}
@@ -240,8 +265,8 @@ func (m *GitTaskWorkspaceManager) branchExists(ctx context.Context, branchName s
 	return false, fmt.Errorf("check branch existence: %w", err)
 }
 
-func (m *GitTaskWorkspaceManager) refreshOrigin(ctx context.Context) {
-	exists, err := m.remoteExists(ctx, "origin")
+func (m *GitTaskWorkspaceManager) refreshOrigin(ctx context.Context, repositoryPath string) {
+	exists, err := m.remoteExistsIn(ctx, repositoryPath, "origin")
 	if err != nil {
 		m.logger.Warn("check git remote before task worktree fetch", "remote", "origin", "error", err)
 		return
@@ -250,13 +275,18 @@ func (m *GitTaskWorkspaceManager) refreshOrigin(ctx context.Context) {
 		return
 	}
 
-	if _, err := m.runGit(ctx, "fetch", "origin", "--prune"); err != nil {
+	if _, err := m.runGitIn(ctx, repositoryPath, "fetch", "origin", "--prune"); err != nil {
 		m.logger.Warn("refresh git remote before task worktree base ref detection", "remote", "origin", "error", err)
+		return
+	}
+
+	if _, err := m.runGitIn(ctx, repositoryPath, "remote", "set-head", "origin", "--auto"); err != nil {
+		m.logger.Warn("refresh git remote head for task worktree base ref detection", "remote", "origin", "error", err)
 	}
 }
 
-func (m *GitTaskWorkspaceManager) remoteExists(ctx context.Context, remoteName string) (bool, error) {
-	_, err := m.runGit(ctx, "remote", "get-url", remoteName)
+func (m *GitTaskWorkspaceManager) remoteExistsIn(ctx context.Context, repositoryPath string, remoteName string) (bool, error) {
+	_, err := m.runGitIn(ctx, repositoryPath, "remote", "get-url", remoteName)
 	if err == nil {
 		return true, nil
 	}
@@ -269,13 +299,13 @@ func (m *GitTaskWorkspaceManager) remoteExists(ctx context.Context, remoteName s
 	return false, fmt.Errorf("check remote existence: %w", err)
 }
 
-func (m *GitTaskWorkspaceManager) originHeadRef(ctx context.Context) (string, bool) {
-	ref, err := m.runGit(ctx, "symbolic-ref", "--quiet", "--short", "refs/remotes/origin/HEAD")
+func (m *GitTaskWorkspaceManager) originHeadRef(ctx context.Context, repositoryPath string) (string, bool) {
+	ref, err := m.runGitIn(ctx, repositoryPath, "symbolic-ref", "--quiet", "--short", "refs/remotes/origin/HEAD")
 	if err != nil || strings.TrimSpace(ref) == "" {
 		return "", false
 	}
 
-	exists, verifyErr := m.refExists(ctx, ref)
+	exists, verifyErr := m.refExists(ctx, repositoryPath, ref)
 	if verifyErr != nil || !exists {
 		return "", false
 	}
@@ -283,8 +313,8 @@ func (m *GitTaskWorkspaceManager) originHeadRef(ctx context.Context) (string, bo
 	return ref, true
 }
 
-func (m *GitTaskWorkspaceManager) refExists(ctx context.Context, ref string) (bool, error) {
-	_, err := m.runGit(ctx, "rev-parse", "--verify", "--quiet", ref+"^{commit}")
+func (m *GitTaskWorkspaceManager) refExists(ctx context.Context, repositoryPath string, ref string) (bool, error) {
+	_, err := m.runGitIn(ctx, repositoryPath, "rev-parse", "--verify", "--quiet", ref+"^{commit}")
 	if err == nil {
 		return true, nil
 	}
@@ -297,13 +327,13 @@ func (m *GitTaskWorkspaceManager) refExists(ctx context.Context, ref string) (bo
 	return false, fmt.Errorf("check ref existence %q: %w", ref, err)
 }
 
-func (m *GitTaskWorkspaceManager) prepareWorktreePath(ctx context.Context, worktreePath string) error {
+func (m *GitTaskWorkspaceManager) prepareWorktreePath(ctx context.Context, repositoryPath string, worktreePath string) error {
 	if err := os.MkdirAll(filepath.Dir(worktreePath), worktreeDirectoryPerms); err != nil {
 		return fmt.Errorf("create worktree parent directory: %w", err)
 	}
 
 	if _, statErr := os.Stat(worktreePath); statErr == nil {
-		if _, err := m.runGit(ctx, "worktree", "remove", "--force", worktreePath); err != nil {
+		if _, err := m.runGitIn(ctx, repositoryPath, "worktree", "remove", "--force", worktreePath); err != nil {
 			m.logger.Debug("ignore stale worktree removal failure before retry", "worktree_path", worktreePath, "error", err)
 		}
 	} else if !errors.Is(statErr, os.ErrNotExist) {
@@ -341,8 +371,192 @@ func (m *GitTaskWorkspaceManager) worktreePath(taskID string) string {
 	return filepath.Join(m.dataDir, worktreesDirectoryName, taskID)
 }
 
-func (m *GitTaskWorkspaceManager) runGit(ctx context.Context, args ...string) (string, error) {
-	commandArgs := append([]string{"-C", m.sourceRepository}, args...)
+func (m *GitTaskWorkspaceManager) managedRepositoryPath() string {
+	baseName := sanitizeTaskRepositoryName(filepath.Base(filepath.Clean(m.sourceRepository)))
+	if baseName == "" {
+		baseName = "source-repository"
+	}
+
+	sourceHash := sha256.Sum256([]byte(filepath.Clean(m.sourceRepository)))
+	suffix := hex.EncodeToString(sourceHash[:managedRepositoryHashByteSize])
+
+	return filepath.Join(m.dataDir, managedRepositoriesDirectory, baseName+"-"+suffix+".git")
+}
+
+func (m *GitTaskWorkspaceManager) ensureManagedRepository(ctx context.Context) (string, error) {
+	remoteConfig, err := m.sourceOriginConfig(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	managedRepositoryPath := m.managedRepositoryPath()
+	if err := os.MkdirAll(filepath.Dir(managedRepositoryPath), worktreeDirectoryPerms); err != nil {
+		return "", fmt.Errorf("create managed repository parent directory: %w", err)
+	}
+
+	_, statErr := os.Stat(managedRepositoryPath)
+	switch {
+	case statErr == nil:
+		isBare, bareErr := m.isBareRepository(ctx, managedRepositoryPath)
+		if bareErr != nil {
+			return "", bareErr
+		}
+		if !isBare {
+			return "", fmt.Errorf("managed task repository is not bare: %s", managedRepositoryPath)
+		}
+	case errors.Is(statErr, os.ErrNotExist):
+		if err := m.initBareRepository(ctx, managedRepositoryPath); err != nil {
+			return "", err
+		}
+	default:
+		return "", fmt.Errorf("stat managed task repository: %w", statErr)
+	}
+
+	if err := m.syncManagedOriginConfig(ctx, managedRepositoryPath, remoteConfig); err != nil {
+		return "", err
+	}
+
+	m.refreshOrigin(ctx, managedRepositoryPath)
+	return managedRepositoryPath, nil
+}
+
+func (m *GitTaskWorkspaceManager) sourceOriginConfig(ctx context.Context) (gitRemoteConfig, error) {
+	exists, err := m.remoteExistsIn(ctx, m.sourceRepository, "origin")
+	if err != nil {
+		return gitRemoteConfig{}, fmt.Errorf("check source repository origin remote: %w", err)
+	}
+	if !exists {
+		return gitRemoteConfig{}, fmt.Errorf(
+			"task mode requires CLAW_CODEX_WORKDIR to have an origin remote: %s",
+			m.sourceRepository,
+		)
+	}
+
+	url, err := m.runGitIn(ctx, m.sourceRepository, "remote", "get-url", "origin")
+	if err != nil {
+		return gitRemoteConfig{}, fmt.Errorf("load source repository origin remote URL: %w", err)
+	}
+
+	pushURL, err := m.optionalGitConfigValue(ctx, m.sourceRepository, "remote.origin.pushurl")
+	if err != nil {
+		return gitRemoteConfig{}, fmt.Errorf("load source repository origin push URL: %w", err)
+	}
+
+	return gitRemoteConfig{
+		url:     strings.TrimSpace(url),
+		pushURL: strings.TrimSpace(pushURL),
+	}, nil
+}
+
+func (m *GitTaskWorkspaceManager) isBareRepository(ctx context.Context, repositoryPath string) (bool, error) {
+	value, err := m.runGitIn(ctx, repositoryPath, "rev-parse", "--is-bare-repository")
+	if err != nil {
+		return false, fmt.Errorf("check managed task repository type: %w", err)
+	}
+
+	return strings.EqualFold(strings.TrimSpace(value), "true"), nil
+}
+
+func (m *GitTaskWorkspaceManager) initBareRepository(ctx context.Context, repositoryPath string) error {
+	//nolint:gosec // The git executable path is intentionally configurable for tests.
+	cmd := exec.CommandContext(ctx, m.gitExecutable, "init", "--bare", repositoryPath)
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		message := strings.TrimSpace(stderr.String())
+		if message == "" {
+			message = strings.TrimSpace(stdout.String())
+		}
+		if message == "" {
+			return fmt.Errorf("initialize managed task repository: %w", err)
+		}
+		return fmt.Errorf("initialize managed task repository: %w: %s", err, message)
+	}
+
+	return nil
+}
+
+func (m *GitTaskWorkspaceManager) syncManagedOriginConfig(
+	ctx context.Context,
+	repositoryPath string,
+	remoteConfig gitRemoteConfig,
+) error {
+	exists, err := m.remoteExistsIn(ctx, repositoryPath, "origin")
+	if err != nil {
+		return fmt.Errorf("check managed task repository origin remote: %w", err)
+	}
+
+	if exists {
+		if _, err := m.runGitIn(ctx, repositoryPath, "remote", "set-url", "origin", remoteConfig.url); err != nil {
+			return fmt.Errorf("update managed task repository origin remote URL: %w", err)
+		}
+	} else {
+		if _, err := m.runGitIn(ctx, repositoryPath, "remote", "add", "origin", remoteConfig.url); err != nil {
+			return fmt.Errorf("add managed task repository origin remote: %w", err)
+		}
+	}
+
+	if _, err := m.runGitIn(ctx, repositoryPath, "config", "--replace-all", "remote.origin.fetch", managedOriginFetchRefspec); err != nil {
+		return fmt.Errorf("configure managed task repository origin fetch refspec: %w", err)
+	}
+
+	if err := m.syncManagedOriginPushURL(ctx, repositoryPath, remoteConfig.pushURL); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *GitTaskWorkspaceManager) syncManagedOriginPushURL(
+	ctx context.Context,
+	repositoryPath string,
+	pushURL string,
+) error {
+	existingPushURL, err := m.optionalGitConfigValue(ctx, repositoryPath, "remote.origin.pushurl")
+	if err != nil {
+		return fmt.Errorf("check managed task repository origin push URL: %w", err)
+	}
+
+	if existingPushURL != "" {
+		if _, err := m.runGitIn(ctx, repositoryPath, "config", "--unset-all", "remote.origin.pushurl"); err != nil {
+			return fmt.Errorf("clear managed task repository origin push URL: %w", err)
+		}
+	}
+
+	if strings.TrimSpace(pushURL) == "" {
+		return nil
+	}
+
+	if _, err := m.runGitIn(ctx, repositoryPath, "config", "remote.origin.pushurl", pushURL); err != nil {
+		return fmt.Errorf("configure managed task repository origin push URL: %w", err)
+	}
+
+	return nil
+}
+
+func (m *GitTaskWorkspaceManager) optionalGitConfigValue(
+	ctx context.Context,
+	repositoryPath string,
+	key string,
+) (string, error) {
+	value, err := m.runGitIn(ctx, repositoryPath, "config", "--get", key)
+	if err == nil {
+		return strings.TrimSpace(value), nil
+	}
+
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
+		return "", nil
+	}
+
+	return "", fmt.Errorf("load git config %s: %w", key, err)
+}
+
+func (m *GitTaskWorkspaceManager) runGitIn(ctx context.Context, repositoryPath string, args ...string) (string, error) {
+	commandArgs := append([]string{"-C", repositoryPath}, args...)
 
 	//nolint:gosec // The git executable path is intentionally configurable for tests.
 	cmd := exec.CommandContext(ctx, m.gitExecutable, commandArgs...)
@@ -363,4 +577,30 @@ func (m *GitTaskWorkspaceManager) runGit(ctx context.Context, args ...string) (s
 	}
 
 	return strings.TrimSpace(stdout.String()), nil
+}
+
+func sanitizeTaskRepositoryName(name string) string {
+	trimmed := strings.TrimSpace(name)
+	if trimmed == "" {
+		return ""
+	}
+
+	var builder strings.Builder
+	builder.Grow(len(trimmed))
+	for _, r := range trimmed {
+		switch {
+		case r >= 'a' && r <= 'z':
+			builder.WriteRune(r)
+		case r >= 'A' && r <= 'Z':
+			builder.WriteRune(r + ('a' - 'A'))
+		case r >= '0' && r <= '9':
+			builder.WriteRune(r)
+		case r == '-', r == '_', r == '.':
+			builder.WriteRune(r)
+		default:
+			builder.WriteByte('-')
+		}
+	}
+
+	return strings.Trim(builder.String(), "-.")
 }

--- a/internal/app/task_workspace_test.go
+++ b/internal/app/task_workspace_test.go
@@ -12,14 +12,14 @@ import (
 	"github.com/HatsuneMiku3939/39claw/internal/app"
 )
 
-func TestGitTaskWorkspaceManagerEnsureReadyCreatesWorktree(t *testing.T) {
+func TestGitTaskWorkspaceManagerEnsureReadyCreatesManagedBareWorktree(t *testing.T) {
 	t.Parallel()
 
 	if _, err := exec.LookPath("git"); err != nil {
 		t.Skip("git is required for worktree integration tests")
 	}
 
-	sourceRepo := createGitRepository(t, "main")
+	sourceRepo := createRemoteBackedGitRepository(t, "main")
 	dataDir := t.TempDir()
 	store := &memoryThreadStore{
 		tasks: map[string]app.Task{
@@ -35,7 +35,7 @@ func TestGitTaskWorkspaceManagerEnsureReadyCreatesWorktree(t *testing.T) {
 		},
 	}
 
-	manager, err := app.NewTaskWorkspaceManager(app.TaskWorkspaceManagerDependencies{
+	manager, err := app.NewTaskWorkspaceManager(context.Background(), app.TaskWorkspaceManagerDependencies{
 		Store:            store,
 		SourceRepository: sourceRepo,
 		DataDir:          dataDir,
@@ -70,12 +70,31 @@ func TestGitTaskWorkspaceManagerEnsureReadyCreatesWorktree(t *testing.T) {
 		t.Fatalf("WorktreeStatus = %q, want %q", readyTask.WorktreeStatus, app.TaskWorktreeStatusReady)
 	}
 
-	if readyTask.BaseRef != "main" {
-		t.Fatalf("BaseRef = %q, want %q", readyTask.BaseRef, "main")
+	if readyTask.BaseRef != "origin/main" {
+		t.Fatalf("BaseRef = %q, want %q", readyTask.BaseRef, "origin/main")
 	}
 
 	if _, err := os.Stat(filepath.Join(wantPath, ".git")); err != nil {
 		t.Fatalf("worktree .git stat error = %v", err)
+	}
+
+	managedRepoPath := managedRepoPathFromDataDir(t, dataDir)
+	originURL := gitOutput(t, sourceRepo, "remote", "get-url", "origin")
+	if got := gitOutput(t, readyTask.WorktreePath, "remote", "get-url", "origin"); got != originURL {
+		t.Fatalf("worktree origin URL = %q, want %q", got, originURL)
+	}
+
+	if got := gitOutput(t, managedRepoPath, "rev-parse", "--is-bare-repository"); got != "true" {
+		t.Fatalf("managed repository bare flag = %q, want %q", got, "true")
+	}
+
+	if _, err := gitOutputWithError(sourceRepo, "show-ref", "--verify", "refs/heads/"+readyTask.BranchName); err == nil {
+		t.Fatalf("source repository unexpectedly contains task branch %q", readyTask.BranchName)
+	}
+
+	runGit(t, readyTask.WorktreePath, "switch", "main")
+	if got := gitOutput(t, readyTask.WorktreePath, "branch", "--show-current"); got != "main" {
+		t.Fatalf("current branch after switch = %q, want %q", got, "main")
 	}
 }
 
@@ -112,7 +131,7 @@ func TestGitTaskWorkspaceManagerEnsureReadyPrefersRemoteDefaultBranch(t *testing
 		},
 	}
 
-	manager, err := app.NewTaskWorkspaceManager(app.TaskWorkspaceManagerDependencies{
+	manager, err := app.NewTaskWorkspaceManager(context.Background(), app.TaskWorkspaceManagerDependencies{
 		Store:            store,
 		SourceRepository: sourceRepo,
 		DataDir:          dataDir,
@@ -151,32 +170,40 @@ func TestGitTaskWorkspaceManagerEnsureReadyPrefersRemoteDefaultBranch(t *testing
 	}
 }
 
-func TestGitTaskWorkspaceManagerEnsureReadyFallsBackToLocalBranchWhenFetchFails(t *testing.T) {
+func TestGitTaskWorkspaceManagerEnsureReadyUsesCachedRemoteRefsWhenFetchFails(t *testing.T) {
 	t.Parallel()
 
 	if _, err := exec.LookPath("git"); err != nil {
 		t.Skip("git is required for worktree integration tests")
 	}
 
-	sourceRepo := createGitRepository(t, "master")
-	runGit(t, sourceRepo, "remote", "add", "origin", filepath.Join(t.TempDir(), "missing-remote.git"))
+	sourceRepo, remoteRepo := createRemoteBackedGitRepositoryWithRemote(t, "master")
 
 	dataDir := t.TempDir()
 	store := &memoryThreadStore{
 		tasks: map[string]app.Task{
-			"user-1:task-local-fallback": {
-				TaskID:         "task-local-fallback",
+			"user-1:task-cached-remote": {
+				TaskID:         "task-cached-remote",
 				DiscordUserID:  "user-1",
-				TaskName:       "Local fallback",
+				TaskName:       "Cached remote",
 				Status:         app.TaskStatusOpen,
-				BranchName:     app.DefaultTaskBranchName("task-local-fallback"),
+				BranchName:     app.DefaultTaskBranchName("task-cached-remote"),
 				WorktreeStatus: app.TaskWorktreeStatusPending,
 				CreatedAt:      time.Date(2026, time.April, 6, 0, 0, 0, 0, time.UTC),
+			},
+			"user-1:task-fetch-failure": {
+				TaskID:         "task-fetch-failure",
+				DiscordUserID:  "user-1",
+				TaskName:       "Fetch failure",
+				Status:         app.TaskStatusOpen,
+				BranchName:     app.DefaultTaskBranchName("task-fetch-failure"),
+				WorktreeStatus: app.TaskWorktreeStatusPending,
+				CreatedAt:      time.Date(2026, time.April, 6, 1, 0, 0, 0, time.UTC),
 			},
 		},
 	}
 
-	manager, err := app.NewTaskWorkspaceManager(app.TaskWorkspaceManagerDependencies{
+	manager, err := app.NewTaskWorkspaceManager(context.Background(), app.TaskWorkspaceManagerDependencies{
 		Store:            store,
 		SourceRepository: sourceRepo,
 		DataDir:          dataDir,
@@ -189,7 +216,7 @@ func TestGitTaskWorkspaceManagerEnsureReadyFallsBackToLocalBranchWhenFetchFails(
 		t.Fatalf("NewTaskWorkspaceManager() error = %v", err)
 	}
 
-	task, ok, err := store.GetTask(context.Background(), "user-1", "task-local-fallback")
+	task, ok, err := store.GetTask(context.Background(), "user-1", "task-cached-remote")
 	if err != nil {
 		t.Fatalf("GetTask() error = %v", err)
 	}
@@ -202,8 +229,27 @@ func TestGitTaskWorkspaceManagerEnsureReadyFallsBackToLocalBranchWhenFetchFails(
 		t.Fatalf("EnsureReady() error = %v", err)
 	}
 
-	if readyTask.BaseRef != "master" {
-		t.Fatalf("BaseRef = %q, want %q", readyTask.BaseRef, "master")
+	if readyTask.BaseRef != "origin/master" {
+		t.Fatalf("BaseRef = %q, want %q", readyTask.BaseRef, "origin/master")
+	}
+
+	runGit(t, sourceRepo, "remote", "set-url", "origin", filepath.Join(filepath.Dir(remoteRepo), "missing-remote.git"))
+
+	secondTask, ok, err := store.GetTask(context.Background(), "user-1", "task-fetch-failure")
+	if err != nil {
+		t.Fatalf("GetTask(second) error = %v", err)
+	}
+	if !ok {
+		t.Fatal("GetTask(second) ok = false, want true")
+	}
+
+	secondReadyTask, err := manager.EnsureReady(context.Background(), secondTask)
+	if err != nil {
+		t.Fatalf("EnsureReady(second) error = %v", err)
+	}
+
+	if secondReadyTask.BaseRef != "origin/master" {
+		t.Fatalf("second BaseRef = %q, want %q", secondReadyTask.BaseRef, "origin/master")
 	}
 }
 
@@ -214,12 +260,12 @@ func TestGitTaskWorkspaceManagerPruneClosedRemovesOldReadyWorktrees(t *testing.T
 		t.Skip("git is required for worktree integration tests")
 	}
 
-	sourceRepo := createGitRepository(t, "main")
+	sourceRepo := createRemoteBackedGitRepository(t, "main")
 	dataDir := t.TempDir()
 	store := &memoryThreadStore{}
 	clock := time.Date(2026, time.April, 5, 15, 4, 0, 0, time.UTC)
 
-	manager, err := app.NewTaskWorkspaceManager(app.TaskWorkspaceManagerDependencies{
+	manager, err := app.NewTaskWorkspaceManager(context.Background(), app.TaskWorkspaceManagerDependencies{
 		Store:            store,
 		SourceRepository: sourceRepo,
 		DataDir:          dataDir,
@@ -296,9 +342,49 @@ func TestGitTaskWorkspaceManagerPruneClosedRemovesOldReadyWorktrees(t *testing.T
 	if newestTask.WorktreeStatus != app.TaskWorktreeStatusReady {
 		t.Fatalf("newest task WorktreeStatus = %q, want %q", newestTask.WorktreeStatus, app.TaskWorktreeStatusReady)
 	}
+
+	managedRepoPath := managedRepoPathFromDataDir(t, dataDir)
+	if got := gitOutput(t, managedRepoPath, "show-ref", "--verify", "refs/heads/task/task-3"); got == "" {
+		t.Fatal("managed repository is missing retained branch refs/heads/task/task-3")
+	}
+
+	if _, err := gitOutputWithError(sourceRepo, "show-ref", "--verify", "refs/heads/task/task-3"); err == nil {
+		t.Fatal("source repository unexpectedly contains pruned task branch")
+	}
+}
+
+func TestGitTaskWorkspaceManagerRejectsSourceRepositoryWithoutOriginRemote(t *testing.T) {
+	t.Parallel()
+
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git is required for worktree integration tests")
+	}
+
+	sourceRepo := createGitRepository(t, "main")
+
+	_, err := app.NewTaskWorkspaceManager(context.Background(), app.TaskWorkspaceManagerDependencies{
+		Store:            &memoryThreadStore{},
+		SourceRepository: sourceRepo,
+		DataDir:          t.TempDir(),
+		GitExecutable:    "git",
+	})
+	if err == nil {
+		t.Fatal("NewTaskWorkspaceManager() error = nil, want missing origin remote")
+	}
+
+	if !strings.Contains(err.Error(), "task mode requires CLAW_CODEX_WORKDIR to have an origin remote") {
+		t.Fatalf("NewTaskWorkspaceManager() error = %q, want missing origin remote guidance", err.Error())
+	}
 }
 
 func createRemoteBackedGitRepository(t *testing.T, branch string) string {
+	t.Helper()
+
+	source, _ := createRemoteBackedGitRepositoryWithRemote(t, branch)
+	return source
+}
+
+func createRemoteBackedGitRepositoryWithRemote(t *testing.T, branch string) (string, string) {
 	t.Helper()
 
 	root := t.TempDir()
@@ -315,7 +401,7 @@ func createRemoteBackedGitRepository(t *testing.T, branch string) string {
 	runGit(t, source, "commit", "-m", "initial commit")
 	runGit(t, source, "push", "-u", "origin", branch)
 
-	return source
+	return source, remote
 }
 
 func createGitRepository(t *testing.T, branch string) string {
@@ -349,14 +435,19 @@ func writeFile(t *testing.T, path string, contents string) {
 func gitOutput(t *testing.T, workdir string, args ...string) string {
 	t.Helper()
 
-	cmd := exec.Command("git", args...)
-	cmd.Dir = workdir
-	output, err := cmd.CombinedOutput()
+	output, err := gitOutputWithError(workdir, args...)
 	if err != nil {
 		t.Fatalf("git %v error = %v\n%s", args, err, output)
 	}
 
-	return strings.TrimSpace(string(output))
+	return output
+}
+
+func gitOutputWithError(workdir string, args ...string) (string, error) {
+	cmd := exec.Command("git", args...)
+	cmd.Dir = workdir
+	output, err := cmd.CombinedOutput()
+	return strings.TrimSpace(string(output)), err
 }
 
 func runGit(t *testing.T, workdir string, args ...string) {
@@ -367,4 +458,19 @@ func runGit(t *testing.T, workdir string, args ...string) {
 	if output, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("git %v error = %v\n%s", args, err, output)
 	}
+}
+
+func managedRepoPathFromDataDir(t *testing.T, dataDir string) string {
+	t.Helper()
+
+	entries, err := os.ReadDir(filepath.Join(dataDir, "repos"))
+	if err != nil {
+		t.Fatalf("ReadDir(repos) error = %v", err)
+	}
+
+	if len(entries) != 1 {
+		t.Fatalf("managed repository count = %d, want %d", len(entries), 1)
+	}
+
+	return filepath.Join(dataDir, "repos", entries[0].Name())
 }


### PR DESCRIPTION
## Summary

- move task worktree parenting from the visible source checkout to a managed bare repository under `CLAW_DATADIR/repos`
- require an `origin` remote for task-mode startup and preserve `origin` push behavior inside task worktrees
- update architecture, product, operations, example, and ExecPlan docs to describe the new repository model

## Background

Task-mode worktrees were previously parented directly from `CLAW_CODEX_WORKDIR`. That made the operator checkout participate in Git branch occupancy, so task worktrees could not reliably switch to the default branch when the visible checkout already had it checked out.

## Related issue(s)

- None.

## Implementation details

- validate the task-mode source checkout by requiring a Git repository with an `origin` remote during startup wiring
- initialize and refresh a managed bare parent under `${CLAW_DATADIR}/repos/<repo-id>.git`, syncing `origin.url`, `remote.origin.fetch`, and optional `remote.origin.pushurl`
- create and prune task worktrees from that managed bare parent while keeping task branches in the managed repository
- add integration-style coverage for managed bare creation, cached remote-ref fallback, branch switching inside task worktrees, pruning behavior, and startup rejection when `origin` is missing

## Test coverage

- `go test ./...`
- `./scripts/lint -c .golangci.yml`

## Breaking changes

- `task` mode now requires `CLAW_CODEX_WORKDIR` to be a Git repository with an `origin` remote

## Notes

- `make` was unavailable in this execution environment, so the documented fallback validation commands were used.

Created by Codex