### PR TITLE
[codex] Align scheduled task persistence docs with implementation

### DIFF
--- a/docs/design-docs/implementation-spec.md
+++ b/docs/design-docs/implementation-spec.md
@@ -57,13 +57,13 @@ The following internal contracts should be treated as stable v1 design targets e
 - `ThreadStore`
   - loads, upserts, and deletes thread bindings and manages task records plus active task state
 - `ScheduledTaskStore`
-  - manages scheduled task definitions, run records, and delivery records
+  - manages `scheduled_tasks`, `scheduled_task_runs`, and `scheduled_task_deliveries` records
 - `CodexGateway`
   - runs a turn against an existing Codex thread when a thread ID is present
   - creates the first remote thread implicitly when the first turn runs without a saved thread ID
   - returns a normalized final response plus the thread ID that should be persisted
 - `ScheduledTaskService`
-  - implements create, list, enable, disable, delete, and execute-now workflows for scheduled tasks
+  - implements MCP-backed conversational create, list, get, update, enable, disable, delete, and execute-now workflows for scheduled tasks
   - owns due-run claiming, execution handoff, and Discord report delivery recording
 - `TaskCommandService`
   - implements the `action:task-current`, `action:task-list`, `action:task-new`, `action:task-switch`, `action:task-close`, and `action:task-reset-context` workflow behind the configured root command
@@ -105,12 +105,12 @@ The storage model uses seven tables:
 - `active_tasks`
   - stores `discord_user_id`, `task_id`, and `updated_at`
   - enforces one active task per Discord user within a bot instance
-- `scheduled_task_definitions`
-  - stores `scheduled_task_id`, `name`, `mode`, `schedule_kind`, `schedule_expr`, `prompt`, nullable `task_prompt_prefix`, `report_target`, `is_enabled`, `last_claimed_at`, `last_scheduled_for`, `created_at`, `updated_at`, and nullable `disabled_at`
+- `scheduled_tasks`
+  - stores `scheduled_task_id`, `name`, `schedule_kind`, `schedule_expr`, `prompt`, `enabled`, nullable `report_target`, `created_at`, `updated_at`, and nullable `disabled_at`
   - uses ULID strings for `scheduled_task_id`
   - stores the canonical schedule definition that 39claw owns locally
 - `scheduled_task_runs`
-  - stores `scheduled_run_id`, `scheduled_task_id`, `mode`, `scheduled_for`, `status`, nullable `codex_thread_id`, nullable `workdir_path`, nullable `temp_worktree_path`, nullable `started_at`, nullable `finished_at`, nullable `error_code`, nullable `error_message`, `created_at`, and `updated_at`
+  - stores `scheduled_run_id`, `scheduled_task_id`, `mode`, `scheduled_for`, `attempt`, `status`, nullable `codex_thread_id`, nullable `workdir_path`, nullable `temp_worktree_path`, nullable `started_at`, nullable `finished_at`, nullable `error_code`, nullable `error_message`, nullable `response_text`, `created_at`, and `updated_at`
   - records each scheduled execution attempt before Codex dispatch begins
 - `scheduled_task_deliveries`
   - stores `scheduled_delivery_id`, `scheduled_run_id`, `report_target`, nullable `discord_message_id`, `status`, nullable `delivered_at`, nullable `error_code`, nullable `error_message`, `created_at`, and `updated_at`
@@ -134,6 +134,7 @@ Queue admission, thread binding lookup, and worktree selection must freeze that 
 When the bot runs in `daily` mode, 39claw also manages a durable memory projection inside `${CLAW_CODEX_WORKDIR}/AGENT_MEMORY`.
 `MEMORY.md` is the primary durable-memory file, and `YYYY-MM-DD.<generation>.md` stores the bridge note created during the first-message preflight for a new daily generation.
 Scheduled tasks are independent from interactive message routing and own their own persisted definition plus run lifecycle.
+Scheduled-task management is not part of the Discord slash-command surface; it is exposed to Codex through a local 39claw-owned MCP server and managed conversationally through the `scheduled_tasks_*` tool family.
 When a scheduled task executes in `daily` mode, it uses `CLAW_CODEX_WORKDIR` directly.
 When a scheduled task executes in `task` mode, it must create a fresh temporary worktree from the managed bare parent, run Codex there, and remove that temporary worktree after the run completes.
 
@@ -150,7 +151,7 @@ Task-control command responses are ephemeral by default.
 When a bot instance runs in `daily` mode, task actions must return a clear not-available response instead of pretending the command worked.
 When a bot instance runs in `daily` mode, the root command should also expose `action:clear`.
 When a bot instance runs in `task` mode, the root command should expose `action:task-current`, `action:task-list`, `action:task-new`, `action:task-switch`, `action:task-close`, and `action:task-reset-context`.
-Scheduled-task control commands should be available in both modes because scheduled execution is orthogonal to the interactive thread mode.
+Scheduled-task management should be available in both modes through MCP-backed conversational management because scheduled execution is orthogonal to the interactive thread mode.
 
 When a bot instance runs in `task` mode, normal messages without an active task must not be routed to Codex.
 They should return actionable guidance that points the user to `action:task-new`, `action:task-list`, or `action:task-switch` on the configured root command.
@@ -218,7 +219,7 @@ When `CLAW_CODEX_HOME` is set, 39claw must inject it into the spawned Codex CLI 
 When `CLAW_MODE=task`, `CLAW_CODEX_WORKDIR` must point to a Git repository with an `origin` remote and acts as the operator-visible source checkout plus validation target for task-mode startup.
 Task-mode startup and first-use preparation must maintain a managed bare parent repository under `${CLAW_DATADIR}/repos`, and task worktrees must be created from that managed parent rather than directly from the visible source checkout.
 When `CLAW_MODE=daily`, startup must materialize the managed durable-memory skill and the `AGENT_MEMORY` directory inside `CLAW_CODEX_WORKDIR`.
-When `CLAW_SCHEDULED_REPORT_TARGET` is set, it becomes the default report target for scheduled tasks that do not override the destination explicitly. Accepted formats are `channel:<id>` and `dm:<user_id>`.
+When `CLAW_SCHEDULED_REPORT_TARGET` is set, it becomes the default `report_target` for scheduled tasks that do not override the destination explicitly. Accepted formats are `channel:<id>` and `dm:<user_id>`.
 `CLAW_LOG_LEVEL` defaults to `info` when omitted.
 When `CLAW_DISCORD_GUILD_ID` is set, slash commands are overwritten in that guild for faster development feedback.
 `CLAW_CODEX_SANDBOX_MODE` defaults to `workspace-write` when omitted.

--- a/docs/design-docs/scheduled-tasks.md
+++ b/docs/design-docs/scheduled-tasks.md
@@ -25,7 +25,7 @@ This document answers those questions at the concept level without turning 39cla
 - Every scheduled execution starts a fresh Codex thread and never reuses a prior scheduled-run thread ID.
 - Scheduled execution uses the same Codex runtime configuration as normal turns, including the same effective repository root for the current bot mode.
 - When the bot instance runs in `task` mode, a scheduled run executes in its own fresh temporary worktree created for that scheduled run and removed after the run finishes.
-- Scheduled tasks are defined by a deliberately small schema: name, schedule, prompt, enabled state, and optional report-channel override.
+- Scheduled tasks are defined by a deliberately small schema: name, schedule, prompt, enabled state, and optional `report_target` override.
 - Infrastructure-level execution failure may trigger at most one automatic retry for the due run; content-level failure is reported by Codex output rather than by a separate 39claw policy engine.
 - Recurring cron schedules do not backfill missed occurrences from before the current scheduler process started; those older overdue boundaries are skipped instead of replayed after downtime.
 - Delivery to Discord is a separate step from Codex execution and should be recorded separately.
@@ -139,13 +139,14 @@ Scheduled-task management should be exposed to Codex as explicit 39claw-owned to
 
 The concept-level tool surface should cover:
 
-- list scheduled tasks
-- inspect one scheduled task
-- create a scheduled task
-- update a scheduled task
-- enable a scheduled task
-- disable a scheduled task
-- delete a scheduled task
+- `scheduled_tasks_list`
+- `scheduled_tasks_get`
+- `scheduled_tasks_create`
+- `scheduled_tasks_update`
+- `scheduled_tasks_enable`
+- `scheduled_tasks_disable`
+- `scheduled_tasks_delete`
+- `scheduled_tasks_execute_now`
 
 These tools should validate input and mutate the canonical store directly.
 Codex should not be expected to invent hidden file formats or write directly into SQLite-managed state.
@@ -173,6 +174,13 @@ Scheduled tasks should use the same mode-aware repository target as normal inter
 
 This keeps scheduled tasks independent from whichever task context a user last selected.
 The feature is instance-scoped automation, not per-user active-task automation.
+
+The effective report target should resolve in this order:
+
+1. the task definition's `report_target`
+2. `CLAW_SCHEDULED_REPORT_TARGET`
+
+Accepted target forms are `channel:<id>` and `dm:<user_id>`.
 
 ### Task-mode scheduled-run workspace rule
 


### PR DESCRIPTION
## Summary

- align scheduled task persistence terminology in the implementation spec with the current SQLite schema and MCP management flow
- replace slash-command-like scheduled task management wording with MCP-backed conversational management wording
- document the current `report_target` fallback and tool naming conventions in the scheduled task design note

## Background

The scheduled task documentation had drifted from the current implementation. The implementation uses `scheduled_tasks`, `scheduled_task_runs`, and `scheduled_task_deliveries`, exposes management through the local scheduled-task MCP server, and resolves delivery targets through `report_target` and `CLAW_SCHEDULED_REPORT_TARGET`.

## Related issue(s)

- None

## Implementation details

- updated `docs/design-docs/implementation-spec.md` to use the current scheduled-task table and field names
- clarified that scheduled task management is MCP-backed conversational management rather than part of the Discord slash-command surface
- kept the task-mode scheduled execution note that each run uses a fresh temporary worktree instead of reusing an interactive task worktree
- updated `docs/design-docs/scheduled-tasks.md` to use `report_target`, the `scheduled_tasks_*` MCP tool names, and the current report-target resolution order

## Test coverage

- `make lint`
- `make test`

## Breaking changes

- None

## Notes

Created by Codex