### PR TITLE
docs: archive completed task reset context ExecPlan

### DIFF
--- a/docs/exec-plans/completed/16-task-reset-context.md
+++ b/docs/exec-plans/completed/16-task-reset-context.md
@@ -18,6 +18,7 @@ This change matters because `task` mode deliberately couples long-lived work to 
 - [x] (2026-04-11 03:24Z) Implemented `action:task-reset-context` in the task command service, root command registration, and Discord routing, including explicit success, no-op, and busy-rejection responses.
 - [x] (2026-04-11 03:28Z) Added store, app, and runtime tests that prove the reset path, no-op fresh-state behavior, busy rejection, and next-message fresh-thread behavior.
 - [x] (2026-04-11 03:31Z) Ran `make test` and `make lint`; both passed after formatting the touched Go files with `gofmt`.
+- [x] (2026-04-11 04:00Z) Confirmed pull request `#83` merged into `origin/master`, fast-forwarded the working branch to the merged commit, and finalized this ExecPlan for archival under `docs/exec-plans/completed/`.
 
 ## Surprises & Discoveries
 
@@ -57,11 +58,17 @@ This change matters because `task` mode deliberately couples long-lived work to 
   Rationale: If the active task has never produced a saved Codex thread ID, the user intent is already satisfied: the next normal message will start fresh in the same workspace. Returning a user-facing failure for that case would create needless friction.
   Date/Author: 2026-04-11 / Codex
 
+- Decision: Archive this plan without adding a new tech-debt entry.
+  Rationale: The merged implementation satisfied the plan's documented acceptance criteria, and no new intentional follow-up gap was introduced beyond the repository's already-tracked standing debt items.
+  Date/Author: 2026-04-11 / Codex
+
 ## Outcomes & Retrospective
 
 Implementation completed on 2026-04-11. The repository now exposes `action:task-reset-context` in `task` mode, deletes only the saved task thread binding when reset succeeds, rejects reset while the active task still has running or queued work, and keeps the active task selection plus task worktree unchanged.
 
 The main tradeoff is that task reset is intentionally narrow: it does not rebuild or repair the task worktree, and it does not target arbitrary non-active tasks. That keeps the feature easy to explain and reuses the existing “missing binding means start a fresh thread” path instead of adding a second thread-rotation mechanism.
+
+Pull request `#83` delivered the implementation and was merged before this archive update. No additional deferred work was identified during archival review, so the plan can move directly to `docs/exec-plans/completed/` as the historical record for issue `#80`.
 
 ## Context and Orientation
 
@@ -453,3 +460,4 @@ Keep the existing dependencies:
 
 Revision Note: 2026-04-11 02:32Z / Codex - Created this active ExecPlan for issue `#80` after reviewing the current task-mode routing, queue, command, and persistence architecture and choosing the smallest coherent design: delete the saved task thread binding while preserving active-task and worktree state.
 Revision Note: 2026-04-11 03:31Z / Codex - Updated this ExecPlan after implementation landed so the living sections, concrete steps, and retrospective now reflect the shipped `task-reset-context` behavior and its passing validation commands.
+Revision Note: 2026-04-11 04:00Z / Codex - Finalized the living sections after confirming pull request `#83` was merged into `origin/master`, then prepared this plan for archival without adding new tech-debt follow-up because the documented acceptance scope was fully satisfied.

--- a/docs/exec-plans/index.md
+++ b/docs/exec-plans/index.md
@@ -25,10 +25,11 @@ Plans in this directory should be written and maintained in line with `.agents/P
 
 These plans are intended to be executed in the order listed below. Most plans follow numeric order, but infrastructure prerequisites may require picking up a later-numbered plan first when it explicitly prepares the repository for another active plan.
 
-- [Add task-scoped context reset without recreating the worktree](./active/16-task-reset-context.md)
+There are no active ExecPlans right now.
 
 ## Recently Completed Plans
 
+- [Add task-scoped context reset without recreating the worktree](./completed/16-task-reset-context.md)
 - [Replace task-mode source-checkout parenting with a managed bare repository](./completed/15-task-managed-bare-parent.md)
 - [Add shared daily generation rotation and `action:clear` to `daily` mode](./completed/12-daily-clear-generation.md)
 - [Build a versioned SQLite migration runner and bootstrap path](./completed/13-sqlite-migration-runner.md)


### PR DESCRIPTION
## Summary

- archive the completed ExecPlan for task-scoped context reset
- update the ExecPlan index to remove the finished plan from the active list
- record the final living-plan archival update after PR #83 merged

## Background

The implementation for issue #80 already landed through PR #83 and has been merged into `master`. The active ExecPlan still needed its final living-document update and archival move into `docs/exec-plans/completed`.

## Related issue(s)

- Closes the documentation follow-up for #80
- Follows implementation PR #83

## Implementation details

- updated `docs/exec-plans/active/16-task-reset-context.md` with the final archival progress entry, decision note, and retrospective note
- moved the plan to `docs/exec-plans/completed/16-task-reset-context.md`
- updated `docs/exec-plans/index.md` so the active list is empty and the completed list includes plan 16

## Test coverage

- `make test`
- `make lint`

## Breaking changes

- None

## Notes

This PR only archives a completed ExecPlan and updates repository planning metadata.

Created by Codex