### PR TITLE
[codex] Add task reset context action for task mode

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -277,6 +277,8 @@ Behavior:
 - messages route to the thread bound to the active task
 - the first normal message for a task may lazily create the managed bare parent and the task worktree before Codex runs
 - changing the active task changes the target thread
+- `/<instance-command> action:task-reset-context` keeps the active task and worktree unchanged but removes only the saved Codex thread continuity for that task
+- `action:task-reset-context` is rejected while the active task still has in-flight or queued work
 - each task maps to a distinct Codex conversation thread, so switching tasks also switches execution context and working directory once the task worktree exists
 
 Minimum v1 UX requirements:
@@ -284,7 +286,8 @@ Minimum v1 UX requirements:
 - create a task
 - select the active task
 - inspect the active task
-- clear or close the active task
+- reset the active task's Codex conversation continuity without recreating its workspace
+- close the active task
 
 Properties:
 

--- a/cmd/39claw/main.go
+++ b/cmd/39claw/main.go
@@ -213,6 +213,7 @@ func run(ctx context.Context, lookupEnv func(string) (string, bool)) error {
 	taskService, err := app.NewTaskCommandService(app.TaskCommandServiceDependencies{
 		CommandName:      cfg.DiscordCommandName,
 		Store:            store,
+		Coordinator:      coordinator,
 		WorkspaceManager: workspaceManager,
 	})
 	if err != nil {

--- a/docs/design-docs/implementation-spec.md
+++ b/docs/design-docs/implementation-spec.md
@@ -54,13 +54,13 @@ The following internal contracts should be treated as stable v1 design targets e
 - `ThreadPolicy`
   - resolves a logical thread key from the configured mode and the current message or task context
 - `ThreadStore`
-  - loads and upserts thread bindings and manages task records plus active task state
+  - loads, upserts, and deletes thread bindings and manages task records plus active task state
 - `CodexGateway`
   - runs a turn against an existing Codex thread when a thread ID is present
   - creates the first remote thread implicitly when the first turn runs without a saved thread ID
   - returns a normalized final response plus the thread ID that should be persisted
 - `TaskCommandService`
-  - implements the `action:task-current`, `action:task-list`, `action:task-new`, `action:task-switch`, and `action:task-close` workflow behind the configured root command
+  - implements the `action:task-current`, `action:task-list`, `action:task-new`, `action:task-switch`, `action:task-close`, and `action:task-reset-context` workflow behind the configured root command
 - `DailyCommandService`
   - implements the `action:clear` workflow behind the configured root command when the bot instance runs in `daily` mode
 
@@ -102,6 +102,7 @@ Task status is `open` or `closed`.
 Task worktree status is `pending`, `ready`, `failed`, or `pruned`.
 Closing a task marks it `closed` and removes its `active_tasks` mapping when that task is currently active.
 `action:task-list` should show open tasks and clearly mark the active task for the requesting user.
+Deleting a task-mode thread binding must not change the task record, active-task mapping, branch name, or worktree path. That operation is how `action:task-reset-context` clears only Codex conversation continuity.
 
 The logical thread key defaults are:
 
@@ -123,7 +124,7 @@ That root command should always expose `action:help`.
 Task-control command responses are ephemeral by default.
 When a bot instance runs in `daily` mode, task actions must return a clear not-available response instead of pretending the command worked.
 When a bot instance runs in `daily` mode, the root command should also expose `action:clear`.
-When a bot instance runs in `task` mode, the root command should expose `action:task-current`, `action:task-list`, `action:task-new`, `action:task-switch`, and `action:task-close`.
+When a bot instance runs in `task` mode, the root command should expose `action:task-current`, `action:task-list`, `action:task-new`, `action:task-switch`, `action:task-close`, and `action:task-reset-context`.
 
 When a bot instance runs in `task` mode, normal messages without an active task must not be routed to Codex.
 They should return actionable guidance that points the user to `action:task-new`, `action:task-list`, or `action:task-switch` on the configured root command.
@@ -136,6 +137,7 @@ When a bot instance runs in `task` mode, `CLAW_CODEX_WORKDIR` must be a Git repo
 Before detecting that base ref, 39claw should synchronize the managed bare parent against the source checkout's `origin` configuration and try `git fetch origin --prune`; a fetch failure should not block task execution by itself when cached remote refs are already available.
 Those managed-parent mutation steps should be serialized per managed repository path within the running process so concurrent task starts do not overlap on one shared bare parent.
 Once the task worktree is ready, Codex runs with the task-specific `worktree_path` as the effective working directory for that turn.
+`action:task-reset-context` deletes the saved thread binding for the active task only when that task has no in-flight or queued work, so the next normal message starts a fresh Codex thread in the same worktree.
 Closed tasks keep their task branches in the managed bare parent, but only the fifteen most recently closed ready tasks keep their worktrees; older closed ready worktrees are force-pruned.
 
 Unsupported guild-channel non-mention chatter is ignored.
@@ -236,6 +238,7 @@ Most of these outcomes should be proven through automated contract coverage plus
 - The first normal message for a new task creates or refreshes a managed bare parent under `${CLAW_DATADIR}/repos`, then creates a task worktree lazily under `${CLAW_DATADIR}/worktrees/<task_id>`, and then runs Codex inside that worktree.
 - `/<instance-command> action:task-switch task_name:<name>` changes the routing target for subsequent normal messages, with `task_id` reserved for ambiguity fallback.
 - `/<instance-command> action:task-close task_name:<name>` closes the task and clears active state when the closed task was active, with `task_id` reserved for ambiguity fallback.
+- `/<instance-command> action:task-reset-context` keeps the active task and worktree but clears only the saved Codex thread continuity for that task.
 - Closed-task worktree retention keeps only the fifteen most recently closed ready worktrees and never deletes the task branches held by the managed bare parent.
 - Existing `daily` and `task` bindings survive process restart through SQLite-backed state.
 - Guild non-mention chatter is ignored, unsupported non-image-only qualifying posts stay silent, supported slash commands respond correctly, and long replies are chunked cleanly.

--- a/docs/design-docs/task-mode-worktrees.md
+++ b/docs/design-docs/task-mode-worktrees.md
@@ -116,6 +116,21 @@ It does not:
 
 The next normal message determines whether the destination task needs lazy worktree creation before Codex runs.
 
+## Task Context Reset
+
+`/<instance-command> action:task-reset-context` keeps the active task record and any existing task worktree exactly as they are, but removes the saved Codex thread binding for that task.
+
+That command does not:
+
+- recreate the worktree
+- delete the worktree
+- change the task branch
+- change which task is active
+
+It only changes Codex conversation continuity. The next normal message for that active task starts a fresh Codex thread in the same worktree.
+
+The command is rejected while that task has in-flight or queued work so no reply arrives after the user believes the context was reset.
+
 ## Task Closing and Worktree Retention
 
 Closing a task changes the task status to `closed` and clears active-task state if the closed task was active.

--- a/docs/design-docs/thread-modes.md
+++ b/docs/design-docs/thread-modes.md
@@ -90,6 +90,8 @@ thread_key = user + task_id
 - the first normal message for a task creates or refreshes the managed bare parent under `${CLAW_DATADIR}/repos` and then creates the task worktree lazily when needed
 - messages are sent to the Codex thread associated with the active task and use that task's worktree once it exists
 - changing tasks changes the target logical thread
+- `/<instance-command> action:task-reset-context` keeps the current task active and the task worktree unchanged while dropping only the saved Codex thread binding for that task
+- `action:task-reset-context` is rejected while that task has in-flight or queued work
 - closed-task worktrees are retained only for the fifteen most recently closed ready tasks
 
 ### UX Requirements
@@ -101,7 +103,8 @@ At a minimum, v1 likely needs:
 - create a task
 - select the current task
 - inspect the current task
-- clear or close the current task context
+- reset only the current task's Codex conversation continuity
+- close the current task
 
 ### UX Properties
 
@@ -115,6 +118,7 @@ Benefits:
 - strong control over context boundaries
 - better fit for issue-based or project-based workflows
 - task switching changes both conversation context and filesystem workspace
+- users can intentionally restart the Codex conversation for one task without rebuilding its workspace
 
 Costs:
 

--- a/docs/exec-plans/active/16-task-reset-context.md
+++ b/docs/exec-plans/active/16-task-reset-context.md
@@ -13,11 +13,11 @@ This change matters because `task` mode deliberately couples long-lived work to 
 ## Progress
 
 - [x] (2026-04-11 02:32Z) Reviewed issue `#80`, the current task-mode routing and command surface, the existing queue behavior, and the prior `daily` clear-generation ExecPlan; wrote this initial active ExecPlan.
-- [ ] Update architecture, design, and product documents so the repository explicitly distinguishes task identity continuity, task workspace continuity, and Codex thread continuity.
-- [ ] Add a persistence primitive that can remove a saved thread binding for one logical task key without touching task metadata or worktree state.
-- [ ] Implement `action:task-reset-context` in the app layer and root-command routing, including explicit idle-success and busy-rejection responses.
-- [ ] Add store, app, and runtime tests that prove the reset path, no-op fresh-state behavior, busy rejection, and next-message fresh-thread behavior.
-- [ ] Run repository validation with `make test` and `make lint`, or the repository-equivalent direct commands if `make` is unavailable in the execution environment, and record the result in this plan.
+- [x] (2026-04-11 03:18Z) Updated architecture, design, and product documents so the repository now distinguishes task identity continuity, task workspace continuity, and Codex thread continuity, and documents `action:task-reset-context` explicitly.
+- [x] (2026-04-11 03:20Z) Added a thread-binding deletion primitive to the app and SQLite store layers without changing task or worktree persistence schemas.
+- [x] (2026-04-11 03:24Z) Implemented `action:task-reset-context` in the task command service, root command registration, and Discord routing, including explicit success, no-op, and busy-rejection responses.
+- [x] (2026-04-11 03:28Z) Added store, app, and runtime tests that prove the reset path, no-op fresh-state behavior, busy rejection, and next-message fresh-thread behavior.
+- [x] (2026-04-11 03:31Z) Ran `make test` and `make lint`; both passed after formatting the touched Go files with `gofmt`.
 
 ## Surprises & Discoveries
 
@@ -35,6 +35,9 @@ This change matters because `task` mode deliberately couples long-lived work to 
 
 - Observation: The current task execution path already creates a fresh remote thread automatically whenever no binding exists for the task logical key. That means deleting the saved binding is enough to trigger a clean restart without changing the task record or worktree path.
   Evidence: `internal/app/message_service_impl.go`
+
+- Observation: No schema migration was needed for this feature because the existing `thread_bindings` table already had the right key shape; only the CRUD surface needed a delete operation.
+  Evidence: `internal/store/sqlite/store.go`, `internal/store/sqlite/store_test.go`
 
 ## Decision Log
 
@@ -56,7 +59,9 @@ This change matters because `task` mode deliberately couples long-lived work to 
 
 ## Outcomes & Retrospective
 
-This plan is not implemented yet. At plan-creation time, the repository already has the needed task identity, worktree, queue, and thread-binding foundations, but it does not yet have a task-specific context-reset action or a binding-deletion primitive. The main goal of this plan is to land that feature without widening it into destructive task closure, workspace recreation, or branch reset behavior.
+Implementation completed on 2026-04-11. The repository now exposes `action:task-reset-context` in `task` mode, deletes only the saved task thread binding when reset succeeds, rejects reset while the active task still has running or queued work, and keeps the active task selection plus task worktree unchanged.
+
+The main tradeoff is that task reset is intentionally narrow: it does not rebuild or repair the task worktree, and it does not target arbitrary non-active tasks. That keeps the feature easy to explain and reuses the existing “missing binding means start a fresh thread” path instead of adding a second thread-rotation mechanism.
 
 ## Context and Orientation
 
@@ -277,10 +282,10 @@ Run all commands from `/home/filepang/.local/share/39claw/39claw/worktrees/01KNX
         go test ./...
         ./scripts/lint -c .golangci.yml
 
-    Expected result:
+    Observed result:
 
-        all Go tests pass
-        lint passes with 0 issues
+        all Go tests passed
+        lint passed with 0 issues
 
 2. Update the task-reset contract documents.
 
@@ -313,9 +318,9 @@ Run all commands from `/home/filepang/.local/share/39claw/39claw/worktrees/01KNX
         go test ./internal/app -run 'Test(TaskCommandServiceResetContext|MessageServiceHandleMessageTaskStartsFreshThreadAfterReset)'
         go test ./internal/runtime/discord -run 'Test(RuntimeTaskResetContext|RegisteredCommandsTaskModeIncludesResetContext|RegisteredCommandsDailyModeOmitsTaskResetContext)'
 
-    Expected result:
+    Observed result:
 
-        each focused package passes with the new reset-context coverage
+        the focused packages passed while iterating, including the new reset-context coverage
 
 5. Run the full repository checks after implementation.
 
@@ -326,6 +331,11 @@ Run all commands from `/home/filepang/.local/share/39claw/39claw/worktrees/01KNX
 
         go test ./...
         ./scripts/lint -c .golangci.yml
+
+    Observed result:
+
+        all Go tests passed
+        lint passed with 0 issues
 
 6. Capture a short proof transcript in this plan once implementation lands.
 
@@ -442,3 +452,4 @@ Keep the existing dependencies:
 - `TaskWorkspaceManager` remains unchanged by this feature because reset must not mutate worktree state
 
 Revision Note: 2026-04-11 02:32Z / Codex - Created this active ExecPlan for issue `#80` after reviewing the current task-mode routing, queue, command, and persistence architecture and choosing the smallest coherent design: delete the saved task thread binding while preserving active-task and worktree state.
+Revision Note: 2026-04-11 03:31Z / Codex - Updated this ExecPlan after implementation landed so the living sections, concrete steps, and retrospective now reflect the shipped `task-reset-context` behavior and its passing validation commands.

--- a/docs/product-specs/discord-command-behavior.md
+++ b/docs/product-specs/discord-command-behavior.md
@@ -129,6 +129,8 @@ The root command should support user-facing actions for:
   - switch the active task to the uniquely named open task, with `task_id` available only when the name is ambiguous
 - `/<instance-command> action:task-close task_name:<name>`
   - close the uniquely named open task, with `task_id` available only when the name is ambiguous
+- `/<instance-command> action:task-reset-context`
+  - keep the active task and worktree unchanged while discarding only the saved Codex conversation continuity for that task
 
 Every instance should also support:
 
@@ -167,6 +169,13 @@ For `action:task-new`, the success response should set the expectation that the 
 
 For `action:task-close`, the success response does not need to describe background worktree pruning in detail, but the product behavior should remain consistent with the task retention policy.
 
+For `action:task-reset-context`, the success response should say clearly that:
+
+- the active task did not change
+- the workspace did not change
+- only Codex conversation continuity was restarted
+- the next normal message will start a fresh thread for that same task
+
 When `action:help` succeeds, the response should give a concise list of supported actions and a short explanation of when to use them.
 
 When `action:clear` succeeds in `daily` mode, the response should tell the user that the next mention will use a fresh shared same-day thread.
@@ -181,6 +190,8 @@ When a task action fails, the response should:
 - suggest the next action when possible
 
 If a task action is invoked against a bot instance running in `daily` mode, the bot should explain that task actions are not available for that instance rather than pretending the command was accepted.
+
+If `action:task-reset-context` is requested while the active task still has running or queued work, the bot should reject the request and tell the user to retry after pending replies finish.
 
 ## Ambiguous Input Handling
 

--- a/docs/product-specs/task-mode-user-flow.md
+++ b/docs/product-specs/task-mode-user-flow.md
@@ -108,6 +108,23 @@ Expected user perception:
 - “The bot should now respond in terms of the new task.”
 - “The switch changes both the Codex context and the task workspace used for later work.”
 
+### Scenario: User resets Codex context for the active task but keeps the workspace
+
+Expected flow:
+
+1. The user has an active task whose worktree is already the correct workspace.
+2. The user invokes `/<instance-command> action:task-reset-context`.
+3. 39claw keeps the active task selection unchanged.
+4. 39claw keeps the existing task branch and worktree unchanged.
+5. 39claw removes only the saved Codex thread continuity for that task.
+6. The next normal message for that task starts a fresh Codex thread in the same worktree.
+
+Expected user perception:
+
+- “I kept the same task.”
+- “I kept the same workspace.”
+- “Only the Codex conversation restarted.”
+
 ### Scenario: The first normal message for a task needs workspace preparation
 
 Expected flow:
@@ -153,6 +170,8 @@ For `task` mode to feel usable, v1 should support at least:
   - switch the active task to the uniquely named open task, with `task_id` used only when the name is ambiguous
 - `/<instance-command> action:task-close task_name:<name>`
   - close the uniquely named open task, with `task_id` used only when the name is ambiguous
+- `/<instance-command> action:task-reset-context`
+  - keep the current active task and worktree but discard only the saved Codex conversation continuity for that task
 
 The root-command action surface should stay explicit and stable enough that users can learn it as the standard task-control surface for `task` mode.
 
@@ -170,6 +189,7 @@ Task-related blocking behavior should be easy to understand without knowledge of
 
 Users should be able to assume that task continuity is stable over multiple sessions unless the bot explicitly reports that something went wrong.
 The active task should remain active until the user explicitly closes it or switches to another task.
+When the user explicitly resets task context, only Codex thread continuity should restart; task identity and workspace continuity should remain stable.
 
 ### Task identity clarity
 
@@ -204,6 +224,11 @@ If a task exists but its thread binding cannot be resumed, the bot should explai
 
 If the task workspace cannot be prepared, the bot should explain that the task workspace is not ready and tell the user to retry.
 The bot should not pretend that Codex processed the message normally.
+
+### Context reset while work is still pending
+
+If the active task still has in-flight or queued work, `action:task-reset-context` should be rejected.
+The bot should explain that the user needs to wait for pending replies to finish before retrying the reset.
 
 ### Incorrect task risk
 

--- a/internal/app/command_surface.go
+++ b/internal/app/command_surface.go
@@ -26,6 +26,10 @@ func (s commandSurface) taskClose(taskID string) string {
 	return fmt.Sprintf("`/%s action:task-close task_id:%s`", s.commandName, taskID)
 }
 
+func (s commandSurface) taskResetContext() string {
+	return fmt.Sprintf("`/%s action:task-reset-context`", s.commandName)
+}
+
 func (s commandSurface) taskIDPlaceholder(action string) string {
 	return fmt.Sprintf("`/%s action:%s task_id:<id>`", s.commandName, action)
 }

--- a/internal/app/message_service.go
+++ b/internal/app/message_service.go
@@ -25,6 +25,7 @@ type DailyMemoryRefresher interface {
 type ThreadStore interface {
 	GetThreadBinding(ctx context.Context, mode string, logicalThreadKey string) (ThreadBinding, bool, error)
 	UpsertThreadBinding(ctx context.Context, binding ThreadBinding) error
+	DeleteThreadBinding(ctx context.Context, mode string, logicalThreadKey string) error
 	GetActiveDailySession(ctx context.Context, localDate string) (DailySession, bool, error)
 	GetLatestDailySessionBefore(ctx context.Context, localDate string) (DailySession, bool, error)
 	CreateDailySession(ctx context.Context, session DailySession) (DailySession, error)

--- a/internal/app/message_service_impl.go
+++ b/internal/app/message_service_impl.go
@@ -554,6 +554,10 @@ func taskIDFromLogicalKey(userID string, logicalKey string) (string, error) {
 	return strings.TrimPrefix(logicalKey, prefix), nil
 }
 
+func buildTaskLogicalKey(userID string, taskID string) string {
+	return userID + ":" + taskID
+}
+
 func isLifecycleContextError(err error) bool {
 	return errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
 }

--- a/internal/app/message_service_test.go
+++ b/internal/app/message_service_test.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"log/slog"
 	"sort"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -518,6 +519,96 @@ func TestMessageServiceHandleMessageTaskReusesTaskBindingAcrossDays(t *testing.T
 
 	if binding.TaskID != "task-1" {
 		t.Fatalf("TaskID = %q, want %q", binding.TaskID, "task-1")
+	}
+}
+
+func TestMessageServiceHandleMessageTaskStartsFreshThreadAfterResetContext(t *testing.T) {
+	t.Parallel()
+
+	store := &memoryThreadStore{
+		tasks: map[string]app.Task{
+			"user-1:task-1": {
+				TaskID:         "task-1",
+				DiscordUserID:  "user-1",
+				TaskName:       "Release work",
+				Status:         app.TaskStatusOpen,
+				WorktreeStatus: app.TaskWorktreeStatusReady,
+				WorktreePath:   "/tmp/worktrees/task-1",
+				CreatedAt:      time.Date(2026, time.April, 5, 0, 0, 0, 0, time.UTC),
+			},
+		},
+		activeTasks: map[string]app.ActiveTask{
+			"user-1": {
+				DiscordUserID: "user-1",
+				TaskID:        "task-1",
+			},
+		},
+		bindings: map[string]app.ThreadBinding{
+			"task:user-1:task-1": {
+				Mode:             "task",
+				LogicalThreadKey: "user-1:task-1",
+				CodexThreadID:    "thread-old",
+				TaskID:           "task-1",
+			},
+		},
+	}
+	gateway := &fakeCodexGateway{
+		results: []app.RunTurnResult{
+			{ThreadID: "thread-new", ResponseText: "Fresh response"},
+		},
+	}
+	coordinator := thread.NewQueueCoordinator()
+	commandService := newTaskCommandServiceWithCoordinator(t, store, coordinator)
+
+	resetResponse, err := commandService.ResetContext(context.Background(), "user-1")
+	if err != nil {
+		t.Fatalf("ResetContext() error = %v", err)
+	}
+
+	if !strings.Contains(resetResponse.Text, "workspace is unchanged") {
+		t.Fatalf("reset response text = %q, want workspace guidance", resetResponse.Text)
+	}
+
+	service := newTaskMessageService(t, store, gateway, coordinator)
+	response, err := service.HandleMessage(context.Background(), app.MessageRequest{
+		UserID:     "user-1",
+		MessageID:  "message-1",
+		Content:    "continue release",
+		Mentioned:  true,
+		ReceivedAt: time.Date(2026, time.April, 5, 0, 2, 0, 0, time.UTC),
+	}, nil)
+	if err != nil {
+		t.Fatalf("HandleMessage() error = %v", err)
+	}
+
+	if response.Text != "Fresh response" {
+		t.Fatalf("response text = %q, want %q", response.Text, "Fresh response")
+	}
+
+	calls := gateway.Calls()
+	if len(calls) != 1 {
+		t.Fatalf("RunTurn() call count = %d, want %d", len(calls), 1)
+	}
+
+	if calls[0].threadID != "" {
+		t.Fatalf("threadID = %q, want empty", calls[0].threadID)
+	}
+
+	if calls[0].workingDirectory != "/tmp/worktrees/task-1" {
+		t.Fatalf("working directory = %q, want %q", calls[0].workingDirectory, "/tmp/worktrees/task-1")
+	}
+
+	binding, ok, err := store.GetThreadBinding(context.Background(), "task", "user-1:task-1")
+	if err != nil {
+		t.Fatalf("GetThreadBinding() error = %v", err)
+	}
+
+	if !ok {
+		t.Fatal("GetThreadBinding() ok = false, want true")
+	}
+
+	if binding.CodexThreadID != "thread-new" {
+		t.Fatalf("CodexThreadID = %q, want %q", binding.CodexThreadID, "thread-new")
 	}
 }
 
@@ -1676,6 +1767,17 @@ func (s *memoryThreadStore) UpsertThreadBinding(_ context.Context, binding app.T
 	}
 
 	s.bindings[binding.Mode+":"+binding.LogicalThreadKey] = binding
+	return nil
+}
+
+func (s *memoryThreadStore) DeleteThreadBinding(_ context.Context, mode string, logicalThreadKey string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.bindings != nil {
+		delete(s.bindings, mode+":"+logicalThreadKey)
+	}
+
 	return nil
 }
 

--- a/internal/app/task_service.go
+++ b/internal/app/task_service.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"strings"
 
+	"github.com/HatsuneMiku3939/39claw/internal/config"
 	"github.com/oklog/ulid/v2"
 )
 
@@ -17,20 +18,23 @@ type TaskCommandService interface {
 	CreateTask(ctx context.Context, userID string, taskName string) (MessageResponse, error)
 	SwitchTask(ctx context.Context, userID string, taskID string, taskName string) (MessageResponse, error)
 	CloseTask(ctx context.Context, userID string, taskID string, taskName string) (MessageResponse, error)
+	ResetContext(ctx context.Context, userID string) (MessageResponse, error)
 }
 
 type TaskCommandServiceDependencies struct {
 	CommandName      string
 	Store            ThreadStore
+	Coordinator      QueueCoordinator
 	WorkspaceManager TaskWorkspaceManager
 	NewTaskID        func() string
 }
 
 type DefaultTaskCommandService struct {
-	commands  commandSurface
-	store     ThreadStore
-	worktrees TaskWorkspaceManager
-	newTaskID func() string
+	commands    commandSurface
+	store       ThreadStore
+	coordinator QueueCoordinator
+	worktrees   TaskWorkspaceManager
+	newTaskID   func() string
 }
 
 func NewTaskCommandService(deps TaskCommandServiceDependencies) (*DefaultTaskCommandService, error) {
@@ -43,6 +47,10 @@ func NewTaskCommandService(deps TaskCommandServiceDependencies) (*DefaultTaskCom
 		return nil, errors.New("command name must not be empty")
 	}
 
+	if deps.Coordinator == nil {
+		return nil, errors.New("queue coordinator must not be nil")
+	}
+
 	newTaskID := deps.NewTaskID
 	if newTaskID == nil {
 		newTaskID = func() string {
@@ -51,10 +59,11 @@ func NewTaskCommandService(deps TaskCommandServiceDependencies) (*DefaultTaskCom
 	}
 
 	return &DefaultTaskCommandService{
-		commands:  newCommandSurface(commandName),
-		store:     deps.Store,
-		worktrees: deps.WorkspaceManager,
-		newTaskID: newTaskID,
+		commands:    newCommandSurface(commandName),
+		store:       deps.Store,
+		coordinator: deps.Coordinator,
+		worktrees:   deps.WorkspaceManager,
+		newTaskID:   newTaskID,
 	}, nil
 }
 
@@ -291,6 +300,69 @@ func (s *DefaultTaskCommandService) CloseTask(ctx context.Context, userID string
 
 	return taskCommandResponse(
 		fmt.Sprintf("Closed task %s.%s", renderTask(task), nextActiveTaskLine),
+	), nil
+}
+
+func (s *DefaultTaskCommandService) ResetContext(ctx context.Context, userID string) (MessageResponse, error) {
+	activeTask, ok, err := s.store.GetActiveTask(ctx, userID)
+	if err != nil {
+		return MessageResponse{}, fmt.Errorf("load active task: %w", err)
+	}
+
+	if !ok {
+		return taskCommandResponse(s.noActiveTaskMessage()), nil
+	}
+
+	task, ok, err := s.store.GetTask(ctx, userID, activeTask.TaskID)
+	if err != nil {
+		return MessageResponse{}, fmt.Errorf("load active task details: %w", err)
+	}
+
+	if !ok {
+		return taskCommandResponse(
+			fmt.Sprintf(
+				"Active task `%s` could not be loaded. Use %s or %s to recover.",
+				activeTask.TaskID,
+				s.commands.taskList(),
+				s.commands.taskSwitchPlaceholder(),
+			),
+		), nil
+	}
+
+	logicalKey := buildTaskLogicalKey(userID, task.TaskID)
+	snapshot := s.coordinator.Snapshot(buildExecutionKey(config.ModeTask, logicalKey))
+	if snapshot.InFlight || snapshot.Queued > 0 {
+		return taskCommandResponse(
+			fmt.Sprintf(
+				"This task still has running or queued work. Wait for pending replies to finish, then retry %s.",
+				s.commands.taskResetContext(),
+			),
+		), nil
+	}
+
+	_, hadBinding, err := s.store.GetThreadBinding(ctx, string(config.ModeTask), logicalKey)
+	if err != nil {
+		return MessageResponse{}, fmt.Errorf("load task thread binding: %w", err)
+	}
+
+	if err := s.store.DeleteThreadBinding(ctx, string(config.ModeTask), logicalKey); err != nil {
+		return MessageResponse{}, fmt.Errorf("delete task thread binding: %w", err)
+	}
+
+	if !hadBinding {
+		return taskCommandResponse(
+			fmt.Sprintf(
+				"Active task %s does not have saved Codex conversation continuity yet. The task is still active, the workspace is unchanged, and your next normal message will already start fresh.",
+				renderTask(task),
+			),
+		), nil
+	}
+
+	return taskCommandResponse(
+		fmt.Sprintf(
+			"Reset Codex conversation continuity for active task %s. The task is still active, the workspace is unchanged, and your next normal message will start a fresh Codex thread for this task.",
+			renderTask(task),
+		),
 	), nil
 }
 

--- a/internal/app/task_service_test.go
+++ b/internal/app/task_service_test.go
@@ -513,9 +513,151 @@ func TestTaskCommandServiceCloseTaskByNameRequiresIDWhenAmbiguous(t *testing.T) 
 	}
 }
 
+func TestTaskCommandServiceResetContextClearsBindingWhenIdle(t *testing.T) {
+	t.Parallel()
+
+	store := &memoryThreadStore{
+		tasks: map[string]app.Task{
+			"user-1:task-1": {
+				TaskID:        "task-1",
+				DiscordUserID: "user-1",
+				TaskName:      "Release work",
+				Status:        app.TaskStatusOpen,
+			},
+		},
+		activeTasks: map[string]app.ActiveTask{
+			"user-1": {
+				DiscordUserID: "user-1",
+				TaskID:        "task-1",
+			},
+		},
+		bindings: map[string]app.ThreadBinding{
+			"task:user-1:task-1": {
+				Mode:             "task",
+				LogicalThreadKey: "user-1:task-1",
+				CodexThreadID:    "thread-old",
+				TaskID:           "task-1",
+			},
+		},
+	}
+	service := newTaskCommandServiceWithCoordinator(t, store, &stubQueueCoordinator{})
+
+	response, err := service.ResetContext(context.Background(), "user-1")
+	if err != nil {
+		t.Fatalf("ResetContext() error = %v", err)
+	}
+
+	want := "Reset Codex conversation continuity for active task `Release work` (`task-1`). The task is still active, the workspace is unchanged, and your next normal message will start a fresh Codex thread for this task."
+	if response.Text != want {
+		t.Fatalf("Text = %q, want %q", response.Text, want)
+	}
+
+	if _, ok, err := store.GetThreadBinding(context.Background(), "task", "user-1:task-1"); err != nil {
+		t.Fatalf("GetThreadBinding() error = %v", err)
+	} else if ok {
+		t.Fatal("GetThreadBinding() ok = true, want false")
+	}
+}
+
+func TestTaskCommandServiceResetContextWithoutBindingReturnsNoOp(t *testing.T) {
+	t.Parallel()
+
+	store := &memoryThreadStore{
+		tasks: map[string]app.Task{
+			"user-1:task-1": {
+				TaskID:        "task-1",
+				DiscordUserID: "user-1",
+				TaskName:      "Release work",
+				Status:        app.TaskStatusOpen,
+			},
+		},
+		activeTasks: map[string]app.ActiveTask{
+			"user-1": {
+				DiscordUserID: "user-1",
+				TaskID:        "task-1",
+			},
+		},
+	}
+	service := newTaskCommandServiceWithCoordinator(t, store, &stubQueueCoordinator{})
+
+	response, err := service.ResetContext(context.Background(), "user-1")
+	if err != nil {
+		t.Fatalf("ResetContext() error = %v", err)
+	}
+
+	want := "Active task `Release work` (`task-1`) does not have saved Codex conversation continuity yet. The task is still active, the workspace is unchanged, and your next normal message will already start fresh."
+	if response.Text != want {
+		t.Fatalf("Text = %q, want %q", response.Text, want)
+	}
+}
+
+func TestTaskCommandServiceResetContextRejectsBusyTask(t *testing.T) {
+	t.Parallel()
+
+	store := &memoryThreadStore{
+		tasks: map[string]app.Task{
+			"user-1:task-1": {
+				TaskID:        "task-1",
+				DiscordUserID: "user-1",
+				TaskName:      "Release work",
+				Status:        app.TaskStatusOpen,
+			},
+		},
+		activeTasks: map[string]app.ActiveTask{
+			"user-1": {
+				DiscordUserID: "user-1",
+				TaskID:        "task-1",
+			},
+		},
+		bindings: map[string]app.ThreadBinding{
+			"task:user-1:task-1": {
+				Mode:             "task",
+				LogicalThreadKey: "user-1:task-1",
+				CodexThreadID:    "thread-old",
+				TaskID:           "task-1",
+			},
+		},
+	}
+	service := newTaskCommandServiceWithCoordinator(t, store, &stubQueueCoordinator{
+		snapshot: app.QueueSnapshot{InFlight: true, Queued: 1},
+	})
+
+	response, err := service.ResetContext(context.Background(), "user-1")
+	if err != nil {
+		t.Fatalf("ResetContext() error = %v", err)
+	}
+
+	want := "This task still has running or queued work. Wait for pending replies to finish, then retry `/release action:task-reset-context`."
+	if response.Text != want {
+		t.Fatalf("Text = %q, want %q", response.Text, want)
+	}
+
+	if _, ok, err := store.GetThreadBinding(context.Background(), "task", "user-1:task-1"); err != nil {
+		t.Fatalf("GetThreadBinding() error = %v", err)
+	} else if !ok {
+		t.Fatal("GetThreadBinding() ok = false, want true")
+	}
+}
+
+func TestTaskCommandServiceResetContextWithoutActiveTaskReturnsGuidance(t *testing.T) {
+	t.Parallel()
+
+	service := newTaskCommandServiceWithCoordinator(t, &memoryThreadStore{}, &stubQueueCoordinator{})
+
+	response, err := service.ResetContext(context.Background(), "user-1")
+	if err != nil {
+		t.Fatalf("ResetContext() error = %v", err)
+	}
+
+	want := "No active task is selected. Use `/release action:task-new task_name:<name>`, `/release action:task-list`, or `/release action:task-switch task_name:<name>` first."
+	if response.Text != want {
+		t.Fatalf("Text = %q, want %q", response.Text, want)
+	}
+}
+
 func newTaskCommandService(t *testing.T, store app.ThreadStore) *app.DefaultTaskCommandService {
 	t.Helper()
-	return newTaskCommandServiceWithWorkspace(t, store, nil, nil)
+	return newTaskCommandServiceWithWorkspaceAndCoordinator(t, store, nil, nil, &stubQueueCoordinator{})
 }
 
 func newTaskCommandServiceWithID(
@@ -524,7 +666,16 @@ func newTaskCommandServiceWithID(
 	newTaskID func() string,
 ) *app.DefaultTaskCommandService {
 	t.Helper()
-	return newTaskCommandServiceWithWorkspace(t, store, newTaskID, nil)
+	return newTaskCommandServiceWithWorkspaceAndCoordinator(t, store, newTaskID, nil, &stubQueueCoordinator{})
+}
+
+func newTaskCommandServiceWithCoordinator(
+	t *testing.T,
+	store app.ThreadStore,
+	coordinator app.QueueCoordinator,
+) *app.DefaultTaskCommandService {
+	t.Helper()
+	return newTaskCommandServiceWithWorkspaceAndCoordinator(t, store, nil, nil, coordinator)
 }
 
 func newTaskCommandServiceWithWorkspace(
@@ -534,10 +685,22 @@ func newTaskCommandServiceWithWorkspace(
 	worktrees app.TaskWorkspaceManager,
 ) *app.DefaultTaskCommandService {
 	t.Helper()
+	return newTaskCommandServiceWithWorkspaceAndCoordinator(t, store, newTaskID, worktrees, &stubQueueCoordinator{})
+}
+
+func newTaskCommandServiceWithWorkspaceAndCoordinator(
+	t *testing.T,
+	store app.ThreadStore,
+	newTaskID func() string,
+	worktrees app.TaskWorkspaceManager,
+	coordinator app.QueueCoordinator,
+) *app.DefaultTaskCommandService {
+	t.Helper()
 
 	service, err := app.NewTaskCommandService(app.TaskCommandServiceDependencies{
 		CommandName:      "release",
 		Store:            store,
+		Coordinator:      coordinator,
 		WorkspaceManager: worktrees,
 		NewTaskID:        newTaskID,
 	})

--- a/internal/dailymemory/service_test.go
+++ b/internal/dailymemory/service_test.go
@@ -229,6 +229,10 @@ func (s *stubThreadStore) UpsertThreadBinding(context.Context, app.ThreadBinding
 	return nil
 }
 
+func (s *stubThreadStore) DeleteThreadBinding(context.Context, string, string) error {
+	return nil
+}
+
 func (s *stubThreadStore) GetActiveDailySession(context.Context, string) (app.DailySession, bool, error) {
 	return app.DailySession{}, false, nil
 }

--- a/internal/runtime/discord/commands.go
+++ b/internal/runtime/discord/commands.go
@@ -37,6 +37,7 @@ func registeredCommands(cfg config.Config) []*discordgo.ApplicationCommand {
 			&discordgo.ApplicationCommandOptionChoice{Name: actionTaskNew, Value: actionTaskNew},
 			&discordgo.ApplicationCommandOptionChoice{Name: actionTaskSwitch, Value: actionTaskSwitch},
 			&discordgo.ApplicationCommandOptionChoice{Name: actionTaskClose, Value: actionTaskClose},
+			&discordgo.ApplicationCommandOptionChoice{Name: actionTaskResetContext, Value: actionTaskResetContext},
 		)
 	}
 
@@ -99,6 +100,7 @@ func helpResponse(commandName string, mode config.Mode) app.MessageResponse {
 			fmt.Sprintf("- `/%s action:%s task_name:<name>` creates and activates a task.", commandName, actionTaskNew),
 			fmt.Sprintf("- `/%s action:%s task_name:<name>` changes the active task and falls back to `task_id` when the name is ambiguous.", commandName, actionTaskSwitch),
 			fmt.Sprintf("- `/%s action:%s task_name:<name>` closes a task and falls back to `task_id` when the name is ambiguous.", commandName, actionTaskClose),
+			fmt.Sprintf("- `/%s action:%s` resets only the saved Codex conversation continuity for the active task.", commandName, actionTaskResetContext),
 		)
 	}
 
@@ -121,7 +123,7 @@ func unsupportedActionText(commandName string, mode config.Mode) string {
 	}
 
 	return fmt.Sprintf(
-		"Unsupported action. Use `/%s action:%s`, `/%s action:%s`, `/%s action:%s`, `/%s action:%s task_name:<name>`, `/%s action:%s task_name:<name>`, or `/%s action:%s task_name:<name>`.",
+		"Unsupported action. Use `/%s action:%s`, `/%s action:%s`, `/%s action:%s`, `/%s action:%s task_name:<name>`, `/%s action:%s task_name:<name>`, `/%s action:%s task_name:<name>`, or `/%s action:%s`.",
 		commandName,
 		actionHelp,
 		commandName,
@@ -134,5 +136,7 @@ func unsupportedActionText(commandName string, mode config.Mode) string {
 		actionTaskSwitch,
 		commandName,
 		actionTaskClose,
+		commandName,
+		actionTaskResetContext,
 	)
 }

--- a/internal/runtime/discord/interaction_mapper.go
+++ b/internal/runtime/discord/interaction_mapper.go
@@ -11,13 +11,14 @@ const (
 	optionTaskName = "task_name"
 	optionTaskID   = "task_id"
 
-	actionHelp        = "help"
-	actionClear       = "clear"
-	actionTaskCurrent = "task-current"
-	actionTaskList    = "task-list"
-	actionTaskNew     = "task-new"
-	actionTaskSwitch  = "task-switch"
-	actionTaskClose   = "task-close"
+	actionHelp             = "help"
+	actionClear            = "clear"
+	actionTaskCurrent      = "task-current"
+	actionTaskList         = "task-list"
+	actionTaskNew          = "task-new"
+	actionTaskSwitch       = "task-switch"
+	actionTaskClose        = "task-close"
+	actionTaskResetContext = "task-reset-context"
 )
 
 type commandRequest struct {

--- a/internal/runtime/discord/interaction_mapper_test.go
+++ b/internal/runtime/discord/interaction_mapper_test.go
@@ -64,6 +64,29 @@ func TestMapInteractionCommand(t *testing.T) {
 			ok: true,
 		},
 		{
+			name: "maps task reset action without task selector fields",
+			event: &discordgo.InteractionCreate{
+				Interaction: &discordgo.Interaction{
+					Type: discordgo.InteractionApplicationCommand,
+					Data: discordgo.ApplicationCommandInteractionData{
+						Name: "release",
+						Options: []*discordgo.ApplicationCommandInteractionDataOption{
+							{Name: optionAction, Type: discordgo.ApplicationCommandOptionString, Value: actionTaskResetContext},
+						},
+					},
+					Member: &discordgo.Member{
+						User: &discordgo.User{ID: "user-3"},
+					},
+				},
+			},
+			want: commandRequest{
+				Name:   "release",
+				Action: actionTaskResetContext,
+				UserID: "user-3",
+			},
+			ok: true,
+		},
+		{
 			name: "keeps request when action is missing",
 			event: &discordgo.InteractionCreate{
 				Interaction: &discordgo.Interaction{

--- a/internal/runtime/discord/runtime.go
+++ b/internal/runtime/discord/runtime.go
@@ -522,7 +522,7 @@ func (r *Runtime) routeCommand(ctx context.Context, request commandRequest) (app
 		}
 
 		return r.dailyCommand.Clear(ctx, request.UserID, time.Now())
-	case actionTaskCurrent, actionTaskList, actionTaskNew, actionTaskSwitch, actionTaskClose:
+	case actionTaskCurrent, actionTaskList, actionTaskNew, actionTaskSwitch, actionTaskClose, actionTaskResetContext:
 		if r.config.Mode != config.ModeTask {
 			return app.MessageResponse{
 				Text:      taskUnavailableDailyMode(r.config.DiscordCommandName),
@@ -541,6 +541,8 @@ func (r *Runtime) routeCommand(ctx context.Context, request commandRequest) (app
 			return r.taskCommand.SwitchTask(ctx, request.UserID, request.TaskID, request.TaskName)
 		case actionTaskClose:
 			return r.taskCommand.CloseTask(ctx, request.UserID, request.TaskID, request.TaskName)
+		case actionTaskResetContext:
+			return r.taskCommand.ResetContext(ctx, request.UserID)
 		}
 
 		return app.MessageResponse{

--- a/internal/runtime/discord/runtime_test.go
+++ b/internal/runtime/discord/runtime_test.go
@@ -93,8 +93,8 @@ func TestRuntimeStartRegistersTaskModeChoices(t *testing.T) {
 	}
 
 	actionOption := command.Options[0]
-	if len(actionOption.Choices) != 6 {
-		t.Fatalf("action choice count = %d, want %d", len(actionOption.Choices), 6)
+	if len(actionOption.Choices) != 7 {
+		t.Fatalf("action choice count = %d, want %d", len(actionOption.Choices), 7)
 	}
 
 	if command.Options[1].Name != optionTaskName {
@@ -1130,6 +1130,10 @@ func TestRuntimeTaskCommandRoutesTaskModeActions(t *testing.T) {
 			Text:      "Closed task `Release work` (`task-1`). No active task is selected now.",
 			Ephemeral: true,
 		},
+		resetResponse: app.MessageResponse{
+			Text:      "Reset Codex conversation continuity for active task `Release work` (`task-1`). The task is still active and the workspace is unchanged.",
+			Ephemeral: true,
+		},
 	}
 	fakeSession := newFakeSession("bot-user")
 	runtime := newTestRuntimeWithServices(t, config.ModeTask, fakeSession, &fakeMessageService{}, taskService)
@@ -1145,6 +1149,7 @@ func TestRuntimeTaskCommandRoutesTaskModeActions(t *testing.T) {
 	fakeSession.dispatchInteraction(commandInteractionEvent("release", "user-1", actionTaskNew, "Release work", ""))
 	fakeSession.dispatchInteraction(commandInteractionEvent("release", "user-1", actionTaskSwitch, "Release work", ""))
 	fakeSession.dispatchInteraction(commandInteractionEvent("release", "user-1", actionTaskClose, "Release work", ""))
+	fakeSession.dispatchInteraction(commandInteractionEvent("release", "user-1", actionTaskResetContext, "", ""))
 
 	if len(taskService.currentCalls) != 1 {
 		t.Fatalf("current call count = %d, want %d", len(taskService.currentCalls), 1)
@@ -1182,11 +1187,15 @@ func TestRuntimeTaskCommandRoutesTaskModeActions(t *testing.T) {
 		t.Fatalf("close task id = %q, want empty", taskService.closeCalls[0].taskID)
 	}
 
-	if len(fakeSession.interactionResponses) != 4 {
-		t.Fatalf("interaction response count = %d, want %d", len(fakeSession.interactionResponses), 4)
+	if len(taskService.resetCalls) != 1 {
+		t.Fatalf("reset call count = %d, want %d", len(taskService.resetCalls), 1)
 	}
 
-	response := fakeSession.interactionResponses[3]
+	if len(fakeSession.interactionResponses) != 5 {
+		t.Fatalf("interaction response count = %d, want %d", len(fakeSession.interactionResponses), 5)
+	}
+
+	response := fakeSession.interactionResponses[4]
 	if response.Data == nil || response.Data.Flags != discordgo.MessageFlagsEphemeral {
 		t.Fatal("task response should be ephemeral")
 	}

--- a/internal/runtime/discord/runtime_test_helpers_test.go
+++ b/internal/runtime/discord/runtime_test_helpers_test.go
@@ -532,6 +532,7 @@ func (s *fakeMessageService) WaitForDrain(ctx context.Context) error {
 
 type fakeTaskCommandService struct {
 	currentCalls []string
+	resetCalls   []string
 	createCalls  []struct {
 		userID   string
 		taskName string
@@ -552,6 +553,7 @@ type fakeTaskCommandService struct {
 	createResponse  app.MessageResponse
 	switchResponse  app.MessageResponse
 	closeResponse   app.MessageResponse
+	resetResponse   app.MessageResponse
 }
 
 func (s *fakeTaskCommandService) ShowCurrentTask(ctx context.Context, userID string) (app.MessageResponse, error) {
@@ -587,6 +589,11 @@ func (s *fakeTaskCommandService) CloseTask(ctx context.Context, userID string, t
 		taskName string
 	}{userID: userID, taskID: taskID, taskName: taskName})
 	return s.closeResponse, nil
+}
+
+func (s *fakeTaskCommandService) ResetContext(ctx context.Context, userID string) (app.MessageResponse, error) {
+	s.resetCalls = append(s.resetCalls, userID)
+	return s.resetResponse, nil
 }
 
 type fakeDailyCommandService struct {
@@ -665,6 +672,17 @@ func (s *memoryThreadStore) UpsertThreadBinding(_ context.Context, binding app.T
 	}
 
 	s.bindings[binding.Mode+":"+binding.LogicalThreadKey] = binding
+	return nil
+}
+
+func (s *memoryThreadStore) DeleteThreadBinding(_ context.Context, mode string, logicalThreadKey string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.bindings != nil {
+		delete(s.bindings, mode+":"+logicalThreadKey)
+	}
+
 	return nil
 }
 
@@ -1107,6 +1125,7 @@ func newContractTaskCommandService(
 	service, err := app.NewTaskCommandService(app.TaskCommandServiceDependencies{
 		CommandName: "release",
 		Store:       store,
+		Coordinator: &stubQueueCoordinator{},
 		NewTaskID:   newTaskID,
 	})
 	if err != nil {

--- a/internal/store/sqlite/store.go
+++ b/internal/store/sqlite/store.go
@@ -105,6 +105,20 @@ func (s *Store) UpsertThreadBinding(ctx context.Context, binding app.ThreadBindi
 	return nil
 }
 
+func (s *Store) DeleteThreadBinding(ctx context.Context, mode string, logicalThreadKey string) error {
+	_, err := s.db.ExecContext(
+		ctx,
+		`DELETE FROM thread_bindings WHERE mode = ? AND logical_thread_key = ?`,
+		mode,
+		logicalThreadKey,
+	)
+	if err != nil {
+		return fmt.Errorf("delete thread binding: %w", err)
+	}
+
+	return nil
+}
+
 func (s *Store) CreateTask(ctx context.Context, task app.Task) error {
 	now := s.clock()
 	if task.CreatedAt.IsZero() {

--- a/internal/store/sqlite/store_test.go
+++ b/internal/store/sqlite/store_test.go
@@ -204,6 +204,36 @@ func TestStoreThreadBindingLifecycle(t *testing.T) {
 	}
 }
 
+func TestStoreDeleteThreadBinding(t *testing.T) {
+	t.Parallel()
+
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	if err := store.UpsertThreadBinding(ctx, app.ThreadBinding{
+		Mode:             "task",
+		LogicalThreadKey: "user-1:task-1",
+		CodexThreadID:    "thread-1",
+		TaskID:           "task-1",
+	}); err != nil {
+		t.Fatalf("UpsertThreadBinding() error = %v", err)
+	}
+
+	if err := store.DeleteThreadBinding(ctx, "task", "user-1:task-1"); err != nil {
+		t.Fatalf("DeleteThreadBinding() error = %v", err)
+	}
+
+	if _, ok, err := store.GetThreadBinding(ctx, "task", "user-1:task-1"); err != nil {
+		t.Fatalf("GetThreadBinding() error = %v", err)
+	} else if ok {
+		t.Fatal("GetThreadBinding() ok = true, want false")
+	}
+
+	if err := store.DeleteThreadBinding(ctx, "task", "user-1:task-1"); err != nil {
+		t.Fatalf("DeleteThreadBinding() second error = %v", err)
+	}
+}
+
 func TestStoreThreadBindingPersistsAcrossReopen(t *testing.T) {
 	t.Parallel()
 

--- a/internal/thread/policy_test.go
+++ b/internal/thread/policy_test.go
@@ -238,6 +238,10 @@ func (s stubThreadStore) UpsertThreadBinding(context.Context, app.ThreadBinding)
 	return nil
 }
 
+func (s stubThreadStore) DeleteThreadBinding(context.Context, string, string) error {
+	return nil
+}
+
 func (s stubThreadStore) GetActiveDailySession(context.Context, string) (app.DailySession, bool, error) {
 	return app.DailySession{}, false, nil
 }


### PR DESCRIPTION
## Summary

- add `action:task-reset-context` to the task-mode root command surface
- clear only the saved task thread binding while keeping the active task and worktree unchanged
- update task-mode architecture, design, product, and ExecPlan docs to match the shipped behavior

## Background

Issue #80 asks for a task-scoped way to restart Codex conversation continuity without recreating the task workspace. The repository already separated task identity, worktree state, and thread binding persistence, so the missing piece was a safe command path that deletes only the saved task binding and rejects reset while work is still running or queued.

## Related issue(s)

- Closes #80

## Implementation details

- added `DeleteThreadBinding` to the app/store contracts and SQLite store implementation
- implemented `TaskCommandService.ResetContext` with success, no-op, and busy-rejection responses
- wired `action:task-reset-context` through Discord command registration, help text, and runtime routing
- added store, app, and runtime coverage for idle reset, no-op reset, busy rejection, and next-message fresh-thread behavior
- updated `ARCHITECTURE.md`, task-mode docs, product specs, and the active ExecPlan living sections

## Test coverage

- `make test`
- `make lint`

## Breaking changes

- None

## Notes

- The reset action is intentionally scoped to the current active task only.
- The action does not recreate or delete task worktrees.
- Created by Codex