### PR TITLE
[codex] fix Node 24 deprecation in GoReleaser workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
           cache: false
 
       - name: Validate GoReleaser configuration
-        uses: goreleaser/goreleaser-action@9c156ee8a17a598857849441385a2041ef570552
+        uses: goreleaser/goreleaser-action@e24998b8b67b290c2fa8b7c14fcfa7de2c5c9b8c
         with:
           version: "latest"
           args: check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
           cache: false
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@9c156ee8a17a598857849441385a2041ef570552
+        uses: goreleaser/goreleaser-action@e24998b8b67b290c2fa8b7c14fcfa7de2c5c9b8c
         with:
           version: "latest"
           args: release --clean

--- a/docs/operations/RELEASE_RUNBOOK.md
+++ b/docs/operations/RELEASE_RUNBOOK.md
@@ -104,7 +104,7 @@ The release workflow:
 
 1. checks out the repository with full history
 2. sets up Go from `go.mod`
-3. runs GoReleaser with `release --clean`
+3. runs the Node 24-compatible `goreleaser/goreleaser-action` release step with `release --clean`
 4. creates or replaces a draft GitHub Release for the pushed tag
 5. uploads release archives for the supported platforms
 6. uploads Linux `.deb` and `.rpm` package artifacts


### PR DESCRIPTION
## Summary

- upgrade the pinned `goreleaser/goreleaser-action` revision in CI and release workflows to a Node 24-compatible release
- keep the release runbook aligned with the workflow behavior

## Background

GitHub Actions warns that the previously pinned `goreleaser/goreleaser-action` revision runs on Node.js 20. GitHub will force JavaScript actions onto Node.js 24 starting June 2, 2026, and remove Node.js 20 from runners on September 16, 2026. This change updates the pinned action revision so the release automation stays compatible.

## Related issue(s)

- None

## Implementation details

- replaced the old `goreleaser/goreleaser-action` SHA in `.github/workflows/ci.yml`
- replaced the old `goreleaser/goreleaser-action` SHA in `.github/workflows/release.yml`
- updated `docs/operations/RELEASE_RUNBOOK.md` to note that the release workflow uses the Node 24-compatible GoReleaser action

## Test coverage

- `make test`
- `make lint`
- `go vet ./...`
- `make release-check`

## Breaking changes

- None

## Notes

- based on the upstream `goreleaser/goreleaser-action` `v7.1.0` release, which includes Node 24 support

Created by Codex