### PR TITLE
Document one-shot task override behavior for task mode

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -272,11 +272,15 @@ thread_key = user + task_id
 Behavior:
 
 - `task` mode requires `CLAW_CODEX_WORKDIR` to be a Git repository with an `origin` remote
-- normal messages require an active task context
+- task names are immutable routing-safe slugs that use only lowercase ASCII letters, digits, and single interior hyphens, stay 3 to 32 characters long, start with a letter, end with a letter or digit, and remain unique among the requesting user's open tasks
+- normal messages require an active task context unless the first meaningful token provides a one-shot `task:<name>` override
 - each task reserves its own branch identity in a managed bare parent repository under `${CLAW_DATADIR}/repos`
-- messages route to the thread bound to the active task
+- messages route to the thread bound to the active task or to the overridden task selected by a one-shot `task:<name>` prefix
 - the first normal message for a task may lazily create the managed bare parent and the task worktree before Codex runs
-- changing the active task changes the target thread
+- changing the active task changes the default target thread for later normal messages that do not provide an override
+- a valid one-shot `task:<name>` override applies only to the current message and does not change the saved active task
+- queue admission, saved thread binding lookup, and task-worktree selection must all use the same effective task chosen for that message
+- invalid, missing, or closed one-shot override targets are rejected explicitly instead of being guessed
 - `/<instance-command> action:task-reset-context` keeps the active task and worktree unchanged but removes only the saved Codex thread continuity for that task
 - `action:task-reset-context` is rejected while the active task still has in-flight or queued work
 - each task maps to a distinct Codex conversation thread, so switching tasks also switches execution context and working directory once the task worktree exists

--- a/README.md
+++ b/README.md
@@ -145,9 +145,10 @@ If `AGENT_MEMORY/` exists in the current workspace, consult its durable memory f
 Use `task` mode when you want durable work streams that continue across multiple days.
 
 - each user works through an explicit active task
+- task names are immutable slug-style identifiers such as `release-bot-v1`
 - each task eventually runs in its own task-specific Git worktree
 - `/<instance-command> action:task-*` controls which task is active
-- normal conversation does not run until a task is selected
+- normal conversation does not run until a task is selected, unless the message uses a one-shot `task:<name>` override
 
 ## How It Behaves in Discord
 
@@ -181,11 +182,17 @@ In `task` mode, the same root command also supports:
 - `/<instance-command> action:task-list`
   - list open tasks and mark the active one
 - `/<instance-command> action:task-new task_name:<name>`
-  - create a task and make it active
+  - create a task from a slug-style name and make it active
 - `/<instance-command> action:task-switch task_name:<name>`
-  - switch the active task by name; use `task_id` only when the name is ambiguous
+  - switch the active task by name
 - `/<instance-command> action:task-close task_name:<name>`
-  - close a task by name; use `task_id` only when the name is ambiguous
+  - close a task by name
+
+In `task` mode, a normal message may also start with `task:<name>` to route only that message to another open task without changing the active task.
+Examples:
+
+- `task:release-bot-v1 fix the failing tests`
+- `task:docs-cleanup` followed by a newline and the rest of the message body
 
 ### Busy conversations
 
@@ -410,6 +417,7 @@ Try one of these:
 - mention the bot with only an image
 
 If you are running in `task` mode, create a task first with `/<your-command> action:task-new task_name:<name>`.
+Choose a routing-safe slug such as `release-bot-v1`, not a free-form label with spaces.
 The first normal message for a new task may spend a moment preparing that task's dedicated worktree before Codex replies.
 
 ## Configuration Reference

--- a/docs/design-docs/architecture-overview.md
+++ b/docs/design-docs/architecture-overview.md
@@ -24,7 +24,7 @@ This leads to two distinct mode families on the same foundation:
 - `daily`
   - knowledge-oriented interaction against repository instructions and documentation, with one active shared generation per local day plus a runtime-managed durable-memory bridge under `AGENT_MEMORY/`
 - `task`
-  - execution-oriented interaction against an operator-visible Git checkout with an `origin` remote, where 39claw manages a separate bare parent repository and each task eventually runs inside its own task-specific worktree
+  - execution-oriented interaction against an operator-visible Git checkout with an `origin` remote, where 39claw manages a separate bare parent repository, each task uses an immutable slug name, and each task eventually runs inside its own task-specific worktree
 
 The detailed rationale for these modes lives in `ARCHITECTURE.md` and `thread-modes.md`.
 
@@ -54,6 +54,7 @@ Processes one user turn end to end by resolving the thread target, coordinating 
 
 Converts Discord context into a logical thread bucket according to the globally configured mode.
 In `daily` mode, the policy still resolves only the local date and the application layer expands that bucket into the active generation key.
+In `task` mode, the policy must resolve the effective task from either the saved active task or a one-shot `task:<name>` override present at the first meaningful token.
 
 ### Thread Store
 

--- a/docs/design-docs/implementation-spec.md
+++ b/docs/design-docs/implementation-spec.md
@@ -93,7 +93,9 @@ The storage model uses four tables:
 - `tasks`
   - stores `task_id`, `discord_user_id`, `task_name`, `status`, `branch_name`, nullable `base_ref`, nullable `worktree_path`, `worktree_status`, `created_at`, `updated_at`, nullable `closed_at`, nullable `worktree_created_at`, nullable `worktree_pruned_at`, and nullable `last_used_at`
   - uses ULID strings for `task_id`
-  - allows duplicate task names for the same user
+  - stores `task_name` as the canonical immutable routing-safe slug for the task
+  - requires task names to match `^[a-z](?:[a-z0-9-]{1,30}[a-z0-9])?$` without consecutive hyphens
+  - requires each user's open task names to be unique, while still allowing a closed task's former name to be reused later
 - `active_tasks`
   - stores `discord_user_id`, `task_id`, and `updated_at`
   - enforces one active task per Discord user within a bot instance
@@ -108,6 +110,10 @@ The logical thread key defaults are:
 
 - `daily`: configured local date formatted as `YYYY-MM-DD` for the outer bucket, with the active visible thread key normalized to `YYYY-MM-DD#<generation>`
 - `task`: `discord_user_id + task_id`
+
+In `task` mode, the effective task for a normal message is the saved active task unless the first meaningful token supplies a one-shot `task:<name>` override.
+That override may follow leading whitespace or the guild-channel bot mention, may be followed by body text on the same line or the next line, and applies only to the current message.
+Queue admission, thread binding lookup, and worktree selection must freeze that effective task at acceptance time so later task switches do not reroute already-accepted work.
 
 When the bot runs in `daily` mode, 39claw also manages a durable memory projection inside `${CLAW_CODEX_WORKDIR}/AGENT_MEMORY`.
 `MEMORY.md` is the primary durable-memory file, and `YYYY-MM-DD.<generation>.md` stores the bridge note created during the first-message preflight for a new daily generation.
@@ -232,13 +238,16 @@ Most of these outcomes should be proven through automated contract coverage plus
 - In `daily` mode, startup does not create or rewrite `AGENTS.md`.
 - A guild mention or direct message with text plus image attachments reaches Codex as multipart input.
 - A guild mention or direct message with only one or more usable image attachments is accepted and answered.
-- In `task` mode, a normal mention without an active task returns guidance instead of routing to Codex.
+- In `task` mode, a normal mention without an active task returns guidance instead of routing to Codex unless that message provides a valid one-shot `task:<name>` override.
 - `/<instance-command> action:task-current` shows the active task for the requesting user.
-- `/<instance-command> action:task-new task_name:<name>` creates a task and sets it active for the requesting user.
+- `/<instance-command> action:task-new task_name:<name>` creates a task with a routing-safe slug name and sets it active for the requesting user.
 - The first normal message for a new task creates or refreshes a managed bare parent under `${CLAW_DATADIR}/repos`, then creates a task worktree lazily under `${CLAW_DATADIR}/worktrees/<task_id>`, and then runs Codex inside that worktree.
-- `/<instance-command> action:task-switch task_name:<name>` changes the routing target for subsequent normal messages, with `task_id` reserved for ambiguity fallback.
-- `/<instance-command> action:task-close task_name:<name>` closes the task and clears active state when the closed task was active, with `task_id` reserved for ambiguity fallback.
+- `/<instance-command> action:task-switch task_name:<name>` changes the default routing target for later normal messages that do not provide an override, with `task_id` reserved only for compatibility with pre-slug tasks during migration.
+- `/<instance-command> action:task-close task_name:<name>` closes the uniquely named open task and clears active state when the closed task was active.
 - `/<instance-command> action:task-reset-context` keeps the active task and worktree but clears only the saved Codex thread continuity for that task.
+- In `task` mode, `task:<name> <body>` and `task:<name>` followed by a newline route only the current message to the named open task without changing the active task.
+- In `task` mode, `task:<name>` with attachments but no body is valid, while a message that has neither body nor attachments is rejected.
+- Invalid task-name format, missing tasks, closed tasks, and policy failures in one-shot override handling return explicit user-facing guidance instead of guessing a target.
 - Closed-task worktree retention keeps only the fifteen most recently closed ready worktrees and never deletes the task branches held by the managed bare parent.
 - Existing `daily` and `task` bindings survive process restart through SQLite-backed state.
 - Guild non-mention chatter is ignored, unsupported non-image-only qualifying posts stay silent, supported slash commands respond correctly, and long replies are chunked cleanly.

--- a/docs/design-docs/state-and-storage.md
+++ b/docs/design-docs/state-and-storage.md
@@ -78,6 +78,7 @@ user -> active_task_id
 ```
 
 This allows ordinary messages to be routed without forcing the user to repeat the task identifier in every message.
+One-shot `task:<name>` overrides do not mutate this saved active-task mapping.
 
 ### 5. Task Worktree Metadata
 
@@ -87,6 +88,7 @@ Each task needs enough metadata to create and later manage an isolated Git workt
 
 That includes:
 
+- immutable routing-safe task name
 - reserved branch name
 - detected base ref
 - worktree path
@@ -94,6 +96,7 @@ That includes:
 - creation, prune, and last-used timestamps
 
 This metadata lets 39claw decide whether a task needs lazy worktree creation, whether a closed task is eligible for pruning, and which working directory Codex should use for the next turn.
+The task-name field also acts as a routing target for one-shot `task:<name>` overrides, so open task names must stay unique per user and must not be silently normalized after creation.
 
 Task mode also owns a repository-shaped on-disk artifact outside SQLite:
 

--- a/docs/design-docs/task-mode-worktrees.md
+++ b/docs/design-docs/task-mode-worktrees.md
@@ -71,6 +71,9 @@ Those are separate concerns and must not be collapsed into one field.
 ## Task Creation
 
 `/<instance-command> action:task-new task_name:<name>` creates the task record and sets it active.
+The submitted `task_name` is the canonical immutable task slug, not a free-form label.
+It must use lowercase ASCII letters, digits, and single interior hyphens only, stay 3 to 32 characters long, start with a letter, end with a letter or digit, and avoid consecutive hyphens.
+Open task names must be unique for the requesting user.
 
 Task creation does not create a worktree immediately.
 Instead, it records the metadata needed for later creation:
@@ -82,8 +85,8 @@ Instead, it records the metadata needed for later creation:
 - `status=open`
 - `worktree_status=pending`
 
-The branch name should be generated once at task creation time from a Git-safe slug of `task_name` and treated as immutable task identity metadata.
-If the task name collapses to an unusable value after normalization, the implementation should fall back to the task ID so branch reservation still succeeds.
+The branch name should be generated once at task creation time directly from the validated task slug and treated as immutable task identity metadata.
+Because `task_name` is already constrained to a routing-safe slug, task creation should reject invalid names instead of normalizing or falling back to the task ID.
 
 ## Lazy Worktree Creation
 
@@ -115,6 +118,23 @@ It does not:
 - eagerly prepare the destination task worktree
 
 The next normal message determines whether the destination task needs lazy worktree creation before Codex runs.
+
+## One-Shot Task Override
+
+In `task` mode, a normal message may begin with a one-shot `task:<name>` prefix that temporarily targets another open task.
+
+That prefix:
+
+- is recognized only at the first meaningful token in the message
+- may appear after leading whitespace
+- may appear after the bot mention in guild channels
+- may be followed by message body text on the same line or the next line
+- may appear alone when the message still has one or more attachments
+
+When the prefix is valid, 39claw resolves the named open task, freezes that task at queue-admission time, and uses that task's thread binding and worktree selection only for the current message.
+The saved active task remains unchanged.
+
+When the prefix is invalid, names a missing or closed task, or leaves the message without both body text and attachments, 39claw must reject the message explicitly instead of guessing a target task.
 
 ## Task Context Reset
 

--- a/docs/design-docs/thread-modes.md
+++ b/docs/design-docs/thread-modes.md
@@ -85,11 +85,13 @@ thread_key = user + task_id
 ### Behavior
 
 - the configured `CLAW_CODEX_WORKDIR` must be a Git repository with an `origin` remote
-- a current task must exist before normal messages can be routed
+- task names are immutable routing-safe slugs and must be unique among the requesting user's open tasks
+- a current task must exist before normal messages can be routed unless the message provides a valid one-shot `task:<name>` override
 - `task-new` creates task metadata immediately but defers worktree creation
 - the first normal message for a task creates or refreshes the managed bare parent under `${CLAW_DATADIR}/repos` and then creates the task worktree lazily when needed
-- messages are sent to the Codex thread associated with the active task and use that task's worktree once it exists
-- changing tasks changes the target logical thread
+- messages are sent to the Codex thread associated with the active task by default and use that task's worktree once it exists
+- a valid one-shot `task:<name>` prefix routes only the current message to another open task and does not change the saved active task
+- changing tasks changes the default target logical thread for later normal messages that do not provide an override
 - `/<instance-command> action:task-reset-context` keeps the current task active and the task worktree unchanged while dropping only the saved Codex thread binding for that task
 - `action:task-reset-context` is rejected while that task has in-flight or queued work
 - closed-task worktrees are retained only for the fifteen most recently closed ready tasks

--- a/docs/product-specs/discord-command-behavior.md
+++ b/docs/product-specs/discord-command-behavior.md
@@ -84,6 +84,7 @@ Examples:
 v1 should use a small, channel-aware trigger contract for normal-message interaction.
 In guild channels, normal-message interaction remains mention-only.
 In direct messages, normal-message interaction should work without an extra bot mention.
+In `task` mode, the first meaningful token of a qualifying normal message may be a one-shot `task:<name>` override, and guild messages may place that token after the bot mention.
 When a qualifying normal message is accepted, it may contain typed text, one or more image attachments, or both.
 If a qualifying trigger is present but the message contains neither text nor a usable image attachment, the bot should stay silent.
 If the turn starts immediately, the bot may first post a short placeholder reply and then edit that same reply as Codex streams progress or partial assistant output.
@@ -113,7 +114,7 @@ This means:
 - every bot instance should expose exactly one slash-command search result
 - bot instances configured for `task` mode should expose task actions through that root command
 - bot instances configured for `daily` mode should expose `help` plus `clear` through that root command
-- users should not need to guess between natural-language task control and slash-command task control
+- users should not need to guess between normal conversation, the one-shot `task:<name>` routing syntax, and slash-command task control
 
 ### Minimum command capabilities
 
@@ -124,11 +125,11 @@ The root command should support user-facing actions for:
 - `/<instance-command> action:task-list`
   - show open task names and IDs, plus each task's current worktree branch when available
 - `/<instance-command> action:task-new task_name:<name>`
-  - create a new task and switch the active task to it
+  - create a new task from a routing-safe slug name and switch the active task to it
 - `/<instance-command> action:task-switch task_name:<name>`
-  - switch the active task to the uniquely named open task, with `task_id` available only when the name is ambiguous
+  - switch the active task to the uniquely named open task
 - `/<instance-command> action:task-close task_name:<name>`
-  - close the uniquely named open task, with `task_id` available only when the name is ambiguous
+  - close the uniquely named open task
 - `/<instance-command> action:task-reset-context`
   - keep the active task and worktree unchanged while discarding only the saved Codex conversation continuity for that task
 
@@ -156,6 +157,29 @@ The root-command action surface should be:
 - list the supported command surface for the current bot instance
 - explain task actions only when that workflow is available for the current bot instance
 - help users recover from missing-context situations without reading internal docs
+
+### Task-name and one-shot override rules
+
+In `task` mode, task names should be treated as stable routing-safe slugs rather than as free-form labels.
+
+Product rules:
+
+- lowercase ASCII only
+- allowed characters are `a-z`, `0-9`, and single interior `-`
+- no spaces
+- starts with a letter
+- ends with a letter or digit
+- no consecutive hyphens
+- length 3 to 32 characters
+- unique among the user's open tasks
+- immutable after creation
+
+Normal messages may use a one-shot `task:<name>` prefix only at the first meaningful token.
+That prefix may be followed by body text on the same line or the next line.
+If a message has attachments but no body text, `task:<name>` alone is still valid.
+If a literal `task:<name>` string appears later in the message body, it should not be treated as an override.
+
+When a valid one-shot override is accepted, the user-facing response should confirm which task handled that message.
 
 ### Success behavior
 
@@ -192,6 +216,7 @@ When a task action fails, the response should:
 If a task action is invoked against a bot instance running in `daily` mode, the bot should explain that task actions are not available for that instance rather than pretending the command was accepted.
 
 If `action:task-reset-context` is requested while the active task still has running or queued work, the bot should reject the request and tell the user to retry after pending replies finish.
+If a one-shot `task:<name>` override is invalid or targets no open task, the bot should reject that message explicitly and tell the user how to recover.
 
 ## Ambiguous Input Handling
 

--- a/docs/product-specs/task-mode-user-flow.md
+++ b/docs/product-specs/task-mode-user-flow.md
@@ -37,11 +37,16 @@ Once a task is active, the user should be able to continue that line of work ove
 Changing the active task should be treated as a meaningful context change.
 The product should make that behavior understandable to the user.
 
-### 4. Missing context should produce actionable guidance
+### 4. Temporary task routing should be explicit and non-sticky
+
+When a user wants to send one message to a different task without changing their default task, the product may support that only through an explicit one-shot syntax such as `task:<name>`.
+That one-shot route should affect only the current message and should not silently change the saved active task.
+
+### 5. Missing context should produce actionable guidance
 
 If the user tries to work without an active task, the response should tell them what to do next in simple language and point them toward the `/<instance-command> action:task-*` command flow.
 
-### 5. Task work should be isolated
+### 6. Task work should be isolated
 
 Each task should run inside its own repository workspace rather than sharing one mutable checkout with other tasks.
 That isolation should make task switching feel like switching work streams, not only switching chat memory.
@@ -69,7 +74,7 @@ Expected flow:
 
 1. The user uses `/<instance-command> action:task-new task_name:<name>`, `/<instance-command> action:task-switch task_name:<name>`, or `/<instance-command> action:task-current` plus other task actions to establish the desired task context.
 2. 39claw records that task as the active context for the user within the current bot instance.
-3. A newly created task reserves its own task branch identity even before worktree creation, using a Git-safe slug derived from `task_name` and falling back to `task_id` only when the name cannot produce a usable branch suffix.
+3. A newly created task reserves its own task branch identity even before worktree creation, using the validated `task_name` slug directly as immutable task identity metadata.
 4. The next normal message routes to the thread associated with that task.
 5. If the task has no ready worktree yet, 39claw prepares the task workspace lazily before running Codex.
 6. If the task has no bound thread yet, 39claw creates one.
@@ -79,6 +84,22 @@ Expected user perception:
 - “I chose the work context.”
 - “The bot now knows what I mean by continuing this task.”
 - “This task has its own workspace.”
+
+### Scenario: User sends one message to a different task without switching
+
+Expected flow:
+
+1. The user already has an active task.
+2. The user sends a normal message that starts with `task:<name>`, either followed by body text on the same line or on the next line.
+3. 39claw validates that `<name>` is a routing-safe task slug and matches one open task for that user.
+4. 39claw freezes that overridden task for queue admission, thread lookup, and worktree selection for the current message only.
+5. 39claw keeps the saved active task unchanged after the reply is delivered.
+
+Expected user perception:
+
+- “I temporarily targeted another task without moving my default context.”
+- “Queued work stayed attached to the task I named.”
+- “My normal task selection did not change behind my back.”
 
 ### Scenario: User continues an active task on a later day
 
@@ -165,21 +186,25 @@ For `task` mode to feel usable, v1 should support at least:
 - `/<instance-command> action:task-list`
   - show open task names and IDs, plus each task's current worktree branch when available
 - `/<instance-command> action:task-new task_name:<name>`
-  - create a new task and switch the active task to it
+  - create a new task from a routing-safe slug name and switch the active task to it
 - `/<instance-command> action:task-switch task_name:<name>`
-  - switch the active task to the uniquely named open task, with `task_id` used only when the name is ambiguous
+  - switch the active task to the uniquely named open task
 - `/<instance-command> action:task-close task_name:<name>`
-  - close the uniquely named open task, with `task_id` used only when the name is ambiguous
+  - close the uniquely named open task
 - `/<instance-command> action:task-reset-context`
   - keep the current active task and worktree but discard only the saved Codex conversation continuity for that task
+- one-shot `task:<name>` override syntax on normal messages
+  - route only the current message to the named open task without changing the active task
 
 The root-command action surface should stay explicit and stable enough that users can learn it as the standard task-control surface for `task` mode.
+The task-name syntax should also stay explicit and stable enough that users can type it reliably inside normal Discord messages.
 
 ## UX Requirements
 
 ### Context safety
 
 The bot should favor correctness of task routing over convenience when the active task is ambiguous or missing.
+That same rule applies to one-shot overrides: invalid names or unresolved targets must be rejected instead of being guessed.
 
 ### Explainability
 
@@ -215,6 +240,7 @@ When no active task exists, the bot should:
 
 If a user closes a task and then immediately sends a normal message, the bot should treat that as a missing-active-task case.
 In `task` mode, normal messages should not trigger task creation or implicit recovery on their own.
+One-shot `task:<name>` syntax is the only accepted shortcut for temporarily routing a normal message without changing the active task.
 
 ### Stale or invalid task binding
 
@@ -235,6 +261,16 @@ The bot should explain that the user needs to wait for pending replies to finish
 If the product is not certain which task should receive a message, it should prefer asking for explicit user action rather than guessing and contaminating the wrong context.
 That same safety rule applies to queued work: the task context must be frozen at queue-admission time rather than re-read later.
 
+### Invalid override syntax
+
+When a normal message starts with `task:<name>`, the bot should reject it explicitly when:
+
+- the task-name format is invalid
+- no matching open task exists
+- the named task is closed
+- the message contains neither body text nor attachments
+- policy checks fail for the overridden task context
+
 ### Closed-task workspace retention
 
 Closing a task should not imply immediate deletion of its task branch.
@@ -253,7 +289,9 @@ The most recent closed task workspaces should remain available longer than older
 
 - Active task state is always user-scoped within a bot instance in v1.
 - The active task should remain active until the user explicitly closes it or switches to another task.
+- Task names are immutable routing-safe slugs that stay unique among a user's open tasks.
 - If a task is closed and the user then sends a normal message, the bot should respond with missing-active-task guidance rather than routing the message normally.
+- A leading `task:<name>` prefix may route one normal message to another open task, but it never changes the saved active task.
 - `task` mode assumes the configured workdir is a Git repository with an `origin` remote.
 - New tasks create metadata first and prepare their task worktree lazily on the first normal message.
 - Closed-task retention keeps only the fifteen most recently closed ready task worktrees.


### PR DESCRIPTION
## Summary

- document the one-shot `task:<name>` override behavior for task-mode normal messages
- define the immutable task-name slug contract and override rejection rules
- align architecture, design, product, and README docs before implementation work

## Background

Issue #85 proposes a one-shot task override syntax for normal messages in task mode. This PR delivers the documentation-first step so the intended behavior is explicit before the implementation and ExecPlan phases.

## Related issue(s)

- Refs #85

## Implementation details

- updated `ARCHITECTURE.md` with the one-shot override routing contract
- updated design docs to describe slug-based task names, frozen queue routing, and worktree selection rules
- updated product docs and README to describe user-facing syntax, validation, and recovery behavior
- no production code changes are included in this PR

## Test coverage

- `make lint`
- `make test`

## Breaking changes

- No runtime behavior changes in this PR
- The documented future task-name contract is stricter than the current implementation and will be enforced in follow-up implementation work

## Notes

- This is the documentation-first PR for the first step of issue #85
- The follow-up steps are the ExecPlan and implementation PRs

Created by Codex
