### PR TITLE
[codex] add scheduled tasks exec plan

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -35,6 +35,7 @@ Instead:
 - 39claw owns Discord integration
 - 39claw owns thread routing policy
 - 39claw owns local persistence for Codex thread bindings
+- 39claw owns scheduled-task definitions, dispatch timing, and Discord delivery for bot-initiated Codex runs
 
 The application should stay intentionally thin.
 
@@ -90,6 +91,7 @@ Losing the mapping between a logical thread key and a Codex thread ID breaks con
 39claw should focus on:
 
 - message intake
+- scheduled-run intake and dispatch
 - thread resolution
 - Codex thread binding
 - response delivery
@@ -98,7 +100,7 @@ It should avoid unnecessary local orchestration layers in v1.
 
 ## 4. System Role
 
-39claw is a stateful gateway between Discord conversations and Codex threads.
+39claw is a stateful gateway between Discord conversations, scheduled bot-initiated runs, and Codex threads.
 
 Its job is to:
 
@@ -113,6 +115,7 @@ Its job is to:
 ```text
 Discord Runtime
   -> Message Application Service
+  -> Scheduled Task Service
     -> Thread Policy
     -> Thread Store
     -> Queue Coordinator
@@ -171,6 +174,7 @@ The thread store persists the mapping between:
 - Codex thread ID
 
 In `task` mode, the thread store must also track task records, the currently selected task for a user within the current bot instance, and task worktree metadata such as branch name, worktree path, and worktree lifecycle state.
+For scheduled tasks, the store must also track persisted task definitions, individual run records, and Discord delivery state for report posting and retry-safe reconciliation.
 
 ### 6.5 Queue Coordinator
 
@@ -186,7 +190,22 @@ Responsibilities:
 The queue is intentionally in memory only.
 It is not part of the durable SQLite state.
 
-### 6.6 Codex Gateway
+### 6.6 Scheduled Task Service
+
+The scheduled task service orchestrates bot-initiated Codex runs that are triggered by persisted schedules instead of a live user message.
+
+Responsibilities:
+
+- manage the lifecycle of scheduled task definitions and validation
+- determine when a scheduled task becomes due according to the configured timezone
+- create a durable run record before dispatch so retries and post-crash reconciliation stay explicit
+- call the Codex gateway using the mode-appropriate working directory policy for the scheduled run
+- deliver the resulting report to the configured Discord channel and persist delivery outcome metadata
+
+Scheduled execution does not replace the normal message flow.
+It is a parallel application entrypoint that reuses the same Codex integration boundary and mode-specific working-directory rules.
+
+### 6.7 Codex Gateway
 
 The Codex gateway wraps the Codex SDK or Codex integration layer.
 
@@ -200,7 +219,7 @@ Responsibilities:
 
 All Codex-specific details should stay behind this boundary.
 
-### 6.7 Response Presenter
+### 6.8 Response Presenter
 
 The presenter adapts normalized application output to Discord-safe responses.
 
@@ -305,6 +324,32 @@ Tradeoffs:
 - requires task-state persistence in addition to thread binding
 - requires Git worktree lifecycle management and cleanup policy
 
+## 7.3 Scheduled Tasks
+
+Purpose:
+
+- let the bot trigger Codex work on a persisted schedule without waiting for a live Discord message
+- deliver the resulting output back into Discord as a bot-authored report
+
+Behavior:
+
+- scheduled task definitions are owned locally by 39claw rather than by Discord message history
+- scheduled runs inherit the bot instance's configured mode, so mode-specific thread and workdir rules still apply
+- when the bot instance runs in `daily` mode, a scheduled run executes directly in `CLAW_CODEX_WORKDIR`
+- when the bot instance runs in `task` mode, a scheduled run must create a fresh temporary worktree for the run, execute Codex there, and remove that temporary worktree after the run finishes
+- scheduled task management and execution are initiated through local 39claw-owned orchestration even though the run itself is still executed by Codex
+- report delivery must be durable enough to distinguish run success from Discord-delivery failure
+
+Properties:
+
+- makes bot-initiated recurring Codex workflows possible without adding a local agent loop
+- keeps scheduling, persistence, and Discord delivery on the 39claw side while leaving reasoning and tool execution to Codex
+
+Tradeoffs:
+
+- introduces additional durable state beyond interactive thread bindings
+- adds reconciliation needs for runs that finish while Discord delivery fails or the process restarts mid-flight
+
 ## 8. Request Flow
 
 ```text
@@ -366,6 +411,9 @@ The minimum persistent state for v1 is:
 - thread bindings
 - active task selection for `task` mode
 - task records with task worktree metadata for `task` mode
+- scheduled task definitions
+- scheduled run records
+- scheduled report delivery records
 
 The bounded queued-message backlog is not persisted.
 It exists only in memory while the process is running.
@@ -396,6 +444,7 @@ v1 should include:
 - global thread mode selection
 - `daily` mode
 - `task` mode
+- scheduled task definitions and execution
 - local persistent thread binding
 - local persistent active task state
 - task-isolated Git worktrees for `task` mode

--- a/docs/design-docs/architecture-overview.md
+++ b/docs/design-docs/architecture-overview.md
@@ -9,7 +9,7 @@ Use this document when you want a quick mental model of the system before readin
 
 ## System Role
 
-39claw is a stateful gateway between Discord conversations and Codex threads.
+39claw is a stateful gateway between Discord conversations, scheduled bot-initiated runs, and Codex threads.
 
 It does not act as a full local coding agent runtime.
 Instead, it delegates agent execution to Codex and manages the local application-side policy.
@@ -27,12 +27,14 @@ This leads to two distinct mode families on the same foundation:
   - execution-oriented interaction against an operator-visible Git checkout with an `origin` remote, where 39claw manages a separate bare parent repository, each task uses an immutable slug name, and each task eventually runs inside its own task-specific worktree
 
 The detailed rationale for these modes lives in `ARCHITECTURE.md` and `thread-modes.md`.
+Scheduled tasks sit beside those interactive modes rather than replacing them: 39claw owns schedule persistence, due-run dispatch, and Discord report delivery, while Codex still executes the actual run inside the mode-appropriate working directory.
 
 ## High-Level Components
 
 ```text
 Discord Runtime
   -> Message Application Service
+  -> Scheduled Task Service
     -> Thread Policy
     -> Thread Store
     -> Queue Coordinator
@@ -58,12 +60,16 @@ In `task` mode, the policy must resolve the effective task from either the saved
 
 ### Thread Store
 
-Persists the local continuity data that lets 39claw resume the correct Codex thread, plus task and task-worktree metadata in `task` mode.
+Persists the local continuity data that lets 39claw resume the correct Codex thread, plus task and task-worktree metadata in `task` mode, plus scheduled-task definitions and run or delivery state.
 
 ### Queue Coordinator
 
 Serializes work per logical thread key.
 The first turn for an idle key runs immediately, up to five additional waiting turns may queue in memory, and further turns receive a retry-later response until capacity returns.
+
+### Scheduled Task Service
+
+Owns schedule definition management, due-run claiming, Codex execution handoff, and Discord report delivery for bot-initiated scheduled runs.
 
 ### Codex Gateway
 
@@ -92,6 +98,18 @@ Adapts normalized application output into Discord-safe responses.
 
 The runtime-owned part stops at creating and refreshing the memory files themselves.
 Whether Codex consults those files during normal visible turns is controlled by the user-owned instructions already present in the workdir, such as `AGENTS.md`.
+```
+
+Scheduled runs follow a parallel path:
+
+```text
+1. Scheduler determines that a persisted scheduled task is due
+2. Scheduled task service creates or claims a durable run record
+3. The service chooses the mode-appropriate workdir policy for that run
+4. In `daily` mode, the run executes directly in `CLAW_CODEX_WORKDIR`
+5. In `task` mode, the run executes in a fresh temporary worktree that is removed after completion
+6. Codex returns the final output and any resulting thread identity
+7. 39claw records the run outcome and separately records whether Discord delivery succeeded
 ```
 
 ## Concurrency Model

--- a/docs/design-docs/implementation-spec.md
+++ b/docs/design-docs/implementation-spec.md
@@ -42,6 +42,7 @@ The recommended delivery order is:
 2. `daily` mode routing and persistence
 3. `task` mode state and command workflow
 4. Discord command and presentation refinement
+5. scheduled task orchestration, persistence, and delivery
 
 ## Internal Interfaces to Freeze
 
@@ -55,10 +56,15 @@ The following internal contracts should be treated as stable v1 design targets e
   - resolves a logical thread key from the configured mode and the current message or task context
 - `ThreadStore`
   - loads, upserts, and deletes thread bindings and manages task records plus active task state
+- `ScheduledTaskStore`
+  - manages scheduled task definitions, run records, and delivery records
 - `CodexGateway`
   - runs a turn against an existing Codex thread when a thread ID is present
   - creates the first remote thread implicitly when the first turn runs without a saved thread ID
   - returns a normalized final response plus the thread ID that should be persisted
+- `ScheduledTaskService`
+  - implements create, list, enable, disable, delete, and execute-now workflows for scheduled tasks
+  - owns due-run claiming, execution handoff, and Discord report delivery recording
 - `TaskCommandService`
   - implements the `action:task-current`, `action:task-list`, `action:task-new`, `action:task-switch`, `action:task-close`, and `action:task-reset-context` workflow behind the configured root command
 - `DailyCommandService`
@@ -82,7 +88,7 @@ SQLite is the required v1 storage backend.
 
 Schema evolution should use embedded, versioned, up-only SQLite migrations tracked through a dedicated `schema_migrations` table rather than relying on ad hoc startup-only column checks inside store CRUD code.
 
-The storage model uses four tables:
+The storage model uses seven tables:
 
 - `thread_bindings`
   - stores `mode`, `logical_thread_key`, `codex_thread_id`, nullable `task_id`, `created_at`, and `updated_at`
@@ -99,6 +105,16 @@ The storage model uses four tables:
 - `active_tasks`
   - stores `discord_user_id`, `task_id`, and `updated_at`
   - enforces one active task per Discord user within a bot instance
+- `scheduled_task_definitions`
+  - stores `scheduled_task_id`, `name`, `mode`, `schedule_kind`, `schedule_expr`, `prompt`, nullable `task_prompt_prefix`, `report_channel_id`, `is_enabled`, `last_claimed_at`, `last_scheduled_for`, `created_at`, `updated_at`, and nullable `disabled_at`
+  - uses ULID strings for `scheduled_task_id`
+  - stores the canonical schedule definition that 39claw owns locally
+- `scheduled_task_runs`
+  - stores `scheduled_run_id`, `scheduled_task_id`, `mode`, `scheduled_for`, `status`, nullable `codex_thread_id`, nullable `workdir_path`, nullable `temp_worktree_path`, nullable `started_at`, nullable `finished_at`, nullable `error_code`, nullable `error_message`, `created_at`, and `updated_at`
+  - records each scheduled execution attempt before Codex dispatch begins
+- `scheduled_task_deliveries`
+  - stores `scheduled_delivery_id`, `scheduled_run_id`, `discord_channel_id`, nullable `discord_message_id`, `status`, nullable `delivered_at`, nullable `error_code`, nullable `error_message`, `created_at`, and `updated_at`
+  - tracks whether a completed run report reached Discord successfully
 
 Task status is `open` or `closed`.
 Task worktree status is `pending`, `ready`, `failed`, or `pruned`.
@@ -117,6 +133,9 @@ Queue admission, thread binding lookup, and worktree selection must freeze that 
 
 When the bot runs in `daily` mode, 39claw also manages a durable memory projection inside `${CLAW_CODEX_WORKDIR}/AGENT_MEMORY`.
 `MEMORY.md` is the primary durable-memory file, and `YYYY-MM-DD.<generation>.md` stores the bridge note created during the first-message preflight for a new daily generation.
+Scheduled tasks are independent from interactive message routing and own their own persisted definition plus run lifecycle.
+When a scheduled task executes in `daily` mode, it uses `CLAW_CODEX_WORKDIR` directly.
+When a scheduled task executes in `task` mode, it must create a fresh temporary worktree from the managed bare parent, run Codex there, and remove that temporary worktree after the run completes.
 
 ## Discord Behavior Defaults
 
@@ -131,6 +150,7 @@ Task-control command responses are ephemeral by default.
 When a bot instance runs in `daily` mode, task actions must return a clear not-available response instead of pretending the command worked.
 When a bot instance runs in `daily` mode, the root command should also expose `action:clear`.
 When a bot instance runs in `task` mode, the root command should expose `action:task-current`, `action:task-list`, `action:task-new`, `action:task-switch`, `action:task-close`, and `action:task-reset-context`.
+Scheduled-task control commands should be available in both modes because scheduled execution is orthogonal to the interactive thread mode.
 
 When a bot instance runs in `task` mode, normal messages without an active task must not be routed to Codex.
 They should return actionable guidance that points the user to `action:task-new`, `action:task-list`, or `action:task-switch` on the configured root command.
@@ -187,9 +207,10 @@ The expected variables are:
 - `CLAW_CODEX_NETWORK_ACCESS`
 - `CLAW_LOG_LEVEL`
 - `CLAW_LOG_FORMAT`
+- `CLAW_SCHEDULED_REPORT_CHANNEL_ID`
 
 `CLAW_MODE`, `CLAW_TIMEZONE`, `CLAW_DISCORD_TOKEN`, `CLAW_DISCORD_COMMAND_NAME`, `CLAW_CODEX_WORKDIR`, `CLAW_DATADIR`, and `CLAW_CODEX_EXECUTABLE` are required.
-`CLAW_DISCORD_GUILD_ID`, `CLAW_CODEX_BASE_URL`, `CLAW_CODEX_API_KEY`, `CLAW_CODEX_HOME`, `CLAW_CODEX_MODEL`, `CLAW_CODEX_SANDBOX_MODE`, `CLAW_CODEX_ADDITIONAL_DIRECTORIES`, `CLAW_CODEX_SKIP_GIT_REPO_CHECK`, `CLAW_CODEX_APPROVAL_POLICY`, `CLAW_CODEX_MODEL_REASONING_EFFORT`, `CLAW_CODEX_WEB_SEARCH_MODE`, `CLAW_CODEX_NETWORK_ACCESS`, `CLAW_LOG_LEVEL`, and `CLAW_LOG_FORMAT` are optional.
+`CLAW_DISCORD_GUILD_ID`, `CLAW_CODEX_BASE_URL`, `CLAW_CODEX_API_KEY`, `CLAW_CODEX_HOME`, `CLAW_CODEX_MODEL`, `CLAW_CODEX_SANDBOX_MODE`, `CLAW_CODEX_ADDITIONAL_DIRECTORIES`, `CLAW_CODEX_SKIP_GIT_REPO_CHECK`, `CLAW_CODEX_APPROVAL_POLICY`, `CLAW_CODEX_MODEL_REASONING_EFFORT`, `CLAW_CODEX_WEB_SEARCH_MODE`, `CLAW_CODEX_NETWORK_ACCESS`, `CLAW_LOG_LEVEL`, `CLAW_LOG_FORMAT`, and `CLAW_SCHEDULED_REPORT_CHANNEL_ID` are optional.
 `CLAW_MODE` accepts `daily` or `task`.
 `CLAW_TIMEZONE` must be set explicitly for each deployment.
 `CLAW_DISCORD_COMMAND_NAME` must be unique per bot instance, normalized to lowercase, and validated conservatively before Discord registration.
@@ -197,6 +218,7 @@ When `CLAW_CODEX_HOME` is set, 39claw must inject it into the spawned Codex CLI 
 When `CLAW_MODE=task`, `CLAW_CODEX_WORKDIR` must point to a Git repository with an `origin` remote and acts as the operator-visible source checkout plus validation target for task-mode startup.
 Task-mode startup and first-use preparation must maintain a managed bare parent repository under `${CLAW_DATADIR}/repos`, and task worktrees must be created from that managed parent rather than directly from the visible source checkout.
 When `CLAW_MODE=daily`, startup must materialize the managed durable-memory skill and the `AGENT_MEMORY` directory inside `CLAW_CODEX_WORKDIR`.
+When `CLAW_SCHEDULED_REPORT_CHANNEL_ID` is set, it becomes the default Discord report target for scheduled tasks that do not override the destination explicitly.
 `CLAW_LOG_LEVEL` defaults to `info` when omitted.
 When `CLAW_DISCORD_GUILD_ID` is set, slash commands are overwritten in that guild for faster development feedback.
 `CLAW_CODEX_SANDBOX_MODE` defaults to `workspace-write` when omitted.
@@ -250,6 +272,7 @@ Most of these outcomes should be proven through automated contract coverage plus
 - Invalid task-name format, missing tasks, closed tasks, and policy failures in one-shot override handling return explicit user-facing guidance instead of guessing a target.
 - Closed-task worktree retention keeps only the fifteen most recently closed ready worktrees and never deletes the task branches held by the managed bare parent.
 - Existing `daily` and `task` bindings survive process restart through SQLite-backed state.
+- Scheduled task definitions survive restart, execute at most once per claimed due time, and persist Discord delivery outcomes separately from Codex execution results.
 - Guild non-mention chatter is ignored, unsupported non-image-only qualifying posts stay silent, supported slash commands respond correctly, and long replies are chunked cleanly.
 - Simultaneous requests for the same logical thread do not execute overlapping Codex turns.
 - Simultaneous requests for the same logical thread receive queued acknowledgments and later deferred replies until the waiting queue reaches five items.

--- a/docs/exec-plans/active/18-scheduled-codex-tasks.md
+++ b/docs/exec-plans/active/18-scheduled-codex-tasks.md
@@ -1,0 +1,391 @@
+# Implement scheduled Codex tasks with MCP-managed definitions and runtime execution
+
+This ExecPlan is a living document. The sections `Progress`, `Surprises & Discoveries`, `Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work proceeds.
+
+This document must be maintained in accordance with `.agents/PLANS.md`.
+
+## Purpose / Big Picture
+
+After this plan, a 39claw operator should be able to start the bot, ask it in normal conversation to create a scheduled task, and then observe 39claw execute that task automatically on schedule and deliver the result to Discord. In `daily` mode, the scheduled run should execute directly in `CLAW_CODEX_WORKDIR`. In `task` mode, the scheduled run should execute in its own fresh temporary worktree that is created for that run and removed after the run finishes.
+
+The user-visible proof is concrete. A contributor should be able to run the bot with a test schedule, create a task through the Codex-visible management tools, wait for the due time, and observe a Discord delivery that names the scheduled task. The same contributor should also be able to inspect SQLite and see one canonical task definition, one admitted run record for the due occurrence, and a separate delivery record. If the bot runs in `task` mode, the contributor should be able to observe that the scheduled run used a temporary worktree that was cleaned up after completion.
+
+## Progress
+
+- [x] (2026-04-12 08:10Z) Reviewed `.agents/PLANS.md`, `docs/design-docs/scheduled-tasks.md`, `docs/product-specs/scheduled-tasks-user-flow.md`, and the current app/store/codex runtime shape to capture a self-contained implementation plan.
+- [ ] Prototype the Codex-visible management surface for scheduled tasks and record the exact managed `CODEX_HOME` layout required by the current Codex CLI.
+- [ ] Add configuration, SQLite schema, and store APIs for canonical scheduled-task definitions, run records, and delivery records.
+- [ ] Implement the local MCP server and managed bootstrap so Codex can list, inspect, create, update, enable, disable, and delete scheduled tasks through tools rather than by editing files.
+- [ ] Implement the scheduler loop, due-run admission, and fresh-thread execution path, including task-mode temporary worktree preparation and cleanup.
+- [ ] Implement Discord delivery for bot-initiated scheduled-run reports and record delivery outcomes separately from run outcomes.
+- [ ] Add automated coverage for schedule parsing, due admission, MCP management, task-mode temporary worktrees, and Discord delivery behavior.
+- [ ] Run `make test` and `make lint` after implementation lands.
+
+## Surprises & Discoveries
+
+- Observation: The repository already has strong infrastructure for thread bindings, active tasks, task worktree creation, and Discord reply delivery, but it has no scheduler loop, no scheduled-task persistence, and no local MCP server.
+  Evidence: `internal/app/message_service_impl.go`, `internal/app/task_workspace.go`, `internal/store/sqlite/store.go`, and the absence of any scheduled-task package under `internal/`.
+
+- Observation: The Codex gateway already reports `mcp_tool_call` progress events, which means the runtime can surface tool activity once a local MCP server exists, but the repository does not yet materialize any managed `CODEX_HOME` artifacts for tools.
+  Evidence: `internal/codex/gateway.go` handles `item.Type == "mcp_tool_call"`, while the only existing managed bootstrap is the daily-memory skill in `internal/dailymemory/bootstrap.go`.
+
+- Observation: `task` mode already owns the managed bare-parent and worktree lifecycle code for interactive tasks, but scheduled tasks intentionally must not reuse an interactive task worktree.
+  Evidence: `internal/app/task_workspace.go` and `docs/design-docs/scheduled-tasks.md`.
+
+## Decision Log
+
+- Decision: Implement scheduled-task management through a local MCP server exposed by the 39claw binary itself instead of through new slash commands.
+  Rationale: The product and design documents already define conversational management through Codex-mediated tools. A local MCP server keeps the implementation aligned with that product contract instead of creating a second management surface that would later need to be replaced.
+  Date/Author: 2026-04-12 / Codex
+
+- Decision: Add an optional instance-level default report target as `CLAW_SCHEDULED_REPORT_CHANNEL_ID`.
+  Rationale: The product spec says `report_channel_id` is optional per task and that omitted values should fall back to instance-level reporting behavior. A dedicated environment variable is the smallest explicit way to define that default without tying scheduled delivery to one user's last message context.
+  Date/Author: 2026-04-12 / Codex
+
+- Decision: In `task` mode, scheduled runs must create a fresh temporary worktree for the run and remove it after the run reaches a terminal result.
+  Rationale: This matches the current design note and prevents scheduled automation from borrowing or mutating an interactive task worktree that may belong to a different ongoing task context.
+  Date/Author: 2026-04-12 / Codex
+
+- Decision: A scheduled task may be created without an explicit `report_channel_id`, but enabling it requires a resolved report target from either the task definition or `CLAW_SCHEDULED_REPORT_CHANNEL_ID`.
+  Rationale: This preserves the product-visible small schema while preventing silently “successful” scheduled runs that have nowhere valid to report.
+  Date/Author: 2026-04-12 / Codex
+
+## Outcomes & Retrospective
+
+No implementation work has landed yet. The intended outcome is a complete scheduled-task feature that stays true to the existing Codex-native architecture: 39claw owns canonical definitions, due-run admission, Discord delivery, and local persistence; Codex owns interpreting user intent and executing the scheduled prompt; and the bot remains small enough that contributors can reason about the whole feature from one plan.
+
+The main risk area is the management surface. The repository already injects `CODEX_HOME` into the Codex CLI process, but it does not yet manage MCP server configuration. This plan deliberately addresses that risk first with a prototype milestone so the rest of the implementation is not built on an unverified assumption.
+
+## Context and Orientation
+
+39claw is a Go-based Discord bot. The current runtime receives Discord inputs, resolves a logical thread key, resumes or creates a Codex thread, and posts the result back to Discord. That user-driven path is implemented mostly in `internal/app/message_service_impl.go`, `internal/thread`, `internal/codex`, and `internal/runtime/discord`.
+
+Persistent state lives in SQLite through `internal/store/sqlite/store.go`. The current application schema supports thread bindings, daily sessions, tasks, and active-task selection. There is no existing scheduled-task table, no scheduler loop, and no bot-initiated delivery path that originates outside a Discord user message.
+
+The current task-mode worktree behavior matters because scheduled tasks add one more execution path. Interactive `task` mode already uses a managed bare parent repository and task worktrees under `CLAW_DATADIR`. Scheduled tasks must not reuse a user's interactive task worktree. Instead, when the bot runs in `task` mode, a scheduled run should create its own temporary worktree from the managed bare parent, execute the run there, and remove the worktree afterward.
+
+The most relevant current files are:
+
+- `docs/design-docs/scheduled-tasks.md`
+  - the implementation-facing design rules for canonical definitions, scheduler behavior, task-mode temporary worktrees, and Discord delivery separation
+- `docs/product-specs/scheduled-tasks-user-flow.md`
+  - the user-facing behavior that the implementation must satisfy
+- `cmd/39claw/main.go`
+  - the bot startup path, configuration loading, and dependency wiring
+- `internal/config/config.go`
+  - environment-variable loading and validation
+- `internal/app/types.go`
+  - the shared application data types such as `Task`, `ThreadBinding`, and `CodexTurnInput`
+- `internal/app/message_service_impl.go`
+  - the current user-message execution path and queue coordination
+- `internal/app/task_workspace.go`
+  - the managed bare-parent and worktree behavior that scheduled `task`-mode runs should reuse at a lower level
+- `internal/app/task_service.go`
+  - the existing task command workflow and task persistence touchpoints
+- `internal/codex/gateway.go` and `internal/codex/exec.go`
+  - the Codex CLI integration and per-turn working-directory override
+- `internal/store/sqlite/store.go`
+  - the current persistence implementation and migration-aware schema handling
+- `internal/runtime/discord`
+  - the Discord adapter that posts replies and command responses
+
+Terms used in this plan:
+
+A “scheduled task definition” is the canonical SQLite-backed record that stores the task name, schedule, prompt, enabled state, and optional per-task report channel override.
+
+A “scheduled run record” is the durable row that represents one admitted due occurrence. It is separate from the definition row so future runs and history can coexist safely.
+
+A “delivery record” is the durable row that records whether Discord delivery succeeded, failed, or was skipped. Delivery status must not overwrite the run status.
+
+A “managed `CODEX_HOME`” is a bot-owned directory that 39claw prepares for spawned Codex processes. The repository already supports passing `CODEX_HOME` to the Codex CLI through configuration. This plan extends that concept so scheduled-task management tools can be exposed through a local MCP server.
+
+A “temporary scheduled-run worktree” is the short-lived Git worktree used only for one scheduled run when the bot instance runs in `task` mode. It is distinct from any interactive task worktree and must be removed after the run reaches a terminal result.
+
+## Starting State
+
+Begin implementation only after confirming the repository still matches these assumptions:
+
+- there is no active scheduled-task implementation under `internal/`
+- `docs/design-docs/scheduled-tasks.md` and `docs/product-specs/scheduled-tasks-user-flow.md` describe the target behavior
+- `internal/app/task_workspace.go` still owns the managed bare-parent and task worktree logic for interactive task mode
+- `cmd/39claw/main.go` still injects `CODEX_HOME` into the spawned Codex environment when configured
+- `make test` and `make lint` pass before implementation begins
+
+Verify that state with:
+
+    cd <repository-root>
+    make test
+    make lint
+
+If any of these assumptions have drifted, update this ExecPlan first so it remains self-contained and truthful.
+
+## Preconditions
+
+This plan fixes the following implementation choices before coding begins:
+
+- scheduled tasks are stored in new SQLite tables instead of in repository files
+- management happens through a local MCP server invoked by Codex, not through new slash commands
+- the repository adds `CLAW_SCHEDULED_REPORT_CHANNEL_ID` as the optional instance default report target
+- the scheduler loop runs inside the 39claw process and participates in startup and shutdown
+- scheduled runs always use fresh Codex threads
+- `daily` mode scheduled runs execute directly in `CLAW_CODEX_WORKDIR`
+- `task` mode scheduled runs execute in fresh temporary worktrees created from the managed bare parent and removed afterward
+- delivery is recorded separately from execution
+- infrastructure-level failure may retry a due run once, but content-level “failure” is whatever Codex writes into the report
+
+## Milestone 1: Prove and document the Codex-visible management surface
+
+At the end of this milestone, a contributor should know exactly how 39claw exposes schedule-management tools to Codex and how the current Codex CLI discovers those tools through `CODEX_HOME`.
+
+Add a local MCP server entrypoint to the 39claw binary, for example a hidden subcommand such as `39claw mcp-scheduled-tasks`. That server should speak stdio and expose a minimal first tool such as `scheduled_tasks_list` backed by SQLite. The goal of this milestone is not the full feature. The goal is to prove the integration path end to end.
+
+Alongside that entrypoint, add a managed bootstrap helper that prepares a bot-owned `CODEX_HOME` directory under `CLAW_DATADIR` when scheduled tasks are enabled. That helper must materialize the exact Codex CLI configuration files or directory layout needed for the current CLI to discover the local MCP server. The contributor executing this plan must record the exact file paths and content shape back into this ExecPlan as soon as the prototype works, because the repository does not currently document this layout anywhere else.
+
+Validation for this milestone is practical. Run a small integration test or manual `codexplay` transcript that starts a Codex thread with the managed `CODEX_HOME`, triggers the prototype tool, and proves that the event stream contains an `mcp_tool_call` item. Do not move to Milestone 2 until this prototype path is working and documented in this plan.
+
+## Milestone 2: Add canonical persistence and management operations
+
+At the end of this milestone, the repository should have SQLite-backed scheduled-task definitions, run records, and delivery records, plus store methods that the MCP server can call directly.
+
+Add new migrations after the current latest version. Use one migration for the canonical definitions table and one migration for run and delivery history so the bootstrap logic stays easy to reason about. The new tables should cover:
+
+- `scheduled_tasks`
+  - stable ID
+  - unique instance-scoped name
+  - schedule kind
+  - schedule expression
+  - prompt
+  - enabled state
+  - nullable `report_channel_id`
+  - created and updated timestamps
+- `scheduled_task_runs`
+  - run ID
+  - scheduled task ID
+  - due time
+  - attempt number
+  - status such as `pending`, `running`, `succeeded`, `failed`, `canceled`
+  - fresh Codex thread ID when known
+  - terminal timestamps
+  - nullable working-directory evidence for debugging
+- `scheduled_task_deliveries`
+  - delivery ID
+  - run ID
+  - resolved target channel ID
+  - delivery status such as `pending`, `succeeded`, `failed`, `skipped`
+  - terminal timestamps
+  - error text when delivery fails
+
+Extend the store interface in `internal/app/message_service.go` or a nearby shared interface file with a focused scheduled-task store boundary rather than bloating `ThreadStore` further. Keep the names explicit: list tasks, get one task by ID or name, create, update, delete, admit due run, mark run started, finish run, record delivery, and query due tasks.
+
+Implement the full management operations in the MCP server on top of that store. These operations must validate task names, schedule syntax, prompt non-emptiness, and report-target rules. Enabling a task must fail when neither the task definition nor `CLAW_SCHEDULED_REPORT_CHANNEL_ID` resolves to a report target.
+
+## Milestone 3: Add scheduler loop and due-run admission
+
+At the end of this milestone, a running bot process should notice due scheduled tasks, admit each due occurrence once, and dispatch execution without depending on an incoming Discord message.
+
+Add a scheduler service under `internal/app` or a clearly named sibling package. That service should:
+
+- accept a clock abstraction so tests can drive time deterministically
+- parse `cron` schedules with a dedicated library such as `github.com/robfig/cron/v3`
+- parse one-shot `at` timestamps in the configured instance timezone using the Go standard library
+- poll or compute due tasks on a short cadence without a busy loop
+- admit each due occurrence exactly once using durable run-state checks in SQLite
+- dispatch the actual Codex execution through a separate run executor
+
+Keep the scheduler lifecycle explicit in `cmd/39claw/main.go`. Start it after store and Discord initialization succeed, and stop it during shutdown before canceling the shared runtime context. Reuse the repository’s current shutdown pattern so scheduled runs can finish or be canceled in a way that leaves clear run status behind.
+
+This milestone must also define the retry rule concretely. When a run fails for infrastructure reasons before a terminal Codex result exists, the scheduler may create exactly one retry attempt. The retry attempt must share the same logical due occurrence but have its own run row or attempt number so history stays auditable.
+
+## Milestone 4: Execute scheduled runs and integrate task-mode temporary worktrees
+
+At the end of this milestone, admitted scheduled runs should actually execute through the Codex gateway, using the correct working-directory rule for the current bot mode.
+
+Implement a scheduled-run executor that takes a due run, resolves its working directory, runs Codex in a fresh thread, captures the response, and records the terminal run status. Reuse the existing `CodexGateway` and `CodexTurnInput` path rather than creating a second Codex integration stack.
+
+For `daily` mode, scheduled runs should pass `CLAW_CODEX_WORKDIR` directly as the working directory.
+
+For `task` mode, scheduled runs must not call the interactive `TaskWorkspaceManager.EnsureReady` path with a fake user task. Instead, extract the lower-level managed bare-parent preparation logic from `internal/app/task_workspace.go` into a reusable helper that can do both of these things:
+
+- prepare or sync the managed bare parent for the configured source checkout
+- create a temporary worktree rooted at a caller-provided path and base ref
+
+Use that helper to create a scheduled-run worktree under a new path such as `${CLAW_DATADIR}/scheduled-worktrees/<run-id>`, execute the run there, and then remove the worktree after the run reaches a terminal result. The cleanup path must run on success and on handled failure, and it must leave a logged error plus durable run evidence when cleanup itself fails.
+
+This milestone must also record the exact prompt sent to Codex. The prompt should be the stored scheduled-task prompt, optionally prefixed with a small runtime-owned header that names the task and due time when that helps debugging, but it must stay small and deterministic.
+
+## Milestone 5: Deliver scheduled results to Discord
+
+At the end of this milestone, successful scheduled runs should appear in Discord with a clear task identity, and failed deliveries should be visible in durable delivery records.
+
+Add a small bot-initiated delivery boundary to the Discord runtime so the scheduler can send a message to a channel without a triggering user message. Keep this separate from the reply path used by `MessageService`. The delivery API should accept channel ID, rendered text, and enough metadata to log the task and run IDs.
+
+Resolve the target channel by this rule:
+
+1. use the task definition’s `report_channel_id` when present
+2. otherwise use `CLAW_SCHEDULED_REPORT_CHANNEL_ID`
+3. if neither exists, refuse to enable the task, or mark delivery as `skipped` only for legacy rows that predate the validation rule
+
+The message format does not need to be ornate, but it must be identifiable. Include the scheduled task name and enough context for a human to tell that the message came from a scheduled run rather than an interactive reply.
+
+## Milestone 6: Complete automated coverage and finalize the living document
+
+At the end of this milestone, the feature should be proven through tests, the plan should record what changed, and the repository should be ready to move this plan from `active/` to `completed/` after implementation is actually done.
+
+Add unit and integration coverage for:
+
+- schedule parsing and next-due computation
+- store CRUD and due-run admission idempotence
+- MCP management-tool handlers
+- managed `CODEX_HOME` bootstrap for the local MCP server
+- scheduler retry behavior
+- daily-mode working-directory selection
+- task-mode temporary scheduled-run worktree creation and cleanup
+- Discord delivery success and failure recording
+
+After implementation lands, update `Progress`, `Surprises & Discoveries`, `Decision Log`, and `Outcomes & Retrospective` with the real results and command outputs. Do not archive this plan until the full acceptance criteria below are satisfied.
+
+## Plan of Work
+
+Start with the integration risk, not the database. Build the smallest possible local MCP server and prove that Codex can see it through a managed `CODEX_HOME`. Once that path exists, the repository can safely commit to management-through-tools without guessing.
+
+Next, add the canonical scheduled-task persistence and keep the history tables separate from the definition table. This lets the scheduler, delivery layer, and management surface evolve independently without overloading one row with incompatible responsibilities.
+
+After persistence is in place, add the scheduler loop and a run executor that reuses the existing Codex gateway. Keep scheduled execution separate from interactive message handling: both paths may call the gateway, but only user messages go through `MessageService`.
+
+Then implement Discord delivery for bot-initiated reports and make delivery records explicit. A run that succeeded but could not be delivered must still count as an executed run.
+
+Finally, wire the task-mode temporary worktree path for scheduled runs by extracting the low-level managed bare-parent logic out of the existing interactive task workspace manager. Do not try to fake an interactive task row just to reuse the current API. Scheduled runs are instance-scoped automation, not hidden user tasks.
+
+## Concrete Steps
+
+Run all commands from the repository root.
+
+1. Confirm the baseline before implementation.
+
+    make test
+    make lint
+
+2. Prototype the MCP path.
+
+    go test ./internal/codex ./cmd/39claw -run 'Test.*Scheduled.*MCP|Test.*CodexHome' -v
+
+    Extend or add tests until there is concrete proof that a Codex thread launched by 39claw can see at least one scheduled-task management tool.
+
+3. Add migrations and store coverage.
+
+    go test ./internal/store/sqlite -run 'Test.*Scheduled' -v
+
+4. Add scheduler and runtime coverage.
+
+    go test ./internal/app ./internal/runtime/discord -run 'Test.*Scheduled' -v
+
+5. Run the full repository checks after the feature lands.
+
+    make test
+    make lint
+
+Expected command outcomes after implementation:
+
+    $ go test ./internal/store/sqlite -run 'Test.*Scheduled' -v
+    === RUN   TestScheduledTaskCRUD
+    --- PASS: TestScheduledTaskCRUD (0.00s)
+    === RUN   TestAdmitDueScheduledRunOnce
+    --- PASS: TestAdmitDueScheduledRunOnce (0.00s)
+    PASS
+
+    $ go test ./internal/app -run 'Test.*Scheduled' -v
+    === RUN   TestSchedulerDispatchesDueRun
+    --- PASS: TestSchedulerDispatchesDueRun (0.00s)
+    === RUN   TestTaskModeScheduledRunUsesTemporaryWorktree
+    --- PASS: TestTaskModeScheduledRunUsesTemporaryWorktree (0.01s)
+    PASS
+
+    $ make lint
+    0 issues.
+    Linting passed
+
+## Validation and Acceptance
+
+This plan is complete when all of the following are true:
+
+- a Codex conversation can manage scheduled tasks through 39claw-owned tools rather than by editing files directly
+- scheduled-task definitions persist in SQLite and survive restart
+- due occurrences are admitted once even across restart
+- scheduled runs always start fresh Codex threads
+- `daily` mode scheduled runs execute directly in `CLAW_CODEX_WORKDIR`
+- `task` mode scheduled runs execute in fresh temporary worktrees that are removed after completion
+- Discord delivery uses either the per-task `report_channel_id` or `CLAW_SCHEDULED_REPORT_CHANNEL_ID`
+- delivery status is recorded separately from execution status
+- infrastructure failure retries a due run once and records the retry clearly
+- `make test` passes
+- `make lint` passes
+
+The acceptance bar is behavioral. A contributor should be able to create a scheduled task, wait for it to fire, observe the Discord delivery, and inspect SQLite to confirm that definition state, run state, and delivery state were all recorded separately.
+
+## Idempotence and Recovery
+
+All schema changes must be additive and safe to rerun through the existing migration runner. A failed scheduled run must never delete the task definition. A failed Discord delivery must never retroactively mark the Codex run as failed. Temporary worktree cleanup in `task` mode is best-effort after the run reaches a terminal result; if cleanup fails, record the failure, leave the run result intact, and make the cleanup path safe to retry manually.
+
+The scheduler itself must be restart-safe. If the process exits after admitting a due run but before delivery completes, the next startup should inspect durable run state and avoid admitting the same due occurrence again while still allowing incomplete terminal transitions to be repaired or reported.
+
+## Artifacts and Notes
+
+The most important proof artifacts to capture during implementation are:
+
+- the exact managed `CODEX_HOME` layout needed for the local MCP server
+- a short event transcript showing an `mcp_tool_call` item for a scheduled-task management tool
+- SQLite test evidence that one due occurrence is admitted once
+- task-mode test evidence that a scheduled run creates and removes a temporary worktree under `${CLAW_DATADIR}/scheduled-worktrees/<run-id>`
+- Discord runtime evidence that delivery failure is recorded separately from run failure
+
+Example end-to-end behavior to preserve:
+
+    user asks the bot to create a scheduled task named "daily-ops" with a cron schedule
+    Codex uses a scheduled-task MCP tool to create it
+    SQLite stores one scheduled_tasks row
+    the scheduler admits the next due occurrence
+    Codex executes the prompt in a fresh thread
+    Discord receives a message that names "daily-ops"
+    SQLite stores one scheduled_task_runs row and one scheduled_task_deliveries row
+
+## Interfaces and Dependencies
+
+Implement the feature with these concrete interfaces and package directions:
+
+- in `internal/config/config.go`, add:
+
+    Config.ScheduledReportChannelID string
+
+  and load it from `CLAW_SCHEDULED_REPORT_CHANNEL_ID`.
+
+- in `internal/app/types.go`, add stable scheduled-task data types such as:
+
+    type ScheduledTask struct { ... }
+    type ScheduledTaskRun struct { ... }
+    type ScheduledTaskDelivery struct { ... }
+
+- define a focused scheduled-task store boundary, for example in `internal/app/message_service.go` or a new `internal/app/scheduled_interfaces.go`, with methods equivalent to:
+
+    CreateScheduledTask(ctx context.Context, task ScheduledTask) error
+    UpdateScheduledTask(ctx context.Context, task ScheduledTask) error
+    DeleteScheduledTask(ctx context.Context, taskID string) error
+    GetScheduledTask(ctx context.Context, taskID string) (ScheduledTask, bool, error)
+    ListScheduledTasks(ctx context.Context) ([]ScheduledTask, error)
+    ListDueScheduledTasks(ctx context.Context, now time.Time) ([]ScheduledTask, error)
+    AdmitScheduledRun(ctx context.Context, task ScheduledTask, dueAt time.Time) (ScheduledTaskRun, bool, error)
+    MarkScheduledRunStarted(ctx context.Context, run ScheduledTaskRun) error
+    FinishScheduledRun(ctx context.Context, run ScheduledTaskRun) error
+    RecordScheduledDelivery(ctx context.Context, delivery ScheduledTaskDelivery) error
+
+- in `cmd/39claw/main.go`, wire:
+
+  - scheduled-task store implementation
+  - local MCP server bootstrap
+  - scheduler service startup and shutdown
+  - bot-initiated Discord delivery helper
+
+- in `internal/app/task_workspace.go`, extract reusable managed-repository helpers so scheduled runs in `task` mode can create temporary worktrees without creating fake interactive tasks.
+
+- add `github.com/robfig/cron/v3` for cron parsing unless a simpler in-repository parser is introduced and documented here first.
+
+Revision note: Created on 2026-04-12 to lock the implementation approach for `docs/design-docs/scheduled-tasks.md` before feature work begins. The plan intentionally front-loads the local MCP integration proof because that is the main unresolved infrastructure dependency.

--- a/docs/exec-plans/index.md
+++ b/docs/exec-plans/index.md
@@ -25,7 +25,7 @@ Plans in this directory should be written and maintained in line with `.agents/P
 
 These plans are intended to be executed in the order listed below. Most plans follow numeric order, but infrastructure prerequisites may require picking up a later-numbered plan first when it explicitly prepares the repository for another active plan.
 
-- None currently.
+- [Implement scheduled Codex tasks with MCP-managed definitions and runtime execution](./active/18-scheduled-codex-tasks.md)
 
 ## Recently Completed Plans
 


### PR DESCRIPTION
## Summary

- add an active ExecPlan for implementing scheduled Codex tasks
- lock the implementation path for MCP-managed task definitions, runtime scheduling, Discord delivery, and task-mode temporary worktrees
- register the new active plan in the ExecPlans index

## Background

`docs/design-docs/scheduled-tasks.md` now defines the target design for scheduled Codex tasks, but the repository did not yet have a self-contained execution plan that explains how to implement that design end to end. This PR adds that living implementation plan so future work can proceed against one locked document instead of re-deciding the architecture during implementation.

## Related issue(s)

- None

## Implementation details

- add `docs/exec-plans/active/18-scheduled-codex-tasks.md`
- capture the implementation milestones for the local MCP server, managed `CODEX_HOME`, SQLite persistence, scheduler loop, Discord delivery, and task-mode temporary worktrees
- record the current assumptions, decisions, acceptance criteria, and validation steps needed to ship the feature safely
- update `docs/exec-plans/index.md` so the new plan appears in the active plans list

## Test coverage

- `make lint`
- `make test`

## Breaking changes

- None

## Notes

- This PR adds planning documentation only.

Created by Codex