### PR TITLE
Show worktree branches in task command output

### DIFF
--- a/docs/product-specs/discord-command-behavior.md
+++ b/docs/product-specs/discord-command-behavior.md
@@ -120,9 +120,9 @@ This means:
 The root command should support user-facing actions for:
 
 - `/<instance-command> action:task-current`
-  - show the current task name and ID
+  - show the current task name and ID, plus the current worktree branch when available
 - `/<instance-command> action:task-list`
-  - show task names and IDs
+  - show open task names and IDs, plus each task's current worktree branch when available
 - `/<instance-command> action:task-new task_name:<name>`
   - create a new task and switch the active task to it
 - `/<instance-command> action:task-switch task_name:<name>`

--- a/docs/product-specs/task-mode-user-flow.md
+++ b/docs/product-specs/task-mode-user-flow.md
@@ -144,9 +144,9 @@ Expected user perception:
 For `task` mode to feel usable, v1 should support at least:
 
 - `/<instance-command> action:task-current`
-  - show the current task name and ID
+  - show the current task name and ID, plus the current worktree branch when available
 - `/<instance-command> action:task-list`
-  - show task names and IDs
+  - show open task names and IDs, plus each task's current worktree branch when available
 - `/<instance-command> action:task-new task_name:<name>`
   - create a new task and switch the active task to it
 - `/<instance-command> action:task-switch task_name:<name>`

--- a/internal/app/message_service.go
+++ b/internal/app/message_service.go
@@ -45,6 +45,10 @@ type TaskWorkspaceManager interface {
 	PruneClosed(ctx context.Context) error
 }
 
+type TaskWorkspaceBranchReader interface {
+	CurrentBranch(ctx context.Context, task Task) (string, bool, error)
+}
+
 type CodexGateway interface {
 	RunTurn(ctx context.Context, threadID string, input CodexTurnInput) (RunTurnResult, error)
 }

--- a/internal/app/task_service.go
+++ b/internal/app/task_service.go
@@ -84,10 +84,15 @@ func (s *DefaultTaskCommandService) ShowCurrentTask(ctx context.Context, userID 
 		), nil
 	}
 
+	renderedTask, err := s.renderTaskWithBranch(ctx, task)
+	if err != nil {
+		return MessageResponse{}, err
+	}
+
 	return taskCommandResponse(
 		fmt.Sprintf(
 			"Active task: %s. Use %s to see open tasks or %s when you're done.",
-			renderTask(task),
+			renderedTask,
 			s.commands.taskList(),
 			s.commands.taskClose(task.TaskID),
 		),
@@ -112,7 +117,12 @@ func (s *DefaultTaskCommandService) ListTasks(ctx context.Context, userID string
 	lines := make([]string, 0, len(tasks))
 	lines = append(lines, "Open tasks:")
 	for _, task := range tasks {
-		line := "- " + renderTask(task)
+		renderedTask, err := s.renderTaskWithBranch(ctx, task)
+		if err != nil {
+			return MessageResponse{}, err
+		}
+
+		line := "- " + renderedTask
 		if ok && activeTask.TaskID == task.TaskID {
 			line += " [active]"
 		}
@@ -329,6 +339,28 @@ func (s *DefaultTaskCommandService) renderActiveTaskSuffix(ctx context.Context, 
 
 func renderTask(task Task) string {
 	return fmt.Sprintf("`%s` (`%s`)", task.TaskName, task.TaskID)
+}
+
+func (s *DefaultTaskCommandService) renderTaskWithBranch(ctx context.Context, task Task) (string, error) {
+	renderedTask := renderTask(task)
+	if s.worktrees == nil {
+		return renderedTask, nil
+	}
+
+	branchReader, ok := s.worktrees.(TaskWorkspaceBranchReader)
+	if !ok {
+		return renderedTask, nil
+	}
+
+	branch, branchOK, err := branchReader.CurrentBranch(ctx, task)
+	if err != nil {
+		return "", fmt.Errorf("load task worktree branch: %w", err)
+	}
+	if !branchOK {
+		return renderedTask, nil
+	}
+
+	return fmt.Sprintf("%s [branch: `%s`]", renderedTask, branch), nil
 }
 
 func taskCommandResponse(text string) MessageResponse {

--- a/internal/app/task_service_test.go
+++ b/internal/app/task_service_test.go
@@ -44,6 +44,44 @@ func TestTaskCommandServiceShowCurrentTask(t *testing.T) {
 	}
 }
 
+func TestTaskCommandServiceShowCurrentTaskIncludesWorktreeBranchWhenAvailable(t *testing.T) {
+	t.Parallel()
+
+	service := newTaskCommandServiceWithWorkspace(t, &memoryThreadStore{
+		tasks: map[string]app.Task{
+			"user-1:task-1": {
+				TaskID:         "task-1",
+				DiscordUserID:  "user-1",
+				TaskName:       "Release work",
+				Status:         app.TaskStatusOpen,
+				WorktreeStatus: app.TaskWorktreeStatusReady,
+				WorktreePath:   "/tmp/worktrees/task-1",
+				CreatedAt:      time.Date(2026, time.April, 5, 0, 0, 0, 0, time.UTC),
+			},
+		},
+		activeTasks: map[string]app.ActiveTask{
+			"user-1": {
+				DiscordUserID: "user-1",
+				TaskID:        "task-1",
+			},
+		},
+	}, nil, &branchReportingTaskWorkspaceManager{
+		branches: map[string]string{
+			"task-1": "main",
+		},
+	})
+
+	response, err := service.ShowCurrentTask(context.Background(), "user-1")
+	if err != nil {
+		t.Fatalf("ShowCurrentTask() error = %v", err)
+	}
+
+	want := "Active task: `Release work` (`task-1`) [branch: `main`]. Use `/release action:task-list` to see open tasks or `/release action:task-close task_id:task-1` when you're done."
+	if response.Text != want {
+		t.Fatalf("Text = %q, want %q", response.Text, want)
+	}
+}
+
 func TestTaskCommandServiceShowCurrentTaskWithoutActiveTaskReturnsGuidance(t *testing.T) {
 	t.Parallel()
 
@@ -154,6 +192,52 @@ func TestTaskCommandServiceListTasksMarksActiveTask(t *testing.T) {
 	}
 
 	want := "Open tasks:\n- `Release work` (`task-1`)\n- `Docs update` (`task-2`) [active]\nUse `/release action:task-switch task_name:<name>` to change the active task."
+	if response.Text != want {
+		t.Fatalf("Text = %q, want %q", response.Text, want)
+	}
+}
+
+func TestTaskCommandServiceListTasksIncludesWorktreeBranchWhenAvailable(t *testing.T) {
+	t.Parallel()
+
+	service := newTaskCommandServiceWithWorkspace(t, &memoryThreadStore{
+		tasks: map[string]app.Task{
+			"user-1:task-1": {
+				TaskID:         "task-1",
+				DiscordUserID:  "user-1",
+				TaskName:       "Release work",
+				Status:         app.TaskStatusOpen,
+				WorktreeStatus: app.TaskWorktreeStatusReady,
+				WorktreePath:   "/tmp/worktrees/task-1",
+				CreatedAt:      time.Date(2026, time.April, 5, 0, 0, 0, 0, time.UTC),
+			},
+			"user-1:task-2": {
+				TaskID:         "task-2",
+				DiscordUserID:  "user-1",
+				TaskName:       "Docs update",
+				Status:         app.TaskStatusOpen,
+				WorktreeStatus: app.TaskWorktreeStatusPending,
+				CreatedAt:      time.Date(2026, time.April, 5, 1, 0, 0, 0, time.UTC),
+			},
+		},
+		activeTasks: map[string]app.ActiveTask{
+			"user-1": {
+				DiscordUserID: "user-1",
+				TaskID:        "task-2",
+			},
+		},
+	}, nil, &branchReportingTaskWorkspaceManager{
+		branches: map[string]string{
+			"task-1": "feature/release",
+		},
+	})
+
+	response, err := service.ListTasks(context.Background(), "user-1")
+	if err != nil {
+		t.Fatalf("ListTasks() error = %v", err)
+	}
+
+	want := "Open tasks:\n- `Release work` (`task-1`) [branch: `feature/release`]\n- `Docs update` (`task-2`) [active]\nUse `/release action:task-switch task_name:<name>` to change the active task."
 	if response.Text != want {
 		t.Fatalf("Text = %q, want %q", response.Text, want)
 	}
@@ -475,4 +559,21 @@ func (*countingTaskWorkspaceManager) EnsureReady(context.Context, app.Task) (app
 func (m *countingTaskWorkspaceManager) PruneClosed(context.Context) error {
 	m.pruneCalls++
 	return nil
+}
+
+type branchReportingTaskWorkspaceManager struct {
+	branches map[string]string
+}
+
+func (*branchReportingTaskWorkspaceManager) EnsureReady(context.Context, app.Task) (app.Task, error) {
+	return app.Task{}, nil
+}
+
+func (*branchReportingTaskWorkspaceManager) PruneClosed(context.Context) error {
+	return nil
+}
+
+func (m *branchReportingTaskWorkspaceManager) CurrentBranch(_ context.Context, task app.Task) (string, bool, error) {
+	branch, ok := m.branches[task.TaskID]
+	return branch, ok, nil
 }

--- a/internal/app/task_workspace.go
+++ b/internal/app/task_workspace.go
@@ -233,6 +233,29 @@ func (m *GitTaskWorkspaceManager) PruneClosed(ctx context.Context) error {
 	return errors.Join(errs...)
 }
 
+func (m *GitTaskWorkspaceManager) CurrentBranch(ctx context.Context, task Task) (string, bool, error) {
+	if task.WorktreeStatus != TaskWorktreeStatusReady {
+		return "", false, nil
+	}
+
+	worktreePath := strings.TrimSpace(task.WorktreePath)
+	if worktreePath == "" {
+		return "", false, nil
+	}
+
+	branch, err := m.runGitIn(ctx, worktreePath, "branch", "--show-current")
+	if err != nil {
+		return "", false, fmt.Errorf("read current worktree branch: %w", err)
+	}
+
+	branch = strings.TrimSpace(branch)
+	if branch == "" {
+		return "", false, nil
+	}
+
+	return branch, true, nil
+}
+
 func (m *GitTaskWorkspaceManager) detectBaseRef(ctx context.Context, repositoryPath string) (string, error) {
 	if ref, ok := m.originHeadRef(ctx, repositoryPath); ok {
 		return ref, nil

--- a/internal/app/task_workspace_test.go
+++ b/internal/app/task_workspace_test.go
@@ -98,6 +98,69 @@ func TestGitTaskWorkspaceManagerEnsureReadyCreatesManagedBareWorktree(t *testing
 	}
 }
 
+func TestGitTaskWorkspaceManagerCurrentBranchReadsWorktreeState(t *testing.T) {
+	t.Parallel()
+
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git is required for worktree integration tests")
+	}
+
+	sourceRepo := createRemoteBackedGitRepository(t, "main")
+	dataDir := t.TempDir()
+	store := &memoryThreadStore{
+		tasks: map[string]app.Task{
+			"user-1:task-1": {
+				TaskID:         "task-1",
+				DiscordUserID:  "user-1",
+				TaskName:       "Release work",
+				Status:         app.TaskStatusOpen,
+				BranchName:     app.DefaultTaskBranchName("task-1"),
+				WorktreeStatus: app.TaskWorktreeStatusPending,
+				CreatedAt:      time.Date(2026, time.April, 5, 0, 0, 0, 0, time.UTC),
+			},
+		},
+	}
+
+	manager, err := app.NewTaskWorkspaceManager(context.Background(), app.TaskWorkspaceManagerDependencies{
+		Store:            store,
+		SourceRepository: sourceRepo,
+		DataDir:          dataDir,
+		GitExecutable:    "git",
+		Clock: func() time.Time {
+			return time.Date(2026, time.April, 5, 15, 4, 0, 0, time.UTC)
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewTaskWorkspaceManager() error = %v", err)
+	}
+
+	task, ok, err := store.GetTask(context.Background(), "user-1", "task-1")
+	if err != nil {
+		t.Fatalf("GetTask() error = %v", err)
+	}
+	if !ok {
+		t.Fatal("GetTask() ok = false, want true")
+	}
+
+	readyTask, err := manager.EnsureReady(context.Background(), task)
+	if err != nil {
+		t.Fatalf("EnsureReady() error = %v", err)
+	}
+
+	runGit(t, readyTask.WorktreePath, "switch", "main")
+
+	branch, branchOK, err := manager.CurrentBranch(context.Background(), readyTask)
+	if err != nil {
+		t.Fatalf("CurrentBranch() error = %v", err)
+	}
+	if !branchOK {
+		t.Fatal("CurrentBranch() ok = false, want true")
+	}
+	if branch != "main" {
+		t.Fatalf("CurrentBranch() = %q, want %q", branch, "main")
+	}
+}
+
 func TestGitTaskWorkspaceManagerEnsureReadyPrefersRemoteDefaultBranch(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- show the current Git branch for task worktrees in `task-current` and `task-list` when available
- read the live branch from the ready worktree instead of relying on stored task metadata
- document and test the new command output behavior

## Background
Users can move a task worktree onto a different branch after it is created. The existing task command output only showed task name and ID, so it did not reveal the branch currently checked out in that worktree.

## Related issue(s)
- N/A

## Implementation details
- added an optional task workspace branch reader interface for command rendering
- taught `GitTaskWorkspaceManager` to read the current branch from a ready worktree with `git branch --show-current`
- updated task command service output and added unit plus Git-backed integration coverage
- updated task-mode product specs to describe the branch display

## Test coverage
- `make test`
- `make lint`

## Breaking changes
- None

## Notes
- branch text is shown only when a ready worktree exists and the current branch can be resolved

Created by Codex