### PR TITLE
[codex] Serialize managed task repository mutations

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -56,6 +56,7 @@ The distinction between `daily` mode and `task` mode is therefore not a differen
 It is a difference in the role of the repository that Codex is operating against.
 
 - In `task` mode, the configured workdir must be a Git repository with an `origin` remote. It remains the operator-visible source checkout and validation anchor, while 39claw creates task-isolated worktrees from its own managed bare parent repository under `CLAW_DATADIR`.
+- Shared managed-repository mutation in `task` mode must be serialized per managed repository path within the process so concurrent task starts do not contend on the same bare parent, while already-ready task worktrees keep their existing task-level concurrency behavior.
 - In `daily` mode, the repository is a knowledge-oriented repository that primarily contains instructions and documentation, allowing Codex to answer questions by following local guidance and searching the knowledge base.
 
 Both modes share the same Codex-native foundation.

--- a/docs/design-docs/implementation-spec.md
+++ b/docs/design-docs/implementation-spec.md
@@ -134,6 +134,7 @@ If `action:clear` is invoked while the current active daily generation still has
 When a bot instance runs in `task` mode, `CLAW_CODEX_WORKDIR` must be a Git repository with an `origin` remote.
 `task-new` creates task metadata only and reserves a branch name derived from the task name with Git-safe normalization; if normalization produces no usable suffix, it falls back to the task ID. The first normal message for a pending or failed task creates the task worktree lazily from a managed bare parent under `${CLAW_DATADIR}/repos`, preferring the remote default branch by trying `origin/HEAD`, then `origin/main`, then `origin/master`, and only then falling back to local `main` or `master` inside that managed repository.
 Before detecting that base ref, 39claw should synchronize the managed bare parent against the source checkout's `origin` configuration and try `git fetch origin --prune`; a fetch failure should not block task execution by itself when cached remote refs are already available.
+Those managed-parent mutation steps should be serialized per managed repository path within the running process so concurrent task starts do not overlap on one shared bare parent.
 Once the task worktree is ready, Codex runs with the task-specific `worktree_path` as the effective working directory for that turn.
 Closed tasks keep their task branches in the managed bare parent, but only the fifteen most recently closed ready tasks keep their worktrees; older closed ready worktrees are force-pruned.
 

--- a/docs/design-docs/task-mode-worktrees.md
+++ b/docs/design-docs/task-mode-worktrees.md
@@ -28,6 +28,7 @@ This turns `task` mode into an execution-oriented workflow instead of a long-liv
 - Worktrees are created lazily on the first normal message that needs to run Codex for the task.
 - The base ref for worktree creation is detected automatically inside the managed bare parent by preferring the remote default branch state.
 - Worktree preparation synchronizes the managed bare parent to the source checkout's `origin` URL and best-effort `pushurl`, then tries `git fetch origin --prune` plus `git remote set-head origin --auto` before resolving the base ref.
+- Because all tasks for one source checkout share that managed bare parent, in-process mutation against the same managed repository path is serialized during lazy preparation and closed-task pruning.
 - Base-ref resolution should prefer `origin/HEAD`, then `origin/main`, then `origin/master`, and only then fall back to local `main` or `master`.
 - Closing a task does not delete its branch from the managed bare parent.
 - Closed-task worktrees are treated as disposable cache-like workspaces.
@@ -149,6 +150,7 @@ Lazy worktree creation failure is handled at normal-message time:
 - the next normal message retries worktree preparation automatically
 
 If the best-effort `git fetch origin --prune` step fails, the system should log the refresh failure but still continue base-ref detection using any already-available remote-tracking refs in the managed bare parent and then the local fallback branches.
+That refresh and the other shared managed-repository mutations should not race with another task preparing or pruning against the same managed bare parent inside the same process.
 
 Pruning failure must not reopen or invalidate the closed task.
 If pruning fails, the system should keep the task in `closed + ready`, log the failure, and try again during a later cleanup opportunity.

--- a/internal/app/task_workspace.go
+++ b/internal/app/task_workspace.go
@@ -12,6 +12,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -24,6 +25,8 @@ const (
 	managedOriginFetchRefspec     = "+refs/heads/*:refs/remotes/origin/*"
 	managedRepositoryHashByteSize = 6
 )
+
+var managedRepositoryLocks = newPathMutexMap()
 
 type TaskWorkspaceManagerDependencies struct {
 	Store            ThreadStore
@@ -48,6 +51,35 @@ type GitTaskWorkspaceManager struct {
 type gitRemoteConfig struct {
 	url     string
 	pushURL string
+}
+
+type pathMutexMap struct {
+	mu    sync.Mutex
+	locks map[string]*sync.Mutex
+}
+
+func newPathMutexMap() *pathMutexMap {
+	return &pathMutexMap{
+		locks: make(map[string]*sync.Mutex),
+	}
+}
+
+func (m *pathMutexMap) lock(path string) func() {
+	key := filepath.Clean(strings.TrimSpace(path))
+
+	m.mu.Lock()
+	lock, ok := m.locks[key]
+	if !ok {
+		lock = &sync.Mutex{}
+		m.locks[key] = lock
+	}
+	m.mu.Unlock()
+
+	lock.Lock()
+
+	return func() {
+		lock.Unlock()
+	}
 }
 
 func NewTaskWorkspaceManager(ctx context.Context, deps TaskWorkspaceManagerDependencies) (*GitTaskWorkspaceManager, error) {
@@ -119,7 +151,12 @@ func (m *GitTaskWorkspaceManager) EnsureReady(ctx context.Context, task Task) (T
 		return task, nil
 	}
 
-	managedRepositoryPath, err := m.ensureManagedRepository(ctx)
+	managedRepositoryPath := m.managedRepositoryPath()
+	unlockManagedRepository := managedRepositoryLocks.lock(managedRepositoryPath)
+	defer unlockManagedRepository()
+
+	var err error
+	managedRepositoryPath, err = m.ensureManagedRepository(ctx)
 	if err != nil {
 		return Task{}, m.markTaskWorktreeFailed(ctx, task, "", err)
 	}
@@ -189,7 +226,11 @@ func (m *GitTaskWorkspaceManager) PruneClosed(ctx context.Context) error {
 		return nil
 	}
 
-	managedRepositoryPath, err := m.ensureManagedRepository(ctx)
+	managedRepositoryPath := m.managedRepositoryPath()
+	unlockManagedRepository := managedRepositoryLocks.lock(managedRepositoryPath)
+	defer unlockManagedRepository()
+
+	managedRepositoryPath, err = m.ensureManagedRepository(ctx)
 	if err != nil {
 		return fmt.Errorf("ensure managed task repository: %w", err)
 	}

--- a/internal/app/task_workspace_test.go
+++ b/internal/app/task_workspace_test.go
@@ -2,10 +2,13 @@ package app_test
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -313,6 +316,214 @@ func TestGitTaskWorkspaceManagerEnsureReadyUsesCachedRemoteRefsWhenFetchFails(t 
 
 	if secondReadyTask.BaseRef != "origin/master" {
 		t.Fatalf("second BaseRef = %q, want %q", secondReadyTask.BaseRef, "origin/master")
+	}
+}
+
+func TestGitTaskWorkspaceManagerEnsureReadySerializesManagedRepositoryMutation(t *testing.T) {
+	t.Parallel()
+
+	realGit, err := exec.LookPath("git")
+	if err != nil {
+		t.Skip("git is required for worktree integration tests")
+	}
+
+	sourceRepo := createRemoteBackedGitRepository(t, "main")
+	dataDir := t.TempDir()
+	traceDir := t.TempDir()
+
+	wrapperPath := filepath.Join(t.TempDir(), "git-wrapper.sh")
+	wrapperScript := fmt.Sprintf(`#!/usr/bin/env bash
+set -euo pipefail
+
+real_git=%q
+trace_dir=%q
+managed_root=%q
+original_args=("$@")
+parsed_args=("$@")
+instrument=0
+
+if [[ ${#parsed_args[@]} -ge 3 && "${parsed_args[0]}" == "-C" ]]; then
+	repository_path="${parsed_args[1]}"
+	parsed_args=("${parsed_args[@]:2}")
+
+	if [[ "${repository_path}" == "${managed_root}"/* ]]; then
+		case "${parsed_args[0]:-}" in
+			config|fetch|worktree)
+				instrument=1
+				;;
+			remote)
+				case "${parsed_args[1]:-}" in
+					add|set-url|set-head)
+						instrument=1
+						;;
+				esac
+				;;
+		esac
+	fi
+elif [[ ${#parsed_args[@]} -ge 3 && "${parsed_args[0]}" == "init" && "${parsed_args[1]}" == "--bare" ]]; then
+	if [[ "${parsed_args[2]}" == "${managed_root}"/* ]]; then
+		instrument=1
+	fi
+fi
+
+acquire_state_lock() {
+	while ! mkdir "${trace_dir}/state.lock" 2>/dev/null; do
+		sleep 0.01
+	done
+}
+
+release_state_lock() {
+	rmdir "${trace_dir}/state.lock"
+}
+
+enter_critical() {
+	acquire_state_lock
+
+	local current=0
+	if [[ -f "${trace_dir}/current" ]]; then
+		current=$(cat "${trace_dir}/current")
+	fi
+	current=$((current + 1))
+	printf '%%s\n' "${current}" > "${trace_dir}/current"
+
+	local max_seen=0
+	if [[ -f "${trace_dir}/max" ]]; then
+		max_seen=$(cat "${trace_dir}/max")
+	fi
+	if (( current > max_seen )); then
+		printf '%%s\n' "${current}" > "${trace_dir}/max"
+	fi
+
+	release_state_lock
+}
+
+leave_critical() {
+	acquire_state_lock
+
+	local current=0
+	if [[ -f "${trace_dir}/current" ]]; then
+		current=$(cat "${trace_dir}/current")
+	fi
+	if (( current > 0 )); then
+		current=$((current - 1))
+	fi
+	printf '%%s\n' "${current}" > "${trace_dir}/current"
+
+	release_state_lock
+}
+
+if (( instrument == 1 )); then
+	enter_critical
+	sleep 0.2
+fi
+
+set +e
+"${real_git}" "${original_args[@]}"
+status=$?
+set -e
+
+if (( instrument == 1 )); then
+	leave_critical
+fi
+
+exit "${status}"
+`, realGit, traceDir, filepath.Join(dataDir, "repos"))
+	if err := os.WriteFile(wrapperPath, []byte(wrapperScript), 0o755); err != nil {
+		t.Fatalf("WriteFile(git wrapper) error = %v", err)
+	}
+
+	store := &memoryThreadStore{
+		tasks: map[string]app.Task{
+			"user-1:task-1": {
+				TaskID:         "task-1",
+				DiscordUserID:  "user-1",
+				TaskName:       "Task 1",
+				Status:         app.TaskStatusOpen,
+				BranchName:     app.DefaultTaskBranchName("Task 1", "task-1"),
+				WorktreeStatus: app.TaskWorktreeStatusPending,
+				CreatedAt:      time.Date(2026, time.April, 7, 0, 0, 0, 0, time.UTC),
+			},
+			"user-1:task-2": {
+				TaskID:         "task-2",
+				DiscordUserID:  "user-1",
+				TaskName:       "Task 2",
+				Status:         app.TaskStatusOpen,
+				BranchName:     app.DefaultTaskBranchName("Task 2", "task-2"),
+				WorktreeStatus: app.TaskWorktreeStatusPending,
+				CreatedAt:      time.Date(2026, time.April, 7, 0, 1, 0, 0, time.UTC),
+			},
+		},
+	}
+
+	manager, err := app.NewTaskWorkspaceManager(context.Background(), app.TaskWorkspaceManagerDependencies{
+		Store:            store,
+		SourceRepository: sourceRepo,
+		DataDir:          dataDir,
+		GitExecutable:    wrapperPath,
+		Clock: func() time.Time {
+			return time.Date(2026, time.April, 7, 1, 0, 0, 0, time.UTC)
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewTaskWorkspaceManager() error = %v", err)
+	}
+
+	type ensureResult struct {
+		task app.Task
+		err  error
+	}
+
+	start := make(chan struct{})
+	results := make(chan ensureResult, 2)
+	var wg sync.WaitGroup
+
+	for _, taskID := range []string{"task-1", "task-2"} {
+		taskID := taskID
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			task, ok, err := store.GetTask(context.Background(), "user-1", taskID)
+			if err != nil {
+				results <- ensureResult{err: err}
+				return
+			}
+			if !ok {
+				results <- ensureResult{err: context.Canceled}
+				return
+			}
+
+			<-start
+			readyTask, ensureErr := manager.EnsureReady(context.Background(), task)
+			results <- ensureResult{task: readyTask, err: ensureErr}
+		}()
+	}
+
+	close(start)
+	wg.Wait()
+	close(results)
+
+	for result := range results {
+		if result.err != nil {
+			t.Fatalf("EnsureReady() error = %v", result.err)
+		}
+		if result.task.WorktreeStatus != app.TaskWorktreeStatusReady {
+			t.Fatalf("WorktreeStatus = %q, want %q", result.task.WorktreeStatus, app.TaskWorktreeStatusReady)
+		}
+	}
+
+	maxActiveBytes, err := os.ReadFile(filepath.Join(traceDir, "max"))
+	if err != nil {
+		t.Fatalf("ReadFile(max) error = %v", err)
+	}
+
+	maxActive, err := strconv.Atoi(strings.TrimSpace(string(maxActiveBytes)))
+	if err != nil {
+		t.Fatalf("Atoi(max) error = %v", err)
+	}
+
+	if maxActive != 1 {
+		t.Fatalf("max concurrent managed repository mutations = %d, want %d", maxActive, 1)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Serialize shared managed bare repository mutation in `EnsureReady` and `PruneClosed`.
- Add deterministic concurrency coverage with an instrumented Git wrapper test.
- Document the repository-scoped locking contract in the architecture and task-mode design docs.

## Background

`task` mode already isolates execution per task, but first-use preparation still mutates one managed bare parent repository for each configured source checkout. Concurrent task starts could overlap on that shared repository and produce avoidable Git contention during preparation.

## Related issue(s)

- Closes #79

## Implementation details

- Add a package-level mutex registry keyed by managed repository path in `internal/app/task_workspace.go`.
- Acquire the repository-scoped lock before shared managed-repository preparation and worktree mutation, while preserving the existing fast path for already-ready worktrees.
- Add `TestGitTaskWorkspaceManagerEnsureReadySerializesManagedRepositoryMutation` to prove the shared bare-parent mutation path stays serialized.
- Update `ARCHITECTURE.md`, `docs/design-docs/task-mode-worktrees.md`, and `docs/design-docs/implementation-spec.md` to describe the new serialization contract.

## Test coverage

- `go test ./internal/app -run 'TestGitTaskWorkspaceManagerEnsureReadySerializesManagedRepositoryMutation' -count=1`
- `go test ./internal/app -run 'TestGitTaskWorkspaceManager' -count=1`
- `make test`
- `make lint`

## Breaking changes

- None.

## Notes

- This change keeps already-ready task worktrees on the existing task-level concurrency path and only serializes shared managed-repository mutation.

Created by Codex