### PR TITLE
[codex] generalize scheduled report targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -472,8 +472,9 @@ The first normal message for a new task may spend a moment preparing that task's
   - `disabled`, `cached`, or `live`
 - `CLAW_CODEX_NETWORK_ACCESS`
   - `true` or `false`
-- `CLAW_SCHEDULED_REPORT_CHANNEL_ID`
-  - default Discord channel used for scheduled-task reports when a task definition does not provide its own `report_channel_id`
+- `CLAW_SCHEDULED_REPORT_TARGET`
+  - default scheduled-task report target when a task definition does not provide its own `report_target`
+  - accepted formats are `channel:<id>` and `dm:<user_id>`
 
 ## Observability
 

--- a/cmd/39claw/main.go
+++ b/cmd/39claw/main.go
@@ -253,15 +253,15 @@ func run(ctx context.Context, lookupEnv func(string) (string, bool)) error {
 	}
 
 	scheduledTaskService, err := app.NewScheduledTaskService(app.ScheduledTaskServiceDependencies{
-		Mode:                   cfg.Mode,
-		Timezone:               cfg.Timezone,
-		Workdir:                cfg.CodexWorkdir,
-		DefaultReportChannelID: cfg.ScheduledReportChannelID,
-		Store:                  store,
-		Gateway:                gateway,
-		ReportSender:           runtime,
-		WorkspaceManager:       scheduledWorkspaceManager,
-		Logger:                 logger,
+		Mode:                cfg.Mode,
+		Timezone:            cfg.Timezone,
+		Workdir:             cfg.CodexWorkdir,
+		DefaultReportTarget: cfg.ScheduledReportTarget,
+		Store:               store,
+		Gateway:             gateway,
+		ReportSender:        runtime,
+		WorkspaceManager:    scheduledWorkspaceManager,
+		Logger:              logger,
 	})
 	if err != nil {
 		return fmt.Errorf("build scheduled task service: %w", err)
@@ -370,10 +370,10 @@ func startScheduledMCPServer(
 	logger *slog.Logger,
 ) (*scheduled.HTTPServer, string, error) {
 	server, err := scheduled.NewHTTPServer(scheduled.HTTPServerDependencies{
-		Store:                  store,
-		Timezone:               cfg.Timezone,
-		DefaultReportChannelID: cfg.ScheduledReportChannelID,
-		Logger:                 logger,
+		Store:               store,
+		Timezone:            cfg.Timezone,
+		DefaultReportTarget: cfg.ScheduledReportTarget,
+		Logger:              logger,
 	})
 	if err != nil {
 		return nil, "", fmt.Errorf("build scheduled MCP HTTP server: %w", err)

--- a/cmd/39claw/main_test.go
+++ b/cmd/39claw/main_test.go
@@ -494,9 +494,9 @@ func TestStartScheduledMCPServerLogsURL(t *testing.T) {
 		context.Background(),
 		noopScheduledTaskStore{},
 		config.Config{
-			Mode:                     config.ModeTask,
-			Timezone:                 location,
-			ScheduledReportChannelID: "1234567890",
+			Mode:                  config.ModeTask,
+			Timezone:              location,
+			ScheduledReportTarget: "channel:1234567890",
 		},
 		logger,
 	)
@@ -535,7 +535,7 @@ func (r *stubDiscordRuntime) Close() error {
 	return nil
 }
 
-func (r *stubDiscordRuntime) SendScheduledReport(ctx context.Context, channelID string, text string) (string, error) {
+func (r *stubDiscordRuntime) SendScheduledReport(ctx context.Context, reportTarget string, text string) (string, error) {
 	return "scheduled-message", nil
 }
 

--- a/docs/design-docs/implementation-spec.md
+++ b/docs/design-docs/implementation-spec.md
@@ -106,14 +106,14 @@ The storage model uses seven tables:
   - stores `discord_user_id`, `task_id`, and `updated_at`
   - enforces one active task per Discord user within a bot instance
 - `scheduled_task_definitions`
-  - stores `scheduled_task_id`, `name`, `mode`, `schedule_kind`, `schedule_expr`, `prompt`, nullable `task_prompt_prefix`, `report_channel_id`, `is_enabled`, `last_claimed_at`, `last_scheduled_for`, `created_at`, `updated_at`, and nullable `disabled_at`
+  - stores `scheduled_task_id`, `name`, `mode`, `schedule_kind`, `schedule_expr`, `prompt`, nullable `task_prompt_prefix`, `report_target`, `is_enabled`, `last_claimed_at`, `last_scheduled_for`, `created_at`, `updated_at`, and nullable `disabled_at`
   - uses ULID strings for `scheduled_task_id`
   - stores the canonical schedule definition that 39claw owns locally
 - `scheduled_task_runs`
   - stores `scheduled_run_id`, `scheduled_task_id`, `mode`, `scheduled_for`, `status`, nullable `codex_thread_id`, nullable `workdir_path`, nullable `temp_worktree_path`, nullable `started_at`, nullable `finished_at`, nullable `error_code`, nullable `error_message`, `created_at`, and `updated_at`
   - records each scheduled execution attempt before Codex dispatch begins
 - `scheduled_task_deliveries`
-  - stores `scheduled_delivery_id`, `scheduled_run_id`, `discord_channel_id`, nullable `discord_message_id`, `status`, nullable `delivered_at`, nullable `error_code`, nullable `error_message`, `created_at`, and `updated_at`
+  - stores `scheduled_delivery_id`, `scheduled_run_id`, `report_target`, nullable `discord_message_id`, `status`, nullable `delivered_at`, nullable `error_code`, nullable `error_message`, `created_at`, and `updated_at`
   - tracks whether a completed run report reached Discord successfully
 
 Task status is `open` or `closed`.
@@ -207,10 +207,10 @@ The expected variables are:
 - `CLAW_CODEX_NETWORK_ACCESS`
 - `CLAW_LOG_LEVEL`
 - `CLAW_LOG_FORMAT`
-- `CLAW_SCHEDULED_REPORT_CHANNEL_ID`
+- `CLAW_SCHEDULED_REPORT_TARGET`
 
 `CLAW_MODE`, `CLAW_TIMEZONE`, `CLAW_DISCORD_TOKEN`, `CLAW_DISCORD_COMMAND_NAME`, `CLAW_CODEX_WORKDIR`, `CLAW_DATADIR`, and `CLAW_CODEX_EXECUTABLE` are required.
-`CLAW_DISCORD_GUILD_ID`, `CLAW_CODEX_BASE_URL`, `CLAW_CODEX_API_KEY`, `CLAW_CODEX_HOME`, `CLAW_CODEX_MODEL`, `CLAW_CODEX_SANDBOX_MODE`, `CLAW_CODEX_ADDITIONAL_DIRECTORIES`, `CLAW_CODEX_SKIP_GIT_REPO_CHECK`, `CLAW_CODEX_APPROVAL_POLICY`, `CLAW_CODEX_MODEL_REASONING_EFFORT`, `CLAW_CODEX_WEB_SEARCH_MODE`, `CLAW_CODEX_NETWORK_ACCESS`, `CLAW_LOG_LEVEL`, `CLAW_LOG_FORMAT`, and `CLAW_SCHEDULED_REPORT_CHANNEL_ID` are optional.
+`CLAW_DISCORD_GUILD_ID`, `CLAW_CODEX_BASE_URL`, `CLAW_CODEX_API_KEY`, `CLAW_CODEX_HOME`, `CLAW_CODEX_MODEL`, `CLAW_CODEX_SANDBOX_MODE`, `CLAW_CODEX_ADDITIONAL_DIRECTORIES`, `CLAW_CODEX_SKIP_GIT_REPO_CHECK`, `CLAW_CODEX_APPROVAL_POLICY`, `CLAW_CODEX_MODEL_REASONING_EFFORT`, `CLAW_CODEX_WEB_SEARCH_MODE`, `CLAW_CODEX_NETWORK_ACCESS`, `CLAW_LOG_LEVEL`, `CLAW_LOG_FORMAT`, and `CLAW_SCHEDULED_REPORT_TARGET` are optional.
 `CLAW_MODE` accepts `daily` or `task`.
 `CLAW_TIMEZONE` must be set explicitly for each deployment.
 `CLAW_DISCORD_COMMAND_NAME` must be unique per bot instance, normalized to lowercase, and validated conservatively before Discord registration.
@@ -218,7 +218,7 @@ When `CLAW_CODEX_HOME` is set, 39claw must inject it into the spawned Codex CLI 
 When `CLAW_MODE=task`, `CLAW_CODEX_WORKDIR` must point to a Git repository with an `origin` remote and acts as the operator-visible source checkout plus validation target for task-mode startup.
 Task-mode startup and first-use preparation must maintain a managed bare parent repository under `${CLAW_DATADIR}/repos`, and task worktrees must be created from that managed parent rather than directly from the visible source checkout.
 When `CLAW_MODE=daily`, startup must materialize the managed durable-memory skill and the `AGENT_MEMORY` directory inside `CLAW_CODEX_WORKDIR`.
-When `CLAW_SCHEDULED_REPORT_CHANNEL_ID` is set, it becomes the default Discord report target for scheduled tasks that do not override the destination explicitly.
+When `CLAW_SCHEDULED_REPORT_TARGET` is set, it becomes the default report target for scheduled tasks that do not override the destination explicitly. Accepted formats are `channel:<id>` and `dm:<user_id>`.
 `CLAW_LOG_LEVEL` defaults to `info` when omitted.
 When `CLAW_DISCORD_GUILD_ID` is set, slash commands are overwritten in that guild for faster development feedback.
 `CLAW_CODEX_SANDBOX_MODE` defaults to `workspace-write` when omitted.

--- a/docs/design-docs/scheduled-tasks.md
+++ b/docs/design-docs/scheduled-tasks.md
@@ -98,8 +98,8 @@ The scheduled-task definition should stay intentionally small.
   - the Codex instruction body for the scheduled run
 - `enabled`
   - whether future due times should be admitted
-- `report_channel_id`
-  - optional Discord channel override for delivery
+- `report_target`
+  - optional delivery override in the form `channel:<id>` or `dm:<user_id>`
 - `created_at`
 - `updated_at`
 
@@ -282,7 +282,7 @@ Scheduled output should be delivered through the existing presentation layer rat
 
 The report-target rule is:
 
-- use `report_channel_id` when the task defines one
+- use `report_target` when the task defines one
 - otherwise use the instance default scheduled-task reporting behavior
 
 The exact message template can stay product-facing, but the design should preserve a few invariants:

--- a/docs/exec-plans/active/18-scheduled-codex-tasks.md
+++ b/docs/exec-plans/active/18-scheduled-codex-tasks.md
@@ -14,7 +14,7 @@ The user-visible proof is concrete. A contributor should be able to run the bot 
 
 - [x] (2026-04-12 08:10Z) Reviewed `.agents/PLANS.md`, `docs/design-docs/scheduled-tasks.md`, `docs/product-specs/scheduled-tasks-user-flow.md`, and the current app/store/codex runtime shape to capture a self-contained implementation plan.
 - [x] (2026-04-12 08:40Z) Added the scheduled-task MCP tool surface and recorded the per-run Codex `--config` override used to register it.
-- [x] (2026-04-12 08:42Z) Added `CLAW_SCHEDULED_REPORT_CHANNEL_ID`, SQLite migrations `0004_scheduled_tasks.sql` and `0005_scheduled_task_history.sql`, and store APIs for scheduled-task definitions, runs, and deliveries.
+- [x] (2026-04-12 08:42Z) Added the instance-level scheduled report target setting, SQLite migrations `0004_scheduled_tasks.sql` and `0005_scheduled_task_history.sql`, and store APIs for scheduled-task definitions, runs, and deliveries.
 - [x] (2026-04-12 08:44Z) Implemented per-run MCP config injection plus MCP-backed create, list, get, update, enable, disable, and delete operations for scheduled tasks.
 - [x] (2026-04-12 08:47Z) Implemented the scheduler loop, due-run admission, fresh-thread execution path, and task-mode temporary scheduled-run worktree creation and cleanup.
 - [x] (2026-04-12 08:48Z) Implemented bot-initiated Discord report delivery and stored delivery outcomes separately from run outcomes.
@@ -47,15 +47,15 @@ The user-visible proof is concrete. A contributor should be able to run the bot 
   Rationale: The product and design documents already define conversational management through Codex-mediated tools. A local MCP server keeps the implementation aligned with that product contract instead of creating a second management surface that would later need to be replaced.
   Date/Author: 2026-04-12 / Codex
 
-- Decision: Add an optional instance-level default report target as `CLAW_SCHEDULED_REPORT_CHANNEL_ID`.
-  Rationale: The product spec says `report_channel_id` is optional per task and that omitted values should fall back to instance-level reporting behavior. A dedicated environment variable is the smallest explicit way to define that default without tying scheduled delivery to one user's last message context.
+- Decision: Add an optional instance-level default report target as `CLAW_SCHEDULED_REPORT_TARGET`.
+  Rationale: The product spec says `report_target` is optional per task and that omitted values should fall back to instance-level reporting behavior. A dedicated environment variable is the smallest explicit way to define that default without tying scheduled delivery to one user's last message context.
   Date/Author: 2026-04-12 / Codex
 
 - Decision: In `task` mode, scheduled runs must create a fresh temporary worktree for the run and remove it after the run reaches a terminal result.
   Rationale: This matches the current design note and prevents scheduled automation from borrowing or mutating an interactive task worktree that may belong to a different ongoing task context.
   Date/Author: 2026-04-12 / Codex
 
-- Decision: A scheduled task may be created without an explicit `report_channel_id`, but enabling it requires a resolved report target from either the task definition or `CLAW_SCHEDULED_REPORT_CHANNEL_ID`.
+- Decision: A scheduled task may be created without an explicit `report_target`, but enabling it requires a resolved report target from either the task definition or `CLAW_SCHEDULED_REPORT_TARGET`.
   Rationale: This preserves the product-visible small schema while preventing silently “successful” scheduled runs that have nowhere valid to report.
   Date/Author: 2026-04-12 / Codex
 
@@ -138,7 +138,7 @@ This plan fixes the following implementation choices before coding begins:
 
 - scheduled tasks are stored in new SQLite tables instead of in repository files
 - management happens through a local MCP server invoked by Codex, not through new slash commands
-- the repository adds `CLAW_SCHEDULED_REPORT_CHANNEL_ID` as the optional instance default report target
+- the repository adds `CLAW_SCHEDULED_REPORT_TARGET` as the optional instance default report target
 - the scheduler loop runs inside the 39claw process and participates in startup and shutdown
 - scheduled runs always use fresh Codex threads
 - `daily` mode scheduled runs execute directly in `CLAW_CODEX_WORKDIR`
@@ -169,7 +169,7 @@ Add new migrations after the current latest version. Use one migration for the c
   - schedule expression
   - prompt
   - enabled state
-  - nullable `report_channel_id`
+  - nullable `report_target`
   - created and updated timestamps
 - `scheduled_task_runs`
   - run ID
@@ -190,7 +190,7 @@ Add new migrations after the current latest version. Use one migration for the c
 
 Extend the store interface in `internal/app/message_service.go` or a nearby shared interface file with a focused scheduled-task store boundary rather than bloating `ThreadStore` further. Keep the names explicit: list tasks, get one task by ID or name, create, update, delete, admit due run, mark run started, finish run, record delivery, and query due tasks.
 
-Implement the full management operations in the MCP server on top of that store. These operations must validate task names, schedule syntax, prompt non-emptiness, and report-target rules. Enabling a task must fail when neither the task definition nor `CLAW_SCHEDULED_REPORT_CHANNEL_ID` resolves to a report target.
+Implement the full management operations in the MCP server on top of that store. These operations must validate task names, schedule syntax, prompt non-emptiness, and report-target rules. Enabling a task must fail when neither the task definition nor `CLAW_SCHEDULED_REPORT_TARGET` resolves to a report target.
 
 ## Milestone 3: Add scheduler loop and due-run admission
 
@@ -234,8 +234,8 @@ Add a small bot-initiated delivery boundary to the Discord runtime so the schedu
 
 Resolve the target channel by this rule:
 
-1. use the task definition’s `report_channel_id` when present
-2. otherwise use `CLAW_SCHEDULED_REPORT_CHANNEL_ID`
+1. use the task definition’s `report_target` when present
+2. otherwise use `CLAW_SCHEDULED_REPORT_TARGET`
 3. if neither exists, refuse to enable the task, or mark delivery as `skipped` only for legacy rows that predate the validation rule
 
 The message format does not need to be ornate, but it must be identifiable. Include the scheduled task name and enough context for a human to tell that the message came from a scheduled run rather than an interactive reply.
@@ -327,7 +327,7 @@ This plan is complete when all of the following are true:
 - scheduled runs always start fresh Codex threads
 - `daily` mode scheduled runs execute directly in `CLAW_CODEX_WORKDIR`
 - `task` mode scheduled runs execute in fresh temporary worktrees that are removed after completion
-- Discord delivery uses either the per-task `report_channel_id` or `CLAW_SCHEDULED_REPORT_CHANNEL_ID`
+- Discord delivery uses either the per-task `report_target` or `CLAW_SCHEDULED_REPORT_TARGET`
 - delivery status is recorded separately from execution status
 - infrastructure failure retries a due run once and records the retry clearly
 - `make test` passes
@@ -367,9 +367,9 @@ Implement the feature with these concrete interfaces and package directions:
 
 - in `internal/config/config.go`, add:
 
-    Config.ScheduledReportChannelID string
+    Config.ScheduledReportTarget string
 
-  and load it from `CLAW_SCHEDULED_REPORT_CHANNEL_ID`.
+  and load it from `CLAW_SCHEDULED_REPORT_TARGET`.
 
 - in `internal/app/types.go`, add stable scheduled-task data types such as:
 

--- a/docs/product-specs/scheduled-tasks-user-flow.md
+++ b/docs/product-specs/scheduled-tasks-user-flow.md
@@ -140,7 +140,7 @@ The minimum product-visible fields are:
 
 Optional field:
 
-- `report_channel_id`
+- `report_target`
 
 There is no separate per-task policy surface in v1.
 Scheduled tasks inherit the same effective permission model as normal message-driven Codex execution.
@@ -253,7 +253,7 @@ Expected user perception:
 
 Expected flow:
 
-1. The task definition includes `report_channel_id`.
+1. The task definition includes `report_target`.
 2. The task runs on schedule.
 3. 39claw delivers the output to the configured Discord report target for that task.
 
@@ -266,7 +266,7 @@ Expected user perception:
 
 Expected flow:
 
-1. The task definition omits `report_channel_id`.
+1. The task definition omits `report_target`.
 2. The task runs on schedule.
 3. 39claw delivers the output using the instance-level reporting behavior.
 

--- a/internal/app/scheduled_report_target.go
+++ b/internal/app/scheduled_report_target.go
@@ -1,0 +1,46 @@
+package app
+
+import (
+	"fmt"
+	"strings"
+)
+
+type ScheduledReportTargetKind string
+
+const (
+	ScheduledReportTargetKindChannel ScheduledReportTargetKind = "channel"
+	ScheduledReportTargetKindDM      ScheduledReportTargetKind = "dm"
+)
+
+type ScheduledReportTarget struct {
+	Kind ScheduledReportTargetKind
+	ID   string
+}
+
+func ParseScheduledReportTarget(raw string) (ScheduledReportTarget, error) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return ScheduledReportTarget{}, fmt.Errorf("scheduled report target must not be empty")
+	}
+
+	kind, id, ok := strings.Cut(trimmed, ":")
+	if !ok {
+		return ScheduledReportTarget{}, fmt.Errorf("scheduled report target must use channel:<id> or dm:<user_id>")
+	}
+
+	normalizedKind := ScheduledReportTargetKind(strings.ToLower(strings.TrimSpace(kind)))
+	normalizedID := strings.TrimSpace(id)
+	if normalizedID == "" {
+		return ScheduledReportTarget{}, fmt.Errorf("scheduled report target id must not be empty")
+	}
+
+	switch normalizedKind {
+	case ScheduledReportTargetKindChannel, ScheduledReportTargetKindDM:
+		return ScheduledReportTarget{
+			Kind: normalizedKind,
+			ID:   normalizedID,
+		}, nil
+	default:
+		return ScheduledReportTarget{}, fmt.Errorf("scheduled report target kind must be channel or dm")
+	}
+}

--- a/internal/app/scheduled_schedule.go
+++ b/internal/app/scheduled_schedule.go
@@ -51,7 +51,7 @@ func ParseScheduledTaskSchedule(task ScheduledTask, location *time.Location) (Pa
 	}
 }
 
-func ValidateScheduledTaskDefinition(task ScheduledTask, location *time.Location, defaultReportChannelID string) error {
+func ValidateScheduledTaskDefinition(task ScheduledTask, location *time.Location, defaultReportTarget string) error {
 	name := strings.TrimSpace(task.Name)
 	if name == "" {
 		return fmt.Errorf("scheduled task name must not be empty")
@@ -69,19 +69,31 @@ func ValidateScheduledTaskDefinition(task ScheduledTask, location *time.Location
 		return err
 	}
 
-	if task.Enabled && ResolveScheduledTaskReportChannel(task, defaultReportChannelID) == "" {
-		return fmt.Errorf("enabled scheduled tasks require report_channel_id or CLAW_SCHEDULED_REPORT_CHANNEL_ID")
+	if reportTarget := strings.TrimSpace(task.ReportTarget); reportTarget != "" {
+		if _, err := ParseScheduledReportTarget(reportTarget); err != nil {
+			return fmt.Errorf("invalid report_target: %w", err)
+		}
+	}
+
+	resolvedReportTarget := ResolveScheduledTaskReportTarget(task, defaultReportTarget)
+	if task.Enabled && resolvedReportTarget == "" {
+		return fmt.Errorf("enabled scheduled tasks require report_target or CLAW_SCHEDULED_REPORT_TARGET")
+	}
+	if task.Enabled {
+		if _, err := ParseScheduledReportTarget(resolvedReportTarget); err != nil {
+			return fmt.Errorf("invalid resolved report target: %w", err)
+		}
 	}
 
 	return nil
 }
 
-func ResolveScheduledTaskReportChannel(task ScheduledTask, defaultReportChannelID string) string {
-	if reportChannelID := strings.TrimSpace(task.ReportChannelID); reportChannelID != "" {
-		return reportChannelID
+func ResolveScheduledTaskReportTarget(task ScheduledTask, defaultReportTarget string) string {
+	if reportTarget := strings.TrimSpace(task.ReportTarget); reportTarget != "" {
+		return reportTarget
 	}
 
-	return strings.TrimSpace(defaultReportChannelID)
+	return strings.TrimSpace(defaultReportTarget)
 }
 
 func ParseScheduledTaskAt(expr string, location *time.Location) (time.Time, error) {

--- a/internal/app/scheduled_schedule_test.go
+++ b/internal/app/scheduled_schedule_test.go
@@ -68,7 +68,27 @@ func TestValidateScheduledTaskDefinitionRequiresReportTargetWhenEnabled(t *testi
 		ScheduleExpr: "0 9 * * *",
 		Prompt:       "Write the report.",
 		Enabled:      true,
-	}, location, "12345"); err != nil {
-		t.Fatalf("ValidateScheduledTaskDefinition() with default report channel error = %v", err)
+	}, location, "channel:12345"); err != nil {
+		t.Fatalf("ValidateScheduledTaskDefinition() with default report target error = %v", err)
+	}
+}
+
+func TestValidateScheduledTaskDefinitionRejectsInvalidReportTarget(t *testing.T) {
+	t.Parallel()
+
+	location, err := time.LoadLocation("Asia/Tokyo")
+	if err != nil {
+		t.Fatalf("LoadLocation() error = %v", err)
+	}
+
+	err = ValidateScheduledTaskDefinition(ScheduledTask{
+		Name:         "Daily report",
+		ScheduleKind: ScheduledTaskScheduleKindCron,
+		ScheduleExpr: "0 9 * * *",
+		Prompt:       "Write the report.",
+		ReportTarget: "mail:user-1",
+	}, location, "")
+	if err == nil {
+		t.Fatal("ValidateScheduledTaskDefinition() error = nil, want invalid report target error")
 	}
 }

--- a/internal/app/scheduled_task_service.go
+++ b/internal/app/scheduled_task_service.go
@@ -20,37 +20,37 @@ const (
 )
 
 type ScheduledTaskServiceDependencies struct {
-	Mode                   config.Mode
-	Timezone               *time.Location
-	Workdir                string
-	DefaultReportChannelID string
-	Store                  ScheduledTaskStore
-	Gateway                CodexGateway
-	ReportSender           ScheduledTaskReportSender
-	WorkspaceManager       ScheduledTaskWorkspaceManager
-	Logger                 *slog.Logger
-	TickInterval           time.Duration
-	Now                    func() time.Time
-	StartedAt              time.Time
-	NewRunID               func() string
-	NewDeliveryID          func() string
+	Mode                config.Mode
+	Timezone            *time.Location
+	Workdir             string
+	DefaultReportTarget string
+	Store               ScheduledTaskStore
+	Gateway             CodexGateway
+	ReportSender        ScheduledTaskReportSender
+	WorkspaceManager    ScheduledTaskWorkspaceManager
+	Logger              *slog.Logger
+	TickInterval        time.Duration
+	Now                 func() time.Time
+	StartedAt           time.Time
+	NewRunID            func() string
+	NewDeliveryID       func() string
 }
 
 type ScheduledTaskService struct {
-	mode                   config.Mode
-	timezone               *time.Location
-	workdir                string
-	defaultReportChannelID string
-	store                  ScheduledTaskStore
-	gateway                CodexGateway
-	reportSender           ScheduledTaskReportSender
-	workspaceManager       ScheduledTaskWorkspaceManager
-	logger                 *slog.Logger
-	tickInterval           time.Duration
-	now                    func() time.Time
-	newRunID               func() string
-	newDeliveryID          func() string
-	startedAt              time.Time
+	mode                config.Mode
+	timezone            *time.Location
+	workdir             string
+	defaultReportTarget string
+	store               ScheduledTaskStore
+	gateway             CodexGateway
+	reportSender        ScheduledTaskReportSender
+	workspaceManager    ScheduledTaskWorkspaceManager
+	logger              *slog.Logger
+	tickInterval        time.Duration
+	now                 func() time.Time
+	newRunID            func() string
+	newDeliveryID       func() string
+	startedAt           time.Time
 
 	mu      sync.Mutex
 	cancel  context.CancelFunc
@@ -110,20 +110,20 @@ func NewScheduledTaskService(deps ScheduledTaskServiceDependencies) (*ScheduledT
 	}
 
 	return &ScheduledTaskService{
-		mode:                   deps.Mode,
-		timezone:               deps.Timezone,
-		workdir:                deps.Workdir,
-		defaultReportChannelID: deps.DefaultReportChannelID,
-		store:                  deps.Store,
-		gateway:                deps.Gateway,
-		reportSender:           deps.ReportSender,
-		workspaceManager:       deps.WorkspaceManager,
-		logger:                 logger,
-		tickInterval:           tickInterval,
-		now:                    now,
-		startedAt:              startedAt,
-		newRunID:               newRunID,
-		newDeliveryID:          newDeliveryID,
+		mode:                deps.Mode,
+		timezone:            deps.Timezone,
+		workdir:             deps.Workdir,
+		defaultReportTarget: deps.DefaultReportTarget,
+		store:               deps.Store,
+		gateway:             deps.Gateway,
+		reportSender:        deps.ReportSender,
+		workspaceManager:    deps.WorkspaceManager,
+		logger:              logger,
+		tickInterval:        tickInterval,
+		now:                 now,
+		startedAt:           startedAt,
+		newRunID:            newRunID,
+		newDeliveryID:       newDeliveryID,
 	}, nil
 }
 
@@ -520,26 +520,26 @@ func isCancellationError(err error) bool {
 }
 
 func (s *ScheduledTaskService) deliverRunResult(ctx context.Context, task ScheduledTask, run ScheduledTaskRun) {
-	channelID := ResolveScheduledTaskReportChannel(task, s.defaultReportChannelID)
+	reportTarget := ResolveScheduledTaskReportTarget(task, s.defaultReportTarget)
 	deliveryLogger := s.logger.With(
 		"task", task.Name,
 		"task_id", task.ScheduledTaskID,
 		"run_id", run.ScheduledRunID,
-		"channel_id", channelID,
+		"report_target", reportTarget,
 	)
 	delivery := ScheduledTaskDelivery{
 		ScheduledDeliveryID: s.newDeliveryID(),
 		ScheduledRunID:      run.ScheduledRunID,
-		DiscordChannelID:    channelID,
+		ReportTarget:        reportTarget,
 		Status:              ScheduledTaskDeliveryStatusPending,
 	}
 
-	if channelID == "" {
+	if reportTarget == "" {
 		now := s.now()
 		delivery.Status = ScheduledTaskDeliveryStatusSkipped
 		delivery.DeliveredAt = &now
-		delivery.ErrorCode = "missing_report_channel"
-		delivery.ErrorMessage = "scheduled task does not resolve to a report channel"
+		delivery.ErrorCode = "missing_report_target"
+		delivery.ErrorMessage = "scheduled task does not resolve to a report target"
 		if err := s.store.CreateScheduledTaskDelivery(ctx, delivery); err != nil {
 			deliveryLogger.Error("record skipped scheduled task delivery", "error", err)
 		}
@@ -553,7 +553,7 @@ func (s *ScheduledTaskService) deliverRunResult(ctx context.Context, task Schedu
 	}
 	deliveryLogger.Info("scheduled task delivery started")
 
-	messageID, err := s.reportSender.SendScheduledReport(ctx, channelID, formatScheduledReport(task, run))
+	messageID, err := s.reportSender.SendScheduledReport(ctx, reportTarget, formatScheduledReport(task, run))
 	now := s.now()
 	delivery.DeliveredAt = &now
 	delivery.UpdatedAt = now

--- a/internal/app/scheduled_task_service_test.go
+++ b/internal/app/scheduled_task_service_test.go
@@ -38,14 +38,14 @@ func TestScheduledTaskServiceTickExecutesAndDeliversDueRun(t *testing.T) {
 	gateway := &fakeScheduledGateway{}
 
 	service, err := NewScheduledTaskService(ScheduledTaskServiceDependencies{
-		Mode:                   config.ModeDaily,
-		Timezone:               location,
-		Workdir:                "/workspace/project",
-		DefaultReportChannelID: "channel-1",
-		Store:                  store,
-		Gateway:                gateway,
-		ReportSender:           &fakeScheduledReportSender{},
-		Logger:                 nil,
+		Mode:                config.ModeDaily,
+		Timezone:            location,
+		Workdir:             "/workspace/project",
+		DefaultReportTarget: "channel:channel-1",
+		Store:               store,
+		Gateway:             gateway,
+		ReportSender:        &fakeScheduledReportSender{},
+		Logger:              nil,
 		Now: func() time.Time {
 			return time.Date(2026, time.April, 12, 8, 1, 0, 0, location)
 		},
@@ -82,8 +82,8 @@ func TestScheduledTaskServiceTickExecutesAndDeliversDueRun(t *testing.T) {
 	if delivery.Status != ScheduledTaskDeliveryStatusSucceeded {
 		t.Fatalf("delivery status = %q, want %q", delivery.Status, ScheduledTaskDeliveryStatusSucceeded)
 	}
-	if delivery.DiscordChannelID != "channel-1" {
-		t.Fatalf("delivery channel = %q, want %q", delivery.DiscordChannelID, "channel-1")
+	if delivery.ReportTarget != "channel:channel-1" {
+		t.Fatalf("delivery report target = %q, want %q", delivery.ReportTarget, "channel:channel-1")
 	}
 	if gateway.runCount() != 1 {
 		t.Fatalf("gateway run count = %d, want %d", gateway.runCount(), 1)
@@ -114,13 +114,13 @@ func TestScheduledTaskServiceTickSkipsBackfillBeforeServiceStart(t *testing.T) {
 	gateway := &fakeScheduledGateway{}
 
 	service, err := NewScheduledTaskService(ScheduledTaskServiceDependencies{
-		Mode:                   config.ModeDaily,
-		Timezone:               location,
-		Workdir:                "/workspace/project",
-		DefaultReportChannelID: "channel-1",
-		Store:                  store,
-		Gateway:                gateway,
-		ReportSender:           &fakeScheduledReportSender{},
+		Mode:                config.ModeDaily,
+		Timezone:            location,
+		Workdir:             "/workspace/project",
+		DefaultReportTarget: "channel:channel-1",
+		Store:               store,
+		Gateway:             gateway,
+		ReportSender:        &fakeScheduledReportSender{},
 		Now: func() time.Time {
 			return time.Date(2026, time.April, 12, 8, 3, 40, 0, location)
 		},
@@ -177,13 +177,13 @@ func TestScheduledTaskServiceTickUsesLatestRunAsAnchor(t *testing.T) {
 	gateway := &fakeScheduledGateway{}
 
 	service, err := NewScheduledTaskService(ScheduledTaskServiceDependencies{
-		Mode:                   config.ModeDaily,
-		Timezone:               location,
-		Workdir:                "/workspace/project",
-		DefaultReportChannelID: "channel-1",
-		Store:                  store,
-		Gateway:                gateway,
-		ReportSender:           &fakeScheduledReportSender{},
+		Mode:                config.ModeDaily,
+		Timezone:            location,
+		Workdir:             "/workspace/project",
+		DefaultReportTarget: "channel:channel-1",
+		Store:               store,
+		Gateway:             gateway,
+		ReportSender:        &fakeScheduledReportSender{},
 		Now: func() time.Time {
 			return time.Date(2026, time.April, 12, 8, 4, 0, 0, location)
 		},
@@ -235,14 +235,14 @@ func TestScheduledTaskServiceExecuteTaskNowRunsImmediately(t *testing.T) {
 	reportSender := &fakeScheduledReportSender{}
 
 	service, err := NewScheduledTaskService(ScheduledTaskServiceDependencies{
-		Mode:                   config.ModeDaily,
-		Timezone:               location,
-		Workdir:                "/workspace/project",
-		DefaultReportChannelID: "channel-1",
-		Store:                  store,
-		Gateway:                gateway,
-		ReportSender:           reportSender,
-		Logger:                 logger,
+		Mode:                config.ModeDaily,
+		Timezone:            location,
+		Workdir:             "/workspace/project",
+		DefaultReportTarget: "channel:channel-1",
+		Store:               store,
+		Gateway:             gateway,
+		ReportSender:        reportSender,
+		Logger:              logger,
 		Now: func() time.Time {
 			return time.Date(2026, time.April, 12, 8, 5, 10, 0, location)
 		},
@@ -299,13 +299,13 @@ func TestScheduledTaskServiceExecuteRunDoesNotRetryCanceledRun(t *testing.T) {
 	gateway := &fakeScheduledGateway{err: context.Canceled}
 
 	service, err := NewScheduledTaskService(ScheduledTaskServiceDependencies{
-		Mode:                   config.ModeDaily,
-		Timezone:               location,
-		Workdir:                "/workspace/project",
-		DefaultReportChannelID: "channel-1",
-		Store:                  store,
-		Gateway:                gateway,
-		ReportSender:           &fakeScheduledReportSender{},
+		Mode:                config.ModeDaily,
+		Timezone:            location,
+		Workdir:             "/workspace/project",
+		DefaultReportTarget: "channel:channel-1",
+		Store:               store,
+		Gateway:             gateway,
+		ReportSender:        &fakeScheduledReportSender{},
 		Now: func() time.Time {
 			return time.Date(2026, time.April, 12, 8, 5, 10, 0, location)
 		},
@@ -352,13 +352,13 @@ func TestNewScheduledTaskServiceDefaultNowUsesLiveClock(t *testing.T) {
 	}
 
 	service, err := NewScheduledTaskService(ScheduledTaskServiceDependencies{
-		Mode:                   config.ModeDaily,
-		Timezone:               location,
-		Workdir:                "/workspace/project",
-		DefaultReportChannelID: "channel-1",
-		Store:                  &fakeScheduledTaskStore{},
-		Gateway:                &fakeScheduledGateway{},
-		ReportSender:           &fakeScheduledReportSender{},
+		Mode:                config.ModeDaily,
+		Timezone:            location,
+		Workdir:             "/workspace/project",
+		DefaultReportTarget: "channel:channel-1",
+		Store:               &fakeScheduledTaskStore{},
+		Gateway:             &fakeScheduledGateway{},
+		ReportSender:        &fakeScheduledReportSender{},
 	})
 	if err != nil {
 		t.Fatalf("NewScheduledTaskService() error = %v", err)
@@ -404,10 +404,10 @@ type fakeScheduledReportSender struct {
 	messages []string
 }
 
-func (s *fakeScheduledReportSender) SendScheduledReport(ctx context.Context, channelID string, text string) (string, error) {
+func (s *fakeScheduledReportSender) SendScheduledReport(ctx context.Context, reportTarget string, text string) (string, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.messages = append(s.messages, channelID+":"+text)
+	s.messages = append(s.messages, reportTarget+":"+text)
 	return "discord-message-1", nil
 }
 

--- a/internal/app/scheduled_tasks.go
+++ b/internal/app/scheduled_tasks.go
@@ -19,7 +19,7 @@ type ScheduledTask struct {
 	ScheduleExpr    string
 	Prompt          string
 	Enabled         bool
-	ReportChannelID string
+	ReportTarget    string
 	CreatedAt       time.Time
 	UpdatedAt       time.Time
 	DisabledAt      *time.Time
@@ -66,7 +66,7 @@ const (
 type ScheduledTaskDelivery struct {
 	ScheduledDeliveryID string
 	ScheduledRunID      string
-	DiscordChannelID    string
+	ReportTarget        string
 	DiscordMessageID    string
 	Status              ScheduledTaskDeliveryStatus
 	DeliveredAt         *time.Time
@@ -93,7 +93,7 @@ type ScheduledTaskStore interface {
 }
 
 type ScheduledTaskReportSender interface {
-	SendScheduledReport(ctx context.Context, channelID string, text string) (string, error)
+	SendScheduledReport(ctx context.Context, reportTarget string, text string) (string, error)
 }
 
 type ScheduledTaskWorkspaceManager interface {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -40,7 +40,7 @@ type Config struct {
 	CodexModelReasoningEffort  string
 	CodexWebSearchMode         string
 	CodexNetworkAccess         *bool
-	ScheduledReportChannelID   string
+	ScheduledReportTarget      string
 	LogLevel                   string
 	LogFormat                  string
 }
@@ -77,7 +77,7 @@ func LoadFromLookup(lookup func(string) (string, bool)) (Config, error) {
 		"CLAW_CODEX_MODEL_REASONING_EFFORT",
 		"CLAW_CODEX_WEB_SEARCH_MODE",
 		"CLAW_CODEX_NETWORK_ACCESS",
-		"CLAW_SCHEDULED_REPORT_CHANNEL_ID",
+		"CLAW_SCHEDULED_REPORT_TARGET",
 	}
 
 	values := make(map[string]string, len(required)+len(optionalKeys))
@@ -154,7 +154,7 @@ func LoadFromLookup(lookup func(string) (string, bool)) (Config, error) {
 		CodexModelReasoningEffort:  values["CLAW_CODEX_MODEL_REASONING_EFFORT"],
 		CodexWebSearchMode:         values["CLAW_CODEX_WEB_SEARCH_MODE"],
 		CodexNetworkAccess:         networkAccess,
-		ScheduledReportChannelID:   values["CLAW_SCHEDULED_REPORT_CHANNEL_ID"],
+		ScheduledReportTarget:      values["CLAW_SCHEDULED_REPORT_TARGET"],
 		LogLevel:                   logLevel,
 		LogFormat:                  logFormat,
 	}, nil

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -38,6 +38,7 @@ func TestLoadFromLookup(t *testing.T) {
 				"CLAW_CODEX_MODEL_REASONING_EFFORT": "high",
 				"CLAW_CODEX_WEB_SEARCH_MODE":        "cached",
 				"CLAW_CODEX_NETWORK_ACCESS":         "false",
+				"CLAW_SCHEDULED_REPORT_TARGET":      "dm:user-1",
 				"CLAW_LOG_LEVEL":                    "debug",
 				"CLAW_LOG_FORMAT":                   "text",
 			},
@@ -62,6 +63,7 @@ func TestLoadFromLookup(t *testing.T) {
 				CodexModelReasoningEffort:  "high",
 				CodexWebSearchMode:         "cached",
 				CodexNetworkAccess:         boolPtr(false),
+				ScheduledReportTarget:      "dm:user-1",
 				LogLevel:                   "debug",
 				LogFormat:                  "text",
 			},
@@ -282,6 +284,10 @@ func TestLoadFromLookup(t *testing.T) {
 				t.Fatalf("CodexNetworkAccess = %v, want %v", got.CodexNetworkAccess, tt.want.CodexNetworkAccess)
 			case *got.CodexNetworkAccess != *tt.want.CodexNetworkAccess:
 				t.Fatalf("CodexNetworkAccess = %t, want %t", *got.CodexNetworkAccess, *tt.want.CodexNetworkAccess)
+			}
+
+			if got.ScheduledReportTarget != tt.want.ScheduledReportTarget {
+				t.Fatalf("ScheduledReportTarget = %q, want %q", got.ScheduledReportTarget, tt.want.ScheduledReportTarget)
 			}
 
 			if got.LogLevel != tt.want.LogLevel {

--- a/internal/runtime/discord/runtime.go
+++ b/internal/runtime/discord/runtime.go
@@ -473,7 +473,7 @@ func (r *Runtime) presentMessageResponse(discordSession session, channelID strin
 	return presentMessage(discordSession, channelID, response)
 }
 
-func (r *Runtime) SendScheduledReport(ctx context.Context, channelID string, text string) (string, error) {
+func (r *Runtime) SendScheduledReport(ctx context.Context, reportTarget string, text string) (string, error) {
 	if err := ctx.Err(); err != nil {
 		return "", err
 	}
@@ -488,14 +488,41 @@ func (r *Runtime) SendScheduledReport(ctx context.Context, channelID string, tex
 	r.mu.Unlock()
 	defer r.workers.Done()
 
-	messageID, err := r.presentMessageResponse(discordSession, channelID, app.MessageResponse{
-		Text: text,
-	})
+	target, err := app.ParseScheduledReportTarget(reportTarget)
 	if err != nil {
 		return "", err
 	}
 
-	return messageID, nil
+	switch target.Kind {
+	case app.ScheduledReportTargetKindChannel:
+		messageID, err := r.presentMessageResponse(discordSession, target.ID, app.MessageResponse{
+			Text: text,
+		})
+		if err != nil {
+			return "", err
+		}
+
+		return messageID, nil
+	case app.ScheduledReportTargetKindDM:
+		channel, err := discordSession.UserChannelCreate(target.ID)
+		if err != nil {
+			return "", fmt.Errorf("open DM channel: %w", err)
+		}
+		if channel == nil || strings.TrimSpace(channel.ID) == "" {
+			return "", errors.New("open DM channel: discord returned an empty DM channel")
+		}
+
+		messageID, err := r.presentMessageResponse(discordSession, channel.ID, app.MessageResponse{
+			Text: text,
+		})
+		if err != nil {
+			return "", err
+		}
+
+		return messageID, nil
+	default:
+		return "", fmt.Errorf("unsupported scheduled report target kind %q", target.Kind)
+	}
 }
 
 func (r *Runtime) addCompletionReaction(discordSession session, channelID string, messageID string) {

--- a/internal/runtime/discord/runtime_test.go
+++ b/internal/runtime/discord/runtime_test.go
@@ -106,6 +106,87 @@ func TestRuntimeStartRegistersTaskModeChoices(t *testing.T) {
 	}
 }
 
+func TestRuntimeSendScheduledReportSupportsChannelAndDMTargets(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name              string
+		reportTarget      string
+		wantCreatedDMUser string
+		wantChannelID     string
+	}{
+		{
+			name:          "channel target",
+			reportTarget:  "channel:channel-1",
+			wantChannelID: "channel-1",
+		},
+		{
+			name:              "dm target",
+			reportTarget:      "dm:user-1",
+			wantCreatedDMUser: "user-1",
+			wantChannelID:     "dm-channel-user-1",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			fakeSession := newFakeSession("bot-user")
+			runtime := newTestRuntime(t, config.ModeDaily, fakeSession)
+
+			if err := runtime.Start(context.Background()); err != nil {
+				t.Fatalf("Start() error = %v", err)
+			}
+			t.Cleanup(func() {
+				_ = runtime.Close()
+			})
+
+			messageID, err := runtime.SendScheduledReport(context.Background(), tt.reportTarget, "scheduled hello")
+			if err != nil {
+				t.Fatalf("SendScheduledReport() error = %v", err)
+			}
+			if messageID != "sent-message-1" {
+				t.Fatalf("message ID = %q, want %q", messageID, "sent-message-1")
+			}
+			if len(fakeSession.createdDMUserIDs) != 0 && tt.wantCreatedDMUser == "" {
+				t.Fatalf("created DM users = %v, want none", fakeSession.createdDMUserIDs)
+			}
+			if tt.wantCreatedDMUser != "" {
+				if len(fakeSession.createdDMUserIDs) != 1 || fakeSession.createdDMUserIDs[0] != tt.wantCreatedDMUser {
+					t.Fatalf("created DM users = %v, want [%q]", fakeSession.createdDMUserIDs, tt.wantCreatedDMUser)
+				}
+			}
+			if len(fakeSession.deliveries) != 1 {
+				t.Fatalf("delivery count = %d, want %d", len(fakeSession.deliveries), 1)
+			}
+			if fakeSession.deliveries[0].ChannelID != tt.wantChannelID {
+				t.Fatalf("delivery channel = %q, want %q", fakeSession.deliveries[0].ChannelID, tt.wantChannelID)
+			}
+		})
+	}
+}
+
+func TestRuntimeSendScheduledReportRejectsInvalidTarget(t *testing.T) {
+	t.Parallel()
+
+	fakeSession := newFakeSession("bot-user")
+	runtime := newTestRuntime(t, config.ModeDaily, fakeSession)
+
+	if err := runtime.Start(context.Background()); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	t.Cleanup(func() {
+		_ = runtime.Close()
+	})
+
+	if _, err := runtime.SendScheduledReport(context.Background(), "mail:user-1", "scheduled hello"); err == nil {
+		t.Fatal("SendScheduledReport() error = nil, want invalid target error")
+	}
+}
+
 func TestRuntimeMentionHandlingRepliesToTriggerMessage(t *testing.T) {
 	t.Parallel()
 

--- a/internal/runtime/discord/runtime_test_helpers_test.go
+++ b/internal/runtime/discord/runtime_test_helpers_test.go
@@ -187,6 +187,7 @@ type fakeSession struct {
 	interactionHandlers []func(*discordgo.Session, *discordgo.InteractionCreate)
 
 	sentMessages         []*discordgo.MessageSend
+	createdDMUserIDs     []string
 	editedMessages       []*discordgo.MessageEdit
 	deletedMessageIDs    []string
 	reactions            []addedReaction
@@ -279,6 +280,22 @@ func (s *fakeSession) ChannelMessageSendComplex(
 	return &discordgo.Message{
 		ID:        "sent-message-" + strconv.Itoa(index),
 		ChannelID: channelID,
+	}, nil
+}
+
+func (s *fakeSession) UserChannelCreate(
+	recipientID string,
+	options ...discordgo.RequestOption,
+) (*discordgo.Channel, error) {
+	s.mu.Lock()
+	s.createdDMUserIDs = append(s.createdDMUserIDs, recipientID)
+	s.mu.Unlock()
+
+	s.signal()
+
+	return &discordgo.Channel{
+		ID:   "dm-channel-" + recipientID,
+		Type: discordgo.ChannelTypeDM,
 	}, nil
 }
 

--- a/internal/runtime/discord/session.go
+++ b/internal/runtime/discord/session.go
@@ -19,6 +19,10 @@ type session interface {
 		data *discordgo.MessageSend,
 		options ...discordgo.RequestOption,
 	) (*discordgo.Message, error)
+	UserChannelCreate(
+		recipientID string,
+		options ...discordgo.RequestOption,
+	) (*discordgo.Channel, error)
 	ChannelMessageEditComplex(
 		data *discordgo.MessageEdit,
 		options ...discordgo.RequestOption,

--- a/internal/scheduled/http_mcp_server.go
+++ b/internal/scheduled/http_mcp_server.go
@@ -19,11 +19,11 @@ const (
 )
 
 type HTTPServerDependencies struct {
-	Store                  app.ScheduledTaskStore
-	Executor               app.ScheduledTaskExecutor
-	Timezone               *time.Location
-	DefaultReportChannelID string
-	Logger                 *slog.Logger
+	Store               app.ScheduledTaskStore
+	Executor            app.ScheduledTaskExecutor
+	Timezone            *time.Location
+	DefaultReportTarget string
+	Logger              *slog.Logger
 }
 
 type HTTPServer struct {
@@ -40,10 +40,10 @@ func NewHTTPServer(deps HTTPServerDependencies) (*HTTPServer, error) {
 	}
 
 	mcpTools := &MCPServer{
-		Store:                  deps.Store,
-		Executor:               deps.Executor,
-		Timezone:               deps.Timezone,
-		DefaultReportChannelID: deps.DefaultReportChannelID,
+		Store:               deps.Store,
+		Executor:            deps.Executor,
+		Timezone:            deps.Timezone,
+		DefaultReportTarget: deps.DefaultReportTarget,
 	}
 	mcpHandler, err := mcpTools.BuildServer()
 	if err != nil {

--- a/internal/scheduled/http_mcp_server_test.go
+++ b/internal/scheduled/http_mcp_server_test.go
@@ -35,9 +35,9 @@ func TestHTTPServerSupportsMCPGoStreamableHTTPClientAndSharesStore(t *testing.T)
 
 	store := sqlitestore.New(db)
 	httpServer, err := NewHTTPServer(HTTPServerDependencies{
-		Store:                  store,
-		Timezone:               location,
-		DefaultReportChannelID: "channel-1",
+		Store:               store,
+		Timezone:            location,
+		DefaultReportTarget: "channel:channel-1",
 	})
 	if err != nil {
 		t.Fatalf("NewHTTPServer() error = %v", err)

--- a/internal/scheduled/mcp_server.go
+++ b/internal/scheduled/mcp_server.go
@@ -20,12 +20,12 @@ const (
 )
 
 type MCPServer struct {
-	Store                  app.ScheduledTaskStore
-	Executor               app.ScheduledTaskExecutor
-	Timezone               *time.Location
-	DefaultReportChannelID string
-	Now                    func() time.Time
-	mu                     sync.RWMutex
+	Store               app.ScheduledTaskStore
+	Executor            app.ScheduledTaskExecutor
+	Timezone            *time.Location
+	DefaultReportTarget string
+	Now                 func() time.Time
+	mu                  sync.RWMutex
 }
 
 func (s *MCPServer) BuildServer() (*mcpserver.MCPServer, error) {
@@ -107,12 +107,12 @@ func (s *MCPServer) getTask(ctx context.Context, request mcp.CallToolRequest) (*
 
 func (s *MCPServer) createTask(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	var args struct {
-		Name            string `json:"name"`
-		ScheduleKind    string `json:"schedule_kind"`
-		ScheduleExpr    string `json:"schedule_expr"`
-		Prompt          string `json:"prompt"`
-		Enabled         bool   `json:"enabled"`
-		ReportChannelID string `json:"report_channel_id"`
+		Name         string `json:"name"`
+		ScheduleKind string `json:"schedule_kind"`
+		ScheduleExpr string `json:"schedule_expr"`
+		Prompt       string `json:"prompt"`
+		Enabled      bool   `json:"enabled"`
+		ReportTarget string `json:"report_target"`
 	}
 	if err := bindToolArguments(request, &args); err != nil {
 		return toolErrorResult("parse scheduled_tasks_create arguments", err), nil
@@ -125,14 +125,14 @@ func (s *MCPServer) createTask(ctx context.Context, request mcp.CallToolRequest)
 		ScheduleExpr:    strings.TrimSpace(args.ScheduleExpr),
 		Prompt:          strings.TrimSpace(args.Prompt),
 		Enabled:         args.Enabled,
-		ReportChannelID: strings.TrimSpace(args.ReportChannelID),
+		ReportTarget:    strings.TrimSpace(args.ReportTarget),
 	}
 	if !task.Enabled {
 		now := s.Now()
 		task.DisabledAt = &now
 	}
 
-	if err := app.ValidateScheduledTaskDefinition(task, s.Timezone, s.DefaultReportChannelID); err != nil {
+	if err := app.ValidateScheduledTaskDefinition(task, s.Timezone, s.DefaultReportTarget); err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}
 	if _, ok, err := s.Store.GetScheduledTaskByName(ctx, task.Name); err != nil {
@@ -149,12 +149,12 @@ func (s *MCPServer) createTask(ctx context.Context, request mcp.CallToolRequest)
 
 func (s *MCPServer) updateTask(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	var args struct {
-		Name            string  `json:"name"`
-		ScheduleKind    *string `json:"schedule_kind"`
-		ScheduleExpr    *string `json:"schedule_expr"`
-		Prompt          *string `json:"prompt"`
-		Enabled         *bool   `json:"enabled"`
-		ReportChannelID *string `json:"report_channel_id"`
+		Name         string  `json:"name"`
+		ScheduleKind *string `json:"schedule_kind"`
+		ScheduleExpr *string `json:"schedule_expr"`
+		Prompt       *string `json:"prompt"`
+		Enabled      *bool   `json:"enabled"`
+		ReportTarget *string `json:"report_target"`
 	}
 	if err := bindToolArguments(request, &args); err != nil {
 		return toolErrorResult("parse scheduled_tasks_update arguments", err), nil
@@ -186,11 +186,11 @@ func (s *MCPServer) updateTask(ctx context.Context, request mcp.CallToolRequest)
 			task.DisabledAt = &now
 		}
 	}
-	if args.ReportChannelID != nil {
-		task.ReportChannelID = strings.TrimSpace(*args.ReportChannelID)
+	if args.ReportTarget != nil {
+		task.ReportTarget = strings.TrimSpace(*args.ReportTarget)
 	}
 
-	if err := app.ValidateScheduledTaskDefinition(task, s.Timezone, s.DefaultReportChannelID); err != nil {
+	if err := app.ValidateScheduledTaskDefinition(task, s.Timezone, s.DefaultReportTarget); err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}
 	if err := s.Store.UpdateScheduledTask(ctx, task); err != nil {
@@ -273,7 +273,7 @@ func (s *MCPServer) toggleTask(
 		task.DisabledAt = &now
 	}
 
-	if err := app.ValidateScheduledTaskDefinition(task, s.Timezone, s.DefaultReportChannelID); err != nil {
+	if err := app.ValidateScheduledTaskDefinition(task, s.Timezone, s.DefaultReportTarget); err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}
 	if err := s.Store.UpdateScheduledTask(ctx, task); err != nil {
@@ -312,7 +312,7 @@ func scheduledTasksCreateTool() mcp.Tool {
 		mcp.WithString("schedule_expr", mcp.Required(), mcp.Description("Cron expression or local-time timestamp.")),
 		mcp.WithString("prompt", mcp.Required(), mcp.Description("Prompt to execute on each scheduled run.")),
 		mcp.WithBoolean("enabled", mcp.Required(), mcp.Description("Whether the task starts enabled.")),
-		mcp.WithString("report_channel_id", mcp.Description("Optional Discord channel override for reports.")),
+		mcp.WithString("report_target", mcp.Description("Optional report override in the form channel:<id> or dm:<user_id>.")),
 	)
 }
 
@@ -325,7 +325,7 @@ func scheduledTasksUpdateTool() mcp.Tool {
 		mcp.WithString("schedule_expr", mcp.Description("Optional schedule expression override.")),
 		mcp.WithString("prompt", mcp.Description("Optional prompt override.")),
 		mcp.WithBoolean("enabled", mcp.Description("Optional enabled-state override.")),
-		mcp.WithString("report_channel_id", mcp.Description("Optional Discord channel override.")),
+		mcp.WithString("report_target", mcp.Description("Optional report override in the form channel:<id> or dm:<user_id>.")),
 	)
 }
 

--- a/internal/scheduled/mcp_server_test.go
+++ b/internal/scheduled/mcp_server_test.go
@@ -36,9 +36,9 @@ func TestMCPServerCreateAndListScheduledTasks(t *testing.T) {
 	}
 
 	scheduledServer := &MCPServer{
-		Store:                  sqlitestore.New(db),
-		Timezone:               location,
-		DefaultReportChannelID: "12345",
+		Store:               sqlitestore.New(db),
+		Timezone:            location,
+		DefaultReportTarget: "channel:12345",
 		Now: func() time.Time {
 			return time.Date(2026, time.April, 12, 8, 0, 0, 0, time.UTC)
 		},
@@ -105,10 +105,10 @@ func TestMCPServerExecuteNowUsesExecutor(t *testing.T) {
 	}
 
 	scheduledServer := &MCPServer{
-		Store:                  &fakeScheduledTaskStore{},
-		Executor:               fakeScheduledTaskExecutor{},
-		Timezone:               location,
-		DefaultReportChannelID: "12345",
+		Store:               &fakeScheduledTaskStore{},
+		Executor:            fakeScheduledTaskExecutor{},
+		Timezone:            location,
+		DefaultReportTarget: "channel:12345",
 	}
 
 	mcpServer, err := scheduledServer.BuildServer()

--- a/internal/store/sqlite/migrate_test.go
+++ b/internal/store/sqlite/migrate_test.go
@@ -27,8 +27,8 @@ func TestMigrateFreshDatabase(t *testing.T) {
 	}
 
 	versions := appliedVersionsForTest(t, db)
-	if !slices.Equal(versions, []int{1, 2, 3, 4, 5}) {
-		t.Fatalf("applied migration versions = %v, want %v", versions, []int{1, 2, 3, 4, 5})
+	if !slices.Equal(versions, []int{1, 2, 3, 4, 5, 6}) {
+		t.Fatalf("applied migration versions = %v, want %v", versions, []int{1, 2, 3, 4, 5, 6})
 	}
 
 	for _, tableName := range []string{
@@ -57,6 +57,28 @@ func TestMigrateFreshDatabase(t *testing.T) {
 
 	if !hasAllColumns(taskColumns, legacyTaskWorktreeColumns) {
 		t.Fatalf("tasks columns = %v, want worktree metadata columns present", taskColumns)
+	}
+
+	scheduledTaskColumns, err := tableColumnNames(context.Background(), db, "scheduled_tasks")
+	if err != nil {
+		t.Fatalf("tableColumnNames(scheduled_tasks) error = %v", err)
+	}
+	if !slices.Contains(scheduledTaskColumns, "report_target") {
+		t.Fatalf("scheduled_tasks columns = %v, want report_target", scheduledTaskColumns)
+	}
+	if slices.Contains(scheduledTaskColumns, "report_channel_id") {
+		t.Fatalf("scheduled_tasks columns = %v, want report_channel_id removed", scheduledTaskColumns)
+	}
+
+	deliveryColumns, err := tableColumnNames(context.Background(), db, "scheduled_task_deliveries")
+	if err != nil {
+		t.Fatalf("tableColumnNames(scheduled_task_deliveries) error = %v", err)
+	}
+	if !slices.Contains(deliveryColumns, "report_target") {
+		t.Fatalf("scheduled_task_deliveries columns = %v, want report_target", deliveryColumns)
+	}
+	if slices.Contains(deliveryColumns, "discord_channel_id") {
+		t.Fatalf("scheduled_task_deliveries columns = %v, want discord_channel_id removed", deliveryColumns)
 	}
 }
 
@@ -146,8 +168,8 @@ func TestMigrateLegacyDatabaseBootstrapRecognizesLatestSchema(t *testing.T) {
 	}
 
 	versions := appliedVersionsForTest(t, reopened)
-	if !slices.Equal(versions, []int{1, 2, 3, 4, 5}) {
-		t.Fatalf("applied migration versions = %v, want %v", versions, []int{1, 2, 3, 4, 5})
+	if !slices.Equal(versions, []int{1, 2, 3, 4, 5, 6}) {
+		t.Fatalf("applied migration versions = %v, want %v", versions, []int{1, 2, 3, 4, 5, 6})
 	}
 
 	store := New(reopened)

--- a/internal/store/sqlite/store.go
+++ b/internal/store/sqlite/store.go
@@ -442,7 +442,7 @@ func (s *Store) CloseTask(ctx context.Context, discordUserID string, taskID stri
 func (s *Store) ListScheduledTasks(ctx context.Context) ([]app.ScheduledTask, error) {
 	rows, err := s.db.QueryContext(
 		ctx,
-		`SELECT scheduled_task_id, name, schedule_kind, schedule_expr, prompt, enabled, report_channel_id,
+		`SELECT scheduled_task_id, name, schedule_kind, schedule_expr, prompt, enabled, report_target,
 			created_at, updated_at, disabled_at
 		FROM scheduled_tasks
 		ORDER BY name ASC`,
@@ -471,7 +471,7 @@ func (s *Store) ListScheduledTasks(ctx context.Context) ([]app.ScheduledTask, er
 func (s *Store) ListEnabledScheduledTasks(ctx context.Context) ([]app.ScheduledTask, error) {
 	rows, err := s.db.QueryContext(
 		ctx,
-		`SELECT scheduled_task_id, name, schedule_kind, schedule_expr, prompt, enabled, report_channel_id,
+		`SELECT scheduled_task_id, name, schedule_kind, schedule_expr, prompt, enabled, report_target,
 			created_at, updated_at, disabled_at
 		FROM scheduled_tasks
 		WHERE enabled = 1
@@ -501,7 +501,7 @@ func (s *Store) ListEnabledScheduledTasks(ctx context.Context) ([]app.ScheduledT
 func (s *Store) GetScheduledTaskByID(ctx context.Context, scheduledTaskID string) (app.ScheduledTask, bool, error) {
 	row := s.db.QueryRowContext(
 		ctx,
-		`SELECT scheduled_task_id, name, schedule_kind, schedule_expr, prompt, enabled, report_channel_id,
+		`SELECT scheduled_task_id, name, schedule_kind, schedule_expr, prompt, enabled, report_target,
 			created_at, updated_at, disabled_at
 		FROM scheduled_tasks
 		WHERE scheduled_task_id = ?`,
@@ -514,7 +514,7 @@ func (s *Store) GetScheduledTaskByID(ctx context.Context, scheduledTaskID string
 func (s *Store) GetScheduledTaskByName(ctx context.Context, name string) (app.ScheduledTask, bool, error) {
 	row := s.db.QueryRowContext(
 		ctx,
-		`SELECT scheduled_task_id, name, schedule_kind, schedule_expr, prompt, enabled, report_channel_id,
+		`SELECT scheduled_task_id, name, schedule_kind, schedule_expr, prompt, enabled, report_target,
 			created_at, updated_at, disabled_at
 		FROM scheduled_tasks
 		WHERE name = ?`,
@@ -536,7 +536,7 @@ func (s *Store) CreateScheduledTask(ctx context.Context, task app.ScheduledTask)
 	_, err := s.db.ExecContext(
 		ctx,
 		`INSERT INTO scheduled_tasks (
-			scheduled_task_id, name, schedule_kind, schedule_expr, prompt, enabled, report_channel_id,
+			scheduled_task_id, name, schedule_kind, schedule_expr, prompt, enabled, report_target,
 			created_at, updated_at, disabled_at
 		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		task.ScheduledTaskID,
@@ -545,7 +545,7 @@ func (s *Store) CreateScheduledTask(ctx context.Context, task app.ScheduledTask)
 		task.ScheduleExpr,
 		task.Prompt,
 		boolToSQLite(task.Enabled),
-		nullableString(task.ReportChannelID),
+		nullableString(task.ReportTarget),
 		task.CreatedAt.Format(time.RFC3339Nano),
 		task.UpdatedAt.Format(time.RFC3339Nano),
 		nullableTime(task.DisabledAt),
@@ -566,7 +566,7 @@ func (s *Store) UpdateScheduledTask(ctx context.Context, task app.ScheduledTask)
 	result, err := s.db.ExecContext(
 		ctx,
 		`UPDATE scheduled_tasks
-		SET name = ?, schedule_kind = ?, schedule_expr = ?, prompt = ?, enabled = ?, report_channel_id = ?,
+		SET name = ?, schedule_kind = ?, schedule_expr = ?, prompt = ?, enabled = ?, report_target = ?,
 			updated_at = ?, disabled_at = ?
 		WHERE scheduled_task_id = ?`,
 		task.Name,
@@ -574,7 +574,7 @@ func (s *Store) UpdateScheduledTask(ctx context.Context, task app.ScheduledTask)
 		task.ScheduleExpr,
 		task.Prompt,
 		boolToSQLite(task.Enabled),
-		nullableString(task.ReportChannelID),
+		nullableString(task.ReportTarget),
 		task.UpdatedAt.Format(time.RFC3339Nano),
 		nullableTime(task.DisabledAt),
 		task.ScheduledTaskID,
@@ -765,12 +765,12 @@ func (s *Store) CreateScheduledTaskDelivery(ctx context.Context, delivery app.Sc
 	_, err := s.db.ExecContext(
 		ctx,
 		`INSERT INTO scheduled_task_deliveries (
-			scheduled_delivery_id, scheduled_run_id, discord_channel_id, discord_message_id, status, delivered_at,
+			scheduled_delivery_id, scheduled_run_id, report_target, discord_message_id, status, delivered_at,
 			error_code, error_message, created_at, updated_at
 		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		delivery.ScheduledDeliveryID,
 		delivery.ScheduledRunID,
-		delivery.DiscordChannelID,
+		delivery.ReportTarget,
 		nullableString(delivery.DiscordMessageID),
 		string(delivery.Status),
 		nullableTime(delivery.DeliveredAt),
@@ -795,10 +795,10 @@ func (s *Store) UpdateScheduledTaskDelivery(ctx context.Context, delivery app.Sc
 	result, err := s.db.ExecContext(
 		ctx,
 		`UPDATE scheduled_task_deliveries
-		SET discord_channel_id = ?, discord_message_id = ?, status = ?, delivered_at = ?, error_code = ?,
+		SET report_target = ?, discord_message_id = ?, status = ?, delivered_at = ?, error_code = ?,
 			error_message = ?, updated_at = ?
 		WHERE scheduled_delivery_id = ?`,
-		delivery.DiscordChannelID,
+		delivery.ReportTarget,
 		nullableString(delivery.DiscordMessageID),
 		string(delivery.Status),
 		nullableTime(delivery.DeliveredAt),
@@ -826,7 +826,7 @@ func scanScheduledTask(scanner interface{ Scan(dest ...any) error }) (app.Schedu
 	var task app.ScheduledTask
 	var scheduleKind string
 	var enabled int
-	var reportChannelID sql.NullString
+	var reportTarget sql.NullString
 	var createdAt string
 	var updatedAt string
 	var disabledAt sql.NullString
@@ -838,7 +838,7 @@ func scanScheduledTask(scanner interface{ Scan(dest ...any) error }) (app.Schedu
 		&task.ScheduleExpr,
 		&task.Prompt,
 		&enabled,
-		&reportChannelID,
+		&reportTarget,
 		&createdAt,
 		&updatedAt,
 		&disabledAt,
@@ -852,7 +852,7 @@ func scanScheduledTask(scanner interface{ Scan(dest ...any) error }) (app.Schedu
 
 	task.ScheduleKind = app.ScheduledTaskScheduleKind(scheduleKind)
 	task.Enabled = enabled != 0
-	task.ReportChannelID = nullableStringValue(reportChannelID)
+	task.ReportTarget = nullableStringValue(reportTarget)
 
 	parsedCreatedAt, err := time.Parse(time.RFC3339Nano, createdAt)
 	if err != nil {

--- a/internal/store/sqlite/store_test.go
+++ b/internal/store/sqlite/store_test.go
@@ -35,8 +35,8 @@ func TestMigrateIsIdempotent(t *testing.T) {
 		t.Fatalf("query schema_migrations count error = %v", err)
 	}
 
-	if count != 5 {
-		t.Fatalf("schema_migrations count = %d, want %d", count, 5)
+	if count != 6 {
+		t.Fatalf("schema_migrations count = %d, want %d", count, 6)
 	}
 }
 
@@ -646,6 +646,7 @@ func TestStoreAdmitScheduledTaskRunRejectsDuplicateAttempt(t *testing.T) {
 		ScheduleExpr:    "0 9 * * *",
 		Prompt:          "Write the report.",
 		Enabled:         true,
+		ReportTarget:    "channel:channel-1",
 	})
 
 	dueTime := time.Date(2026, time.April, 12, 0, 0, 0, 0, time.UTC)
@@ -706,6 +707,7 @@ func TestStoreListScheduledTaskRunsForDueTimeOrdersAttempts(t *testing.T) {
 		ScheduleExpr:    "0 9 * * *",
 		Prompt:          "Write the report.",
 		Enabled:         true,
+		ReportTarget:    "channel:channel-1",
 	})
 
 	dueTime := time.Date(2026, time.April, 12, 0, 0, 0, 0, time.UTC)
@@ -748,6 +750,89 @@ func TestStoreListScheduledTaskRunsForDueTimeOrdersAttempts(t *testing.T) {
 	}
 	if listedRuns[1].ScheduledRunID != "run-2" {
 		t.Fatalf("listedRuns[1].ScheduledRunID = %q, want %q", listedRuns[1].ScheduledRunID, "run-2")
+	}
+}
+
+func TestStoreScheduledTaskAndDeliveryPersistReportTarget(t *testing.T) {
+	t.Parallel()
+
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	task := app.ScheduledTask{
+		ScheduledTaskID: "scheduled-task-1",
+		Name:            "daily-report",
+		ScheduleKind:    app.ScheduledTaskScheduleKindCron,
+		ScheduleExpr:    "0 9 * * *",
+		Prompt:          "Write the report.",
+		Enabled:         true,
+		ReportTarget:    "dm:user-1",
+	}
+	createScheduledTaskForTest(t, ctx, store, task)
+
+	storedTask, ok, err := store.GetScheduledTaskByName(ctx, task.Name)
+	if err != nil {
+		t.Fatalf("GetScheduledTaskByName() error = %v", err)
+	}
+	if !ok {
+		t.Fatal("GetScheduledTaskByName() ok = false, want true")
+	}
+	if storedTask.ReportTarget != task.ReportTarget {
+		t.Fatalf("stored task report target = %q, want %q", storedTask.ReportTarget, task.ReportTarget)
+	}
+
+	run, admitted, err := store.AdmitScheduledTaskRun(ctx, app.ScheduledTaskRun{
+		ScheduledRunID:  "run-1",
+		ScheduledTaskID: task.ScheduledTaskID,
+		Mode:            "daily",
+		ScheduledFor:    time.Date(2026, time.April, 12, 0, 0, 0, 0, time.UTC),
+		Attempt:         1,
+		Status:          app.ScheduledTaskRunStatusSucceeded,
+	})
+	if err != nil {
+		t.Fatalf("AdmitScheduledTaskRun() error = %v", err)
+	}
+	if !admitted {
+		t.Fatal("AdmitScheduledTaskRun() admitted = false, want true")
+	}
+
+	delivery := app.ScheduledTaskDelivery{
+		ScheduledDeliveryID: "delivery-1",
+		ScheduledRunID:      run.ScheduledRunID,
+		ReportTarget:        "dm:user-1",
+		Status:              app.ScheduledTaskDeliveryStatusPending,
+	}
+	if err := store.CreateScheduledTaskDelivery(ctx, delivery); err != nil {
+		t.Fatalf("CreateScheduledTaskDelivery() error = %v", err)
+	}
+
+	if err := store.UpdateScheduledTaskDelivery(ctx, app.ScheduledTaskDelivery{
+		ScheduledDeliveryID: delivery.ScheduledDeliveryID,
+		ScheduledRunID:      delivery.ScheduledRunID,
+		ReportTarget:        delivery.ReportTarget,
+		DiscordMessageID:    "discord-message-1",
+		Status:              app.ScheduledTaskDeliveryStatusSucceeded,
+		DeliveredAt:         timePtr(time.Date(2026, time.April, 12, 0, 1, 0, 0, time.UTC)),
+	}); err != nil {
+		t.Fatalf("UpdateScheduledTaskDelivery() error = %v", err)
+	}
+
+	var persistedReportTarget string
+	var persistedMessageID sql.NullString
+	if err := store.db.QueryRowContext(
+		ctx,
+		`SELECT report_target, discord_message_id
+		FROM scheduled_task_deliveries
+		WHERE scheduled_delivery_id = ?`,
+		delivery.ScheduledDeliveryID,
+	).Scan(&persistedReportTarget, &persistedMessageID); err != nil {
+		t.Fatalf("query scheduled_task_deliveries error = %v", err)
+	}
+	if persistedReportTarget != delivery.ReportTarget {
+		t.Fatalf("persisted report target = %q, want %q", persistedReportTarget, delivery.ReportTarget)
+	}
+	if !persistedMessageID.Valid || persistedMessageID.String != "discord-message-1" {
+		t.Fatalf("persisted message ID = %+v, want %q", persistedMessageID, "discord-message-1")
 	}
 }
 

--- a/migrations/sqlite/0006_scheduled_report_targets.sql
+++ b/migrations/sqlite/0006_scheduled_report_targets.sql
@@ -1,0 +1,3 @@
+ALTER TABLE scheduled_tasks RENAME COLUMN report_channel_id TO report_target;
+
+ALTER TABLE scheduled_task_deliveries RENAME COLUMN discord_channel_id TO report_target;


### PR DESCRIPTION
## Summary

- generalize scheduled report configuration and task overrides from channel-only fields to `report_target`
- support scheduled report delivery to either `channel:<id>` or `dm:<user_id>`
- migrate validation, persistence, docs, and automated coverage to the new target model

## Background

Scheduled task reporting was previously hard-coded around Discord channel IDs. That made DM delivery impossible and left configuration, task definitions, and delivery records using channel-specific naming even though the report destination is conceptually broader.

## Related issue(s)

- None.

## Implementation details

- add a shared scheduled report target parser and validation path in the app layer
- replace `CLAW_SCHEDULED_REPORT_CHANNEL_ID` and `report_channel_id` with `CLAW_SCHEDULED_REPORT_TARGET` and `report_target`
- route `dm:` targets through Discord DM channel creation while preserving the existing channel send path for `channel:` targets
- add SQLite migration `0006_scheduled_report_targets.sql` to rename persisted scheduled task and delivery columns to `report_target`
- update scheduled MCP surfaces, config wiring, docs, and tests to reflect the immediate replacement policy

## Test coverage

- `go test ./...`
- `make lint`

## Breaking changes

- `CLAW_SCHEDULED_REPORT_CHANNEL_ID` is replaced by `CLAW_SCHEDULED_REPORT_TARGET`
- scheduled task `report_channel_id` inputs are replaced by `report_target`
- only `channel:<id>` and `dm:<user_id>` are accepted target formats

## Notes

- existing persisted scheduled task and delivery rows are migrated to `report_target` on startup
- this PR intentionally applies the compatibility policy as an immediate replacement with no fallback to legacy field names

Created by Codex
